### PR TITLE
Adjust clang-format options

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,6 @@
 Language: Cpp
 BasedOnStyle: Google
+BinPackArguments: false
+BinPackParameters: false
+BreakStringLiterals: false
+ReflowComments: false


### PR DESCRIPTION
- BinPackArguments: false, BinPackParameters: false

  Only merge long list of arguments if everything fits on one line, otherwise
  keep every argument on a separate line.
  Better for overall readability since we have lots of functions with
  long argument lists. Especially needed for methods.cc.

- BreakStringLiterals: false

  Keep WSM descriptions in methods.cc readable even if String literals
  don't fit in 80 chars.

- ReflowComments: false

  Don't break formatting of long comments (e.g. formulas) which are longer than
  80 chars.