### PR TITLE
Fix out-of-bounds assertion in mspecies

### DIFF
--- a/src/linefunctiondata.cc
+++ b/src/linefunctiondata.cc
@@ -104,12 +104,12 @@ std::istream& LineShape::from_artscat4(std::istream& is,
   m.mspecies = ArrayOfSpeciesTag(6 + i);
 
   // Set species
-  m.mspecies[i + 1] = SpeciesTag(String("N2"));
-  m.mspecies[i + 2] = SpeciesTag(String("O2"));
-  m.mspecies[i + 3] = SpeciesTag(String("H2O"));
-  m.mspecies[i + 4] = SpeciesTag(String("CO2"));
-  m.mspecies[i + 5] = SpeciesTag(String("H2"));
-  m.mspecies[i + 6] = SpeciesTag(String("He"));
+  m.mspecies[i] = SpeciesTag(String("N2"));
+  m.mspecies[i + 1] = SpeciesTag(String("O2"));
+  m.mspecies[i + 2] = SpeciesTag(String("H2O"));
+  m.mspecies[i + 3] = SpeciesTag(String("CO2"));
+  m.mspecies[i + 4] = SpeciesTag(String("H2"));
+  m.mspecies[i + 5] = SpeciesTag(String("He"));
 
   // Temperature types
   for (auto& v : m.mdata) {


### PR DESCRIPTION
This fixes assertion failures in several tests:

TestIsoRatios, TestSurf_Earth, TestSurf_Mars, TestSurf_Venus, TestRTwithCIA, DemoVenus_fullRT_1D_clearsky.

Caveats:

Only TestSurf_Earth runs successfully afterwards.

TestSurf_Venus and TestSurf_Mars fail with:
```
Run-time error in function: xsec_species                                                                                                                                             
Bad VMRs, your atmosphere does not support the line of interest   
```

TestIsoRatios, TestRTwithCIA, DemoVenus_fullRT_1D_clearsky fail with a segfault in lineshape_voigt_kuntz6 afterwards.

@riclarsson I'll debug these later, if I know if this fix is correct.
