### PR TITLE
Revised doxygen documentation of m_rt4.cc and rt4.cc/h

### DIFF
--- a/src/m_rt4.cc
+++ b/src/m_rt4.cc
@@ -365,7 +365,7 @@ void RT4CalcWithRT4Surface(Workspace& ws,
 }
 
 #else /* ENABLE_RT4 */
-
+/* Workspace method: Doxygen documentation will be auto-generated */
 void RT4Calc(Workspace&,
              // WS Output:
              Tensor7&,
@@ -404,7 +404,7 @@ void RT4Calc(Workspace&,
              const Verbosity&) {
   throw runtime_error("This version of ARTS was compiled without RT4 support.");
 }
-
+/* Workspace method: Doxygen documentation will be auto-generated */
 void RT4CalcWithRT4Surface(Workspace&,
                            // WS Output:
                            Tensor7&,

--- a/src/rt4.cc
+++ b/src/rt4.cc
@@ -52,26 +52,7 @@ extern const Numeric RAD2DEG;
 extern const Numeric SPEED_OF_LIGHT;
 extern const Numeric COSMIC_BG_TEMP;
 
-//! check_rt4_input
-/*!
-  Checks that input of RT4Calc* is sane.
 
-  \param nhstreams             Number of single hemisphere streams (quadrature angles).
-  \param nhza                  Number of single hemisphere additional angles with RT output.
-  \param nummu                 Total number of single hemisphere angles with RT output.
-  \param cloudbox_on           as the WSV 
-  \param rt4_is_initialized    as the WSV 
-  \param atmfields_checked     as the WSV 
-  \param atmgeom_checked       as the WSV 
-  \param cloudbox_checked      as the WSV 
-  \param nstreams              Total number of quadrature angles (both hemispheres).
-  \param quad_type             Quadrature method.
-  \param pnd_ncols             Number of columns (latitude points) in *pnd_field*.
-  \param ifield_npages         Number of pages (polar angle points) in *doit_i_field*.
-  
-  \author Jana Mendrok
-  \date   2017-02-22
-*/
 void check_rt4_input(  // Output
     Index& nhstreams,
     Index& nhza,
@@ -214,22 +195,7 @@ void check_rt4_input(  // Output
   //------------- end of checks ---------------------------------------
 }
 
-//! get_quad_angles
-/*!
-  Derive the quadrature angles related to selected RT4 quadrature type and set
-  scat_za_grid accordingly.
 
-  \param mu_values             Quadrature angle cosines.
-  \param quad_weights          Quadrature weights associated with mu_values.
-  \param scat_za_grid          as the WSV
-  \param scat_aa_grid          as the WSV
-  \param quad_type             Quadrature method.
-  \param nhstreams             Number of single hemisphere streams (quadrature angles). 
-  \param nhza                  Number of single hemisphere additional angles with RT output.
-
-  \author Jana Mendrok
-  \date   2017-02-22
-*/
 void get_quad_angles(  // Output
     VectorView mu_values,
     VectorView quad_weights,
@@ -272,25 +238,7 @@ void get_quad_angles(  // Output
   scat_aa_grid[0] = 0.;
 }
 
-//! get_rt4surf_props
-/*!
-  Derive surface property input for RT4's proprietary surface handling depending
-  on surface reflection type.
 
-  \param ground_albedo         Scalar surface albedo (for ground_type=L).
-  \param ground_reflec         Vector surface relfectivity (for ground_type=S).
-  \param ground_index          Surface complex refractive index (for ground_type=F).
-  \param f_grid                as the WSV
-  \param ground_type           Surface reflection type flag.
-  \param surface_skin_t        as the WSV
-  \param surface_scalar_reflectivity  as the WSV (used with ground_type=L).
-  \param surface_reflectivity  as the WSV (used with ground_type=S).
-  \param surface_complex_refr_index   as the WSV (used with ground_type=F).
-  \param stokes_dim            as the WSV
-
-  \author Jana Mendrok
-  \date   2017-02-22
-*/
 void get_rt4surf_props(  // Output
     Vector& ground_albedo,
     Tensor3& ground_reflec,
@@ -406,45 +354,7 @@ void get_rt4surf_props(  // Output
   }
 }
 
-//! run_rt4
-/*!
-  Prepares actual input variables for RT4, runs it, and sorts the output into
-  doit_i_field.
 
-  \param ws                    Current workspace
-  \param doit_i_field          as the WSV
-  \param f_grid                as the WSV
-  \param p_grid                as the WSV
-  \param z_field               as the WSV
-  \param t_field               as the WSV
-  \param vmr_field             as the WSV
-  \param pnd_field             as the WSV
-  \param scat_data             as the WSV
-  \param propmat_clearsky_agenda  as the WSA
-  \param cloudbox_limits       as the WSV 
-  \param stokes_dim            as the WSV
-  \param nummu                 Total number of single hemisphere angles with RT output. 
-  \param nhza                  Number of single hemisphere additional angles with RT output.
-  \param ground_type           Surface reflection type flag.
-  \param surface_skin_t        as the WSV
-  \param ground_albedo         Scalar surface albedo (for ground_type=L).
-  \param ground_reflec         Vector surface relfectivity (for ground_type=S).
-  \param ground_index          Surface complex refractive index (for ground_type=F).
-  \param surf_refl_mat         Surface reflection matrix (for ground_type=A).
-  \param surf_emis_vec         Surface emission vector (for ground_type=A).
-  \param quad_type             Quadrature method.
-  \param scat_za_grid          as the WSV
-  \param mu_values             Quadrature angle cosines.
-  \param quad_weights          Quadrature weights associated with mu_values.
-  \param auto_inc_nstreams     as the WSV
-  \param pfct_method           see RT4Calc doc.
-  \param pfct_aa_grid_size     see RT4Calc doc. 
-  \param pfct_threshold        Requested scatter_matrix norm accuracy (in terms of single scat albedo).
-  \param max_delta_tau         see RT4Calc doc.
-
-  \author Jana Mendrok
-  \date   2017-02-22
-*/
 void run_rt4(Workspace& ws,
              // Output
              Tensor7& doit_i_field,
@@ -1030,45 +940,7 @@ void run_rt4(Workspace& ws,
   }
 }
 
-//! run_rt4_new
-/*!
-  Prepares actual input variables for RT4, runs it, and sorts the output into
-  doit_i_field.
 
-  \param ws                    Current workspace
-  \param doit_i_field          as the WSV
-  \param f_grid                as the WSV
-  \param p_grid                as the WSV
-  \param z_field               as the WSV
-  \param t_field               as the WSV
-  \param vmr_field             as the WSV
-  \param pnd_field             as the WSV
-  \param scat_data             as the WSV
-  \param propmat_clearsky_agenda  as the WSA
-  \param cloudbox_limits       as the WSV 
-  \param stokes_dim            as the WSV
-  \param nummu                 Total number of single hemisphere angles with RT output. 
-  \param nhza                  Number of single hemisphere additional angles with RT output.
-  \param ground_type           Surface reflection type flag.
-  \param surface_skin_t        as the WSV
-  \param ground_albedo         Scalar surface albedo (for ground_type=L).
-  \param ground_reflec         Vector surface relfectivity (for ground_type=S).
-  \param ground_index          Surface complex refractive index (for ground_type=F).
-  \param surf_refl_mat         Surface reflection matrix (for ground_type=A).
-  \param surf_emis_vec         Surface emission vector (for ground_type=A).
-  \param quad_type             Quadrature method.
-  \param scat_za_grid          as the WSV
-  \param mu_values             Quadrature angle cosines.
-  \param quad_weights          Quadrature weights associated with mu_values.
-  \param auto_inc_nstreams     as the WSV
-  \param pfct_method           see RT4Calc doc.
-  \param pfct_aa_grid_size     see RT4Calc doc. 
-  \param pfct_threshold        Requested scatter_matrix norm accuracy (in terms of single scat albedo).
-  \param max_delta_tau         see RT4Calc doc.
-
-  \author Jana Mendrok
-  \date   2017-02-22
-*/
 void run_rt4_new(Workspace& ws,
                  // Output
                  Tensor7& doit_i_field,
@@ -1577,18 +1449,7 @@ void run_rt4_new(Workspace& ws,
   }
 }
 
-//! scat_za_grid_adjust
-/*!
-  Reset scat_za_grid such that it is consistent with ARTS' scat_za_grid
-  requirements (instead of with RT4 as in input state).
 
-  \param scat_za_grid          as the WSV
-  \param mu_values             Quadrature angle cosines.
-  \param nummu                 Number of single hemisphere polar angles.
-
-  \author Jana Mendrok
-  \date   2017-02-22
-*/
 void scat_za_grid_adjust(  // Output
     Vector& scat_za_grid,
     // Input
@@ -1603,22 +1464,7 @@ void scat_za_grid_adjust(  // Output
   }
 }
 
-//! gas_optpropCalc
-/*!
-  Calculates layer averaged gaseous extinction (gas_extinct). This variable is
-  required as input for the RT4 subroutine.
 
-  \param ws                    Current workspace
-  \param gas_extinct           Layer averaged gas extinction for all layers
-  \param propmat_clearsky_agenda as the WSA
-  \param t_field               as the WSV
-  \param vmr_field             as the WSV
-  \param p_grid                as the WSV
-  \param f_mono                frequency (single entry vector)
-  
-  \author Jana Mendrok
-  \date   2016-08-08
-*/
 void gas_optpropCalc(Workspace& ws,
                      VectorView gas_extinct,
                      const Agenda& propmat_clearsky_agenda,
@@ -1685,25 +1531,7 @@ void gas_optpropCalc(Workspace& ws,
   }
 }
 
-//! par_optpropCalc
-/*!
-  Calculates layer averaged particle extinction and absorption (extinct_matrix
-  and emis_vector)). These variables are required as input for the RT4 subroutine.
 
-  \param emis_vector           Layer averaged particle absorption for all particle layers
-  \param extinct_matrix        Layer averaged particle extinction for all particle layers
-  \param scat_data             as the WSV
-  \param scat_za_grid          as the WSV
-  \param f_index               index of frequency grid point handeled
-  \param pnd_field             as the WSV
-  \param t_field               as the WSV
-  \param cloudbox_limits       as the WSV 
-  \param stokes_dim            as the WSV
-  \param nummu                 Number of single hemisphere polar angles.
-  
-  \author Jana Mendrok
-  \date   2016-08-08
-*/
 void par_optpropCalc(Tensor4View emis_vector,
                      Tensor5View extinct_matrix,
                      //VectorView scatlayers,
@@ -1826,25 +1654,7 @@ void par_optpropCalc(Tensor4View emis_vector,
   }
 }
 
-//! par_optpropCalc
-/*!
-  Calculates layer averaged particle extinction and absorption (extinct_matrix
-  and emis_vector)). These variables are required as input for the RT4 subroutine.
 
-  \param emis_vector           Layer averaged particle absorption for all particle layers
-  \param extinct_matrix        Layer averaged particle extinction for all particle layers
-  \param scat_data             as the WSV
-  \param scat_za_grid          as the WSV
-  \param f_index               index of frequency grid point handeled
-  \param pnd_field             as the WSV
-  \param t_field               as the WSV
-  \param cloudbox_limits       as the WSV 
-  \param stokes_dim            as the WSV
-  \param nummu                 Number of single hemisphere polar angles.
-  
-  \author Jana Mendrok
-  \date   2016-08-08
-*/
 void par_optpropCalc2(Tensor5View emis_vector,
                       Tensor6View extinct_matrix,
                       //VectorView scatlayers,
@@ -1937,29 +1747,7 @@ void par_optpropCalc2(Tensor5View emis_vector,
   }
 }
 
-//! sca_optpropCalc
-/*!
-  Calculates layer (and azimuthal) averaged phase matrix (scatter_matrix). This
-  variable is required as input for the RT4 subroutine.
 
-  \param scatter_matrix        Layer averaged scattering matrix (azimuth mode 0) for all particle layers
-  \param pfct_failed           Flag whether norm of scatter_matrix is sufficiently accurate
-  \param emis_vector           Layer averaged particle absorption for all particle layers
-  \param extinct_matrix        Layer averaged particle extinction for all particle layers
-  \param f_index               as the WSV
-  \param scat_data             as the (new-type, f_grid prepared) WSV
-  \param pnd_field             as the WSV
-  \param stokes_dim            as the WSV
-  \param scat_za_grid          as the WSV
-  \param quad_weights          Quadrature weights associated with scat_za_grid 
-  \param pfct_method           Method for scattering matrix temperature dependance handling
-  \param pfct_aa_grid_size     Number of azimuthal grid points in Fourier series decomposition of randomly oriented particles
-  \param pfct_threshold        Requested scatter_matrix norm accuracy (in terms of single scat albedo)
-  \param auto_inc_nstreams     as the WSV
-  
-  \author Jana Mendrok
-  \date   2016-08-08
-*/
 void sca_optpropCalc(  //Output
     Tensor6View scatter_matrix,
     Index& pfct_failed,
@@ -2320,25 +2108,7 @@ void sca_optpropCalc(  //Output
   }
 }
 
-//! surf_optpropCalc
-/*!
-  Calculates bidirectional surface reflection matrices and emission direction
-  dependent surface emission terms as required as input for the RT4 subroutine.
 
-  \param ws                    Current workspace
-  \param surf_refl_mat         Bidirectional surface reflection matrices on RT4 stream directions.
-  \param surf_emis_vec         Directional surface emission vector on RT4 stream directions.
-  \param surface_rtprop_agenda as the WSA
-  \param f_grid                as the WSV
-  \param scat_za_grid          as the WSV
-  \param mu_values             Cosines of scat_za_grid angles.
-  \param quad_weights          Quadrature weights associated with mu_values.
-  \param stokes_dim            as the WSV
-  \param surf_alt              Surface altitude.
-  
-  \author Jana Mendrok
-  \date   2017-02-09
-*/
 void surf_optpropCalc(Workspace& ws,
                       //Output
                       Tensor5View surf_refl_mat,
@@ -2558,20 +2328,7 @@ void surf_optpropCalc(Workspace& ws,
   }
 }
 
-//! Calculate radiation field using RT4
-/*! 
-  Calculate radiation field using Evans' RT4 model (part of PolRadTran).
 
-  This is a direct interface to the (almost orignal) RT4 FORTRAN code. No checks
-  of input are made. Function is only to be called through other
-  functions/methods, which have to ensure input consistency.
-
-  \param[out] name            descript
-  \param[in]  name            descript [unit]
-
-  \author Jana Mendrok
-  \date 2016-05-24
-*/
 void rt4_test(Tensor4& out_rad,
               const String& datapath,
               const Verbosity& verbosity) {

--- a/src/rt4.h
+++ b/src/rt4.h
@@ -32,6 +32,32 @@
 
 #include "messages.h"
 
+//! Checks that input of RT4Calc* is sane.
+/*!
+
+  \param[out]  nhstreams Number of single hemisphere streams (quadrature angles)
+  \param[out]  nhza Number of single hemisphere additional angles with RT output
+  \param[out]  nummu Total number of single hemisphere angles with RT output
+  \param[in]   cloudbox_on Flag to activate the cloud box
+  \param[in]   atmfields_checked OK-flag for atmospheric grids and (physical)
+               fields
+  \param[in]   atmgeom_checked OK-flag for the geometry of the model atmosphere
+  \param[in]   cloudbox_checked OK-flag for variables associated with the
+               cloudbox
+  \param[in]   scat_data_checked OK-flag for scat_data
+  \param[in]   cloudbox_limits Cloudbox limits
+  \param[in]   scat_data Array of single scattering data
+  \param[in]   atmosphere_dim Dimension of atmosphere
+  \param[in]   stokes_dim Dimension of Stokes vector
+  \param[in]   nstreams Total number of quadrature angles (both hemispheres).
+  \param[in]   quad_type Quadrature method.
+  \param[in]   add_straight_angles Flag whether to include nadir and zenith as
+               explicit directions
+  \param[in]   pnd_ncols Number of columns (latitude points) in *pnd_field*.
+
+  \author Jana Mendrok
+  \date   2017-02-22
+*/
 void check_rt4_input(  // Output
     Index& nhstreams,
     Index& nhza,
@@ -51,6 +77,23 @@ void check_rt4_input(  // Output
     const Index& add_straight_angles,
     const Index& pnd_ncols);
 
+//! Derive the quadrature angles
+/*!
+  Derive the quadrature angles related to selected RT4 quadrature type and set
+  scat_za_grid accordingly.
+
+  \param[out]  mu_values Quadrature angle cosines.
+  \param[out]  quad_weights Quadrature weights associated with mu_values.
+  \param[out]  scat_za_grid Zenith angle grid
+  \param[out]  scat_aa_grid Azimuth angle grid
+  \param[in]   quad_type Quadrature method.
+  \param[in]   nhstreams Number of single hemisphere streams (quadrature angles)
+  \param[in]   nhza Number of single hemisphere additional angles with RT output
+  \param[in]   nummu Total number of single hemisphere angles with RT output
+
+  \author Jana Mendrok
+  \date   2017-02-22
+*/
 void get_quad_angles(  // Output
     VectorView mu_values,
     VectorView quad_weights,
@@ -62,6 +105,29 @@ void get_quad_angles(  // Output
     const Index& nhza,
     const Index& nummu);
 
+
+//! Derive surface property input for RT4's proprietary surface handling
+/*!
+  Derive surface property input for RT4's proprietary surface handling depending
+  on surface reflection type.
+
+  \param[out]  ground_albedo Scalar surface albedo (for ground_type=L).
+  \param[out]  ground_reflec Vector surface relfectivity (for ground_type=S).
+  \param[out]  ground_index Surface complex refractive index (for ground_type=F).
+  \param[in]   f_grid Frequency grid
+  \param[in]   ground_type Surface reflection type flag.
+  \param[in]   surface_skin_t Surface skin temperature
+  \param[in]   surface_scalar_reflectivity Surface scalar reflectivity
+               (used with ground_type=L).
+  \param[in]   surface_reflectivity  Surface reflectivity
+               (used with ground_type=S).
+  \param[in]   surface_complex_refr_index  Surface complex refractive index
+               (used with ground_type=F).
+  \param[in]   stokes_dim Dimension of Stokes vector
+
+  \author Jana Mendrok
+  \date   2017-02-22
+*/
 void get_rt4surf_props(  // Output
     Vector& ground_albedo,
     Tensor3& ground_reflec,
@@ -75,6 +141,63 @@ void get_rt4surf_props(  // Output
     const GriddedField3& surface_complex_refr_index,
     const Index& stokes_dim);
 
+//! Runs RT4
+/*!
+  Prepares actual input variables for RT4, runs it, and sorts the output into
+  doit_i_field.
+
+  \param[in,out] ws Current workspace
+  \param[out]    doit_i_field Radiation field
+  \param[out]    scat_za_grid Zenith angle grid
+  \param[in]     f_grid Frequency grid
+  \param[in]     p_grid Pressure
+  \param[in]     z_field Field of geometrical altitudes
+  \param[in]     t_field Atmospheric temperature field
+  \param[in]     vmr_field VMR field
+  \param[in]     pnd_field PND field
+  \param[in]     scat_data Array of single scattering data
+  \param[in]     propmat_clearsky_agenda calculates the absorption coefficient
+                 matrix
+  \param[in]     cloudbox_limits Cloudbox limits
+  \param[in]     stokes_dim Dimension of Stokes vector
+  \param[in]     nummu Total number of single hemisphere angles with RT output.
+  \param[in]     nhza Number of single hemisphere additional angles with RT
+                 output.
+  \param[in]     ground_type Surface reflection type flag.
+  \param[in]     surface_skin_t Surface skin temperature
+  \param[in]     ground_albedo Scalar surface albedo (for ground_type=L).
+  \param[in]     ground_reflec Vector surface relfectivity (for ground_type=S).
+  \param[in]     ground_index Surface complex refractive index
+                 (for ground_type=F).
+  \param[in]     surf_refl_mat Surface reflection matrix (for ground_type=A).
+  \param[in]     surf_emis_vec Surface emission vector (for ground_type=A).
+  \param[in]     surface_rtprop_agenda Provides radiative properties of the
+                 surface
+  \param[in]     surf_altitude Surface altitude (lowest level of z_field)
+  \param[in]     quad_type Quadrature method.
+  \param[in]     mu_values Quadrature angle cosines.
+  \param[in]     quad_weights Quadrature weights associated with mu_values.
+  \param[in]     auto_inc_nstreams Flag whether to internally increase nstreams
+  \param[in]     robust if auto_inc_nstreams>0,flag whether to not fail even if
+                 scattering matrix norm is not preserved when maximum stream
+                 number is reached
+  \param[in]     za_interp_order if auto_inc_nstreams>0, polar angle
+                 interpolation order
+  \param[in]     cos_za_interp if auto_inc_nstreams>0, flag whether to do polar
+                 angle interpolation in cosine (='mu') space
+  \param[in]     pfct_method Flag which method to apply to derive phase function
+  \param[in]     pfct_aa_grid_size Number of azimuthal angle grid points to
+                 consider in Fourier series decomposition of scattering matrix
+  \param[in]     pfct_threshold Requested scatter_matrix norm accuracy
+                 (in terms of single scat albedo).
+  \param[in]     max_delta_tau Maximum optical depth of infinitesimal layer
+  \param[in]     new_optprop Flag whether to use old (0) or new(1) optical
+                 property extraction scheme
+  \param[in]     verbosity Verbosity setting
+
+  \author Jana Mendrok
+  \date   2017-02-22
+*/
 void run_rt4(Workspace& ws,
              // Output
              Tensor7& doit_i_field,
@@ -115,12 +238,133 @@ void run_rt4(Workspace& ws,
              const Index& new_optprop,
              const Verbosity& verbosity);
 
+//! Runs RT4
+/*!
+  Prepares actual input variables for RT4, runs it, and sorts the output into
+  doit_i_field.
+
+  \param[in,out] ws Current workspace
+  \param[out]    doit_i_field Radiation field
+  \param[out]    scat_za_grid Zenith angle grid
+  \param[in]     f_grid Frequency grid
+  \param[in]     p_grid Pressure
+  \param[in]     z_field Field of geometrical altitudes
+  \param[in]     t_field Atmospheric temperature field
+  \param[in]     vmr_field VMR field
+  \param[in]     pnd_field PND field
+  \param[in]     scat_data Array of single scattering data
+  \param[in]     propmat_clearsky_agenda calculates the absorption coefficient
+                 matrix
+  \param[in]     cloudbox_limits Cloudbox limits
+  \param[in]     stokes_dim Dimension of Stokes vector
+  \param[in]     nummu Total number of single hemisphere angles with RT output.
+  \param[in]     nhza Number of single hemisphere additional angles with RT output.
+  \param[in]     ground_type Surface reflection type flag.
+  \param[in]     surface_skin_t Surface scalar temperature
+  \param[in]     ground_albedo Scalar surface albedo (for ground_type=L).
+  \param[in]     ground_reflec Vector surface relfectivity (for ground_type=S).
+  \param[in]     ground_index Surface complex refractive index (for ground_type=F).
+  \param[in]     surf_refl_mat Surface reflection matrix (for ground_type=A).
+  \param[in]     surf_emis_vec Surface emission vector (for ground_type=A).
+  \param[in]     surface_rtprop_agenda Provides radiative properties of the
+                 surface
+  \param[in]     surf_altitude Surface altitude (lowest level of z_field)
+  \param[in]     quad_type Quadrature method.
+  \param[in]     mu_values Quadrature angle cosines.
+  \param[in]     quad_weights Quadrature weights associated with mu_values.
+  \param[in]     auto_inc_nstreams Flag whether to internally increase nstreams
+  \param[in]     robust if auto_inc_nstreams>0,flag whether to not fail even if
+                 scattering matrix norm is not preserved when maximum stream
+                 number is reached
+  \param[in]     za_interp_order if auto_inc_nstreams>0, polar angle
+                 interpolation order
+  \param[in]     cos_za_interp if auto_inc_nstreams>0, flag whether to do polar
+                 angle interpolation in cosine (='mu') space
+  \param[in]     pfct_method Flag which method to apply to derive phase function
+  \param[in]     pfct_aa_grid_size Number of azimuthal angle grid points to
+                 consider in Fourier series decomposition of scattering matrix
+  \param[in]     pfct_threshold Requested scatter_matrix norm accuracy
+                 (in terms of single scat albedo).
+  \param[in]     max_delta_tau Maximum optical depth of infinitesimal layer
+  \param[in]     verbosity Verbosity setting
+
+  \author Jana Mendrok
+  \date   2017-02-22
+*/
+void run_rt4_new(Workspace& ws,
+    // Output
+                 Tensor7& doit_i_field,
+                 Vector& scat_za_grid,
+    // Input
+                 ConstVectorView f_grid,
+                 ConstVectorView p_grid,
+                 ConstTensor3View z_field,
+                 ConstTensor3View t_field,
+                 ConstTensor4View vmr_field,
+                 ConstTensor4View pnd_field,
+                 const ArrayOfArrayOfSingleScatteringData& scat_data,
+                 const Agenda& propmat_clearsky_agenda,
+                 const ArrayOfIndex& cloudbox_limits,
+                 const Index& stokes_dim,
+                 const Index& nummu,
+                 const Index& nhza,
+                 const String& ground_type,
+                 const Numeric& surface_skin_t,
+                 ConstVectorView ground_albedo,
+                 ConstTensor3View ground_reflec,
+                 ConstComplexVectorView ground_index,
+                 ConstTensor5View surf_refl_mat,
+                 ConstTensor3View surf_emis_vec,
+                 const Agenda& surface_rtprop_agenda,
+                 const Numeric& surf_altitude,
+                 const String& quad_type,
+                 Vector& mu_values,
+                 ConstVectorView quad_weights,
+                 const Index& auto_inc_nstreams,
+                 const Index& robust,
+                 const Index& za_interp_order,
+                 const Index& cos_za_interp,
+                 const String& pfct_method,
+                 const Index& pfct_aa_grid_size,
+                 const Numeric& pfct_threshold,
+                 const Numeric& max_delta_tau,
+                 const Verbosity& verbosity);
+
+//! Reset scat_za_grid such that it is consistent with ARTS
+/*!
+  Reset scat_za_grid such that it is consistent with ARTS' scat_za_grid
+  requirements (instead of with RT4 as in input state).
+
+  \param[out]  scat_za_grid Zenith angle grid
+  \param[in]   mu_values Quadrature angle cosines.
+  \param[in]   nummu Number of single hemisphere polar angles.
+
+  \author Jana Mendrok
+  \date   2017-02-22
+*/
 void scat_za_grid_adjust(  // Output
     Vector& scat_za_grid,
     // Input
     ConstVectorView mu_values,
     const Index& nummu);
 
+//! Calculates layer averaged gaseous extinction
+/*!
+  Calculates layer averaged gaseous extinction (gas_extinct). This variable is
+  required as input for the RT4 subroutine.
+
+  \param[in,out]  ws Current workspace
+  \param[out]     gas_extinct Layer averaged gas extinction for all layers
+  \param[in]      propmat_clearsky_agenda propmat_clearsky_agenda calculates
+                  the absorption coefficient matrix
+  \param[in]      t_field Atmospheric temperature field
+  \param[in]      vmr_field VMR field
+  \param[in]      p_grid Pressure grid
+  \param[in]      f_mono Frequency (single entry vector)
+
+  \author Jana Mendrok
+  \date   2016-08-08
+*/
 void gas_optpropCalc(Workspace& ws,
                      //Output
                      VectorView gas_extinct,
@@ -131,6 +375,28 @@ void gas_optpropCalc(Workspace& ws,
                      ConstVectorView p_grid,
                      ConstVectorView f_mono);
 
+//! Calculates layer averaged particle extinction and absorption
+/*!
+  Calculates layer averaged particle extinction and absorption (extinct_matrix
+  and emis_vector)). These variables are required as input for the RT4 subroutine.
+
+  \param[out] emis_vector Layer averaged particle absorption for all particle
+              layers
+  \param[out] extinct_matrix  Layer averaged particle extinction for all
+              particle layers
+  \param[in]  scat_data Array of single scattering data
+  \param[in]  scat_za_grid Zenith angle grid
+  \param[in]  f_index Index of frequency grid point handeled
+  \param[in]  pnd_field PND field
+  \param[in]  t_field Atmospheric temperature field
+  \param[in]  cloudbox_limits Cloudbox limits
+  \param[in]  stokes_dim Dimension of Stokes vector
+  \param[in]  nummu Number of single hemisphere polar angles.
+  \param[in]  verbosity Verbosity setting
+
+  \author Jana Mendrok
+  \date   2016-08-08
+*/
 void par_optpropCalc(  //Output
     Tensor4View emis_vector,
     Tensor5View extinct_matrix,
@@ -146,6 +412,26 @@ void par_optpropCalc(  //Output
     const Index& nummu,
     const Verbosity& verbosity);
 
+//! Calculates layer averaged particle extinction and absorption
+/*!
+  Calculates layer averaged particle extinction and absorption (extinct_matrix
+  and emis_vector)). These variables are required as input for the RT4 subroutine.
+
+  \param[out] emis_vector Layer averaged particle absorption for all particle
+              layers
+  \param[out] extinct_matrix  Layer averaged particle extinction for all
+              particle layers
+  \param[in]  scat_data Array of single scattering data
+  \param[in]  scat_za_grid Zenith angle grid
+  \param[in]  f_index Index of frequency grid point handeled
+  \param[in]  pnd_field PND field
+  \param[in]  t_field Atmospheric temperature field
+  \param[in]  cloudbox_limits Cloudbox limits
+  \param[in]  stokes_dim Dimension of Stokes vector
+
+  \author Jana Mendrok
+  \date   2016-08-08
+*/
 void par_optpropCalc2(  //Output
     Tensor5View emis_vector,
     Tensor6View extinct_matrix,
@@ -159,6 +445,38 @@ void par_optpropCalc2(  //Output
     const ArrayOfIndex& cloudbox_limits,
     const Index& stokes_dim);
 
+//! Calculates layer (and azimuthal) averaged phase matrix
+/*!
+  Calculates layer (and azimuthal) averaged phase matrix (scatter_matrix). This
+  variable is required as input for the RT4 subroutine.
+
+  \param[out] scatter_matrix  Layer averaged scattering matrix (azimuth mode 0)
+              for all particle layers
+  \param[out] pfct_failed Flag whether norm of scatter_matrix is sufficiently
+              accurate
+  \param[in]  emis_vector Layer averaged particle absorption for all particle
+              layers
+  \param[in]  extinct_matrix Layer averaged particle extinction for all particle
+              layers
+  \param[in]  f_index Frequency index
+  \param[in]  scat_data Array of single scattering data
+              (new-type, f_grid prepared)
+  \param[in]  pnd_field PND field
+  \param[in]  stokes_dim Dimension of Stokes vector
+  \param[in]  scat_za_grid Zenith angle grid
+  \param[in]  quad_weights Quadrature weights associated with scat_za_grid
+  \param[in]  pfct_method Method for scattering matrix temperature dependance
+              handling
+  \param[in]  pfct_aa_grid_size Number of azimuthal grid points in Fourier
+              series decomposition of randomly oriented particles
+  \param[in]  pfct_threshold Requested scatter_matrix norm accuracy
+              (in terms of single scat albedo)
+  \param[in]  auto_inc_nstreams Flag whether to internally increase nstreams
+  \param[in]  verbosity Verbosity setting
+
+  \author Jana Mendrok
+  \date   2016-08-08
+*/
 void sca_optpropCalc(  //Output
     Tensor6View scatter_matrix,
     Index& pfct_failed,
@@ -177,6 +495,28 @@ void sca_optpropCalc(  //Output
     const Index& auto_inc_nstreams,
     const Verbosity& verbosity);
 
+//! Calculates bidirectional surface reflection matrices and emission direction
+/*!
+  Calculates bidirectional surface reflection matrices and emission direction
+  dependent surface emission terms as required as input for the RT4 subroutine.
+
+  \param[in,out]  ws Current workspace
+  \param[out]     surf_refl_mat Bidirectional surface reflection matrices on
+                  RT4 stream directions.
+  \param[out]     surf_emis_vec Directional surface emission vector on RT4
+                  stream directions.
+  \param[in]      surface_rtprop_agenda surface_rtprop_agenda Provides radiative
+                  properties of the surface
+  \param[in]      f_grid Frequency grid
+  \param[in]      scat_za_grid Zenith angle grid
+  \param[in]      mu_values Cosines of scat_za_grid angles.
+  \param[in]      quad_weights Quadrature weights associated with mu_values.
+  \param[in]      stokes_dim Dimension of Stokes vector
+  \param[in]      surf_alt Surface altitude.
+
+  \author Jana Mendrok
+  \date   2017-02-09
+*/
 void surf_optpropCalc(Workspace& ws,
                       //Output
                       Tensor5View surf_refl_mat,
@@ -190,6 +530,21 @@ void surf_optpropCalc(Workspace& ws,
                       const Index& stokes_dim,
                       const Numeric& surf_alt);
 
+//! Calculate radiation field using RT4
+/*!
+  Calculate radiation field using Evans' RT4 model (part of PolRadTran).
+
+  This is a direct interface to the (almost orignal) RT4 FORTRAN code. No checks
+  of input are made. Function is only to be called through other
+  functions/methods, which have to ensure input consistency.
+
+  \param[out] out_rad FIXMEDOC
+  \param[in]  datapath FIXMEDOC
+  \param[in]  verbosity Verbosity setting
+
+  \author Jana Mendrok
+  \date 2016-05-24
+*/
 void rt4_test(Tensor4& out_rad,
               const String& datapath,
               const Verbosity& verbosity);


### PR DESCRIPTION
The doxygen documentation was shifted from rt4.cc to rt4.h and
updated. Furthermore, added missing tags m_rt4.cc about documentation is
automatically generated for workspace methods.