### PR TITLE
Added ignore status to generated 3rdparty folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@
 /build*/
 /controlfiles/**/*.rep
 heaptrack.*.gz
+3rdparty/wigner/fastwigxj/gen/
+3rdparty/wigner/fastwigxj/obj/
+


### PR DESCRIPTION
The auto-generated Wigner-folders showed up in git-status.  This ignores them.