### PR TITLE
Add missing header

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -54,6 +54,7 @@
 #ifndef CONSTANTS_IN_ARTS_H
 #define CONSTANTS_IN_ARTS_H
 
+#include <cmath>
 #include "matpack.h"
 
 /** Namespace containing several constants, physical and mathematical **/

--- a/src/constants.h
+++ b/src/constants.h
@@ -54,6 +54,7 @@
 #ifndef CONSTANTS_IN_ARTS_H
 #define CONSTANTS_IN_ARTS_H
 
+#include "matpack.h"
 
 /** Namespace containing several constants, physical and mathematical **/
 namespace Constant {

--- a/src/doit.h
+++ b/src/doit.h
@@ -39,6 +39,7 @@
 #include "agenda_class.h"
 #include "matpackVI.h"
 #include "ppath.h"
+#include "propagationmatrix.h"
 
 
 void rte_step_doit(//Output and Input:

--- a/src/linemixing.h
+++ b/src/linemixing.h
@@ -27,6 +27,7 @@
 #include "linerecord.h"
 #include "absorption.h"
 #include "constants.h"
+#include "complex.h"
 
 
 template<class T> inline Numeric rotational_energy_hund_b_molecule(

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -42,6 +42,7 @@
 #include "math_funcs.h"
 #include "matpackI.h"
 #include "matpackII.h"
+#include "messages.h"
 
 
 /*===========================================================================

--- a/src/surface.h
+++ b/src/surface.h
@@ -37,6 +37,11 @@
 #ifndef surface_h
 #define surface_h
 
+#include "complex.h"
+#include "matpackIV.h"
+#include "mystring.h"
+#include "ppath.h"
+
 Numeric calc_incang(
    ConstVectorView   rte_los,
    ConstVectorView   specular_los );

--- a/src/tessem.cc
+++ b/src/tessem.cc
@@ -38,7 +38,7 @@
   \param[in,out] is Input file stream
   \param[out] net Neural network parameters
 */
-void tessem_read_ascii(ifstream& is, TessemNN& net)
+void tessem_read_ascii(std::ifstream& is, TessemNN& net)
 {
     is >> net.nb_inputs >> net.nb_cache >> net.nb_outputs;
 

--- a/src/tessem.h
+++ b/src/tessem.h
@@ -27,6 +27,7 @@
 #ifndef tessem_h
 #define tessem_h
 
+#include <fstream>
 #include "matpackI.h"
 
 
@@ -45,7 +46,7 @@ typedef struct
     Vector y_max;
 } TessemNN;
 
-void tessem_read_ascii(ifstream& is, TessemNN& net);
+void tessem_read_ascii(std::ifstream& is, TessemNN& net);
 
 void tessem_prop_nn(VectorView& ny, const TessemNN& net, ConstVectorView nx);
 


### PR DESCRIPTION
While testing clang-format, which reorders includes alphabetically, it became apparent that several of our headers are not self-contained. Not sure how to test for this globally.