### PR TITLE
Removed old RT4 functions and renamed newer ones

### DIFF
--- a/controlfiles/artscomponents/polradtran/TestRT4.arts
+++ b/controlfiles/artscomponents/polradtran/TestRT4.arts
@@ -93,7 +93,7 @@ RT4Calc #( nstreams=64 )
 
 Tensor7Create( ifield_old_optprop )
 Copy( ifield_old_optprop, doit_i_field )
-RT4Calc( new_optprop=1 ) #, nstreams=64 )
+RT4Calc #( nstreams=64 )
 CompareRelative( ifield_old_optprop, doit_i_field, 1e-6 )
 Compare( ifield_old_optprop, doit_i_field, 1e-30 )
 

--- a/src/m_rt4.cc
+++ b/src/m_rt4.cc
@@ -398,7 +398,6 @@ void RT4Calc(Workspace&,
              const Index&,
              const Index&,
              const Numeric&,
-             const Index&,
              const Verbosity&) {
   throw runtime_error("This version of ARTS was compiled without RT4 support.");
 }

--- a/src/m_rt4.cc
+++ b/src/m_rt4.cc
@@ -79,7 +79,6 @@ void RT4Calc(Workspace& ws,
              const Index& za_interp_order,
              const Index& cos_za_interp,
              const Numeric& max_delta_tau,
-             const Index& new_optprop,
              const Verbosity& verbosity) {
   if (!cloudbox_on) {
     CREATE_OUT1;
@@ -198,7 +197,6 @@ void RT4Calc(Workspace& ws,
           pfct_aa_grid_size,
           pfct_threshold,
           max_delta_tau,
-          new_optprop,
           verbosity);
 
   scat_za_grid_adjust(scat_za_grid, mu_values, nummu);
@@ -323,6 +321,7 @@ void RT4CalcWithRT4Surface(Workspace& ws,
                     stokes_dim);
 
   Agenda dummy_agenda;
+
   run_rt4(ws,
           doit_i_field,
           scat_za_grid,
@@ -358,7 +357,6 @@ void RT4CalcWithRT4Surface(Workspace& ws,
           pfct_aa_grid_size,
           pfct_threshold,
           max_delta_tau,
-          0,
           verbosity);
 
   scat_za_grid_adjust(scat_za_grid, mu_values, nummu);

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -15381,8 +15381,7 @@ void define_md_data_raw() {
           "robust",
           "za_interp_order",
           "cos_za_interp",
-          "max_delta_tau",
-          "new_optprop"),
+          "max_delta_tau"),
       GIN_TYPE("Index",
                "String",
                "String",
@@ -15392,10 +15391,9 @@ void define_md_data_raw() {
                "Index",
                "Index",
                "Index",
-               "Numeric",
-               "Index"),
+               "Numeric"),
       GIN_DEFAULT(
-          "16", "median", "D", "1", "19", "0", "0", "1", "0", "1e-6", "0"),
+          "16", "median", "D", "1", "19", "0", "0", "1", "0", "1e-6"),
       GIN_DESC("Number of polar angle directions (streams) in RT4"
                " solution (must be an even number).",
                "Flag which method to apply to derive phase function (for"
@@ -15425,9 +15423,7 @@ void define_md_data_raw() {
                "For *auto_inc_nstreams*>0, flag whether to do polar angle"
                " interpolation in cosine (='mu') space.",
                "Maximum optical depth of infinitesimal layer (where single"
-               " scattering approximation is assumed to apply).",
-               "Flag whether to use old (0) or new(1) optical property"
-               " extraction scheme.")));
+               " scattering approximation is assumed to apply).")));
 
   md_data_raw.push_back(MdRecord(
       NAME("RT4CalcWithRT4Surface"),

--- a/src/rt4.cc
+++ b/src/rt4.cc
@@ -354,7 +354,6 @@ void get_rt4surf_props(  // Output
   }
 }
 
-
 void run_rt4(Workspace& ws,
              // Output
              Tensor7& doit_i_field,
@@ -392,593 +391,7 @@ void run_rt4(Workspace& ws,
              const Index& pfct_aa_grid_size,
              const Numeric& pfct_threshold,
              const Numeric& max_delta_tau,
-             const Index& new_optprop,
              const Verbosity& verbosity) {
-  // Input variables for RT4
-  Index num_layers = p_grid.nelem() - 1;
-  /*
-  bool do_non_iso;
-  if( p_grid.nelem() == pnd_field.npages() )
-    // cloudbox covers whole atmo anyways. no need for a calculation of
-    // non-iso incoming field at top-of-cloudbox. disort will be run over
-    // whole atmo.
-    {
-      do_non_iso = false;
-      num_layers = p_grid.nelem()-1;
-    }
-  else
-    {
-      if( non_iso_inc )
-        // cloudbox only covers part of atmo. disort will be initialized with
-        // non-isotropic incoming field and run over cloudbox only.
-        {
-          do_non_iso = true;
-          num_layers = pnd_field.npages()-1;
-        }
-      else
-        // cloudbox only covers part of atmo. disort will be run over whole
-        // atmo, though (but only in-cloudbox rad field passed to doit_i_field).
-        {
-          do_non_iso = false;
-          num_layers = p_grid.nelem()-1;
-        }
-    }
-  */
-
-  // Top of the atmosphere temperature
-  //  FIXME: so far hard-coded to cosmic background. However, change that to set
-  //  according to/from space_agenda.
-  // to do so, we need to hand over sky_radiance instead of sky_temp as
-  // Tensor3(2,stokes_dim,nummu) per frequency. That is, for properly using
-  // iy_space_agenda, we need to recall the agenda over the stream angles (not
-  // sure what to do with the upwelling ones. according to the RT¤-internal
-  // sizing, sky_radiance contains even those. but they might not be used
-  // (check!) and hence be set arbitrary.
-  const Numeric sky_temp = COSMIC_BG_TEMP;
-
-  // Data fields
-  Vector height(num_layers + 1);
-  Vector temperatures(num_layers + 1);
-  for (Index i = 0; i < height.nelem(); i++) {
-    height[i] = z_field(num_layers - i, 0, 0);
-    temperatures[i] = t_field(num_layers - i, 0, 0);
-  }
-
-  // this indexes all cloudbox layers as cloudy layers.
-  // optional FIXME: to use the power of RT4 (faster solving scheme for
-  // individual non-cloudy layers), one should consider non-cloudy layers within
-  // cloudbox. That requires some kind of recognition and index setting based on
-  // pnd_field or (derived) cloud layer extinction or scattering.
-  // we use something similar with iyHybrid. have a look there...
-  const Index num_scatlayers = pnd_field.npages() - 1;
-  Vector scatlayers(num_layers, 0.);
-  Vector gas_extinct(num_layers, 0.);
-  Tensor6 scatter_matrix(
-      num_scatlayers, 4, nummu, stokes_dim, nummu, stokes_dim, 0.);
-  Tensor6 extinct_matrix(
-      1, num_scatlayers, 2, nummu, stokes_dim, stokes_dim, 0.);
-  Tensor5 emis_vector(1, num_scatlayers, 2, nummu, stokes_dim, 0.);
-
-  // if there is no scatt particle at all, we don't need to calculate the
-  // scat properties (FIXME: that should rather be done by a proper setting
-  // of scat_layers).
-  Vector pnd_per_level(pnd_field.npages());
-  for (Index clev = 0; clev < pnd_field.npages(); clev++)
-    pnd_per_level[clev] = pnd_field(joker, clev, 0, 0).sum();
-  Numeric pndtot = pnd_per_level.sum();
-
-  for (Index i = 0; i < cloudbox_limits[1] - cloudbox_limits[0]; i++) {
-    scatlayers[num_layers - 1 - cloudbox_limits[0] - i] = float(i + 1);
-  }
-
-  // Output variables
-  Tensor3 up_rad(num_layers + 1, nummu, stokes_dim, 0.);
-  Tensor3 down_rad(num_layers + 1, nummu, stokes_dim, 0.);
-
-  Tensor6 extinct_matrix_allf;
-  Tensor5 emis_vector_allf;
-  if (new_optprop && !auto_inc_nstreams) {
-    extinct_matrix_allf.resize(
-        f_grid.nelem(), num_scatlayers, 2, nummu, stokes_dim, stokes_dim);
-    emis_vector_allf.resize(
-        f_grid.nelem(), num_scatlayers, 2, nummu, stokes_dim);
-    par_optpropCalc2(emis_vector_allf,
-                     extinct_matrix_allf,
-                     //scatlayers,
-                     scat_data,
-                     scat_za_grid,
-                     -1,
-                     pnd_field,
-                     t_field(Range(0, num_layers + 1), joker, joker),
-                     cloudbox_limits,
-                     stokes_dim);
-    if (emis_vector_allf.nshelves() == 1)  // scat_data had just a single freq
-                                           // point. copy into emis/ext here and
-                                           // don't touch anymore later on.
-    {
-      emis_vector = emis_vector_allf(Range(0, 1), joker, joker, joker, joker);
-      extinct_matrix =
-          extinct_matrix_allf(Range(0, 1), joker, joker, joker, joker, joker);
-    }
-  }
-
-  // FIXME: once, all old optprop scheme incl. the applied agendas is removed,
-  // we can remove this as well.
-  Vector scat_za_grid_orig;
-  if (auto_inc_nstreams)
-    // For the WSV scat_za_grid, we need to reset these grids instead of
-    // creating a new container. this because further down some agendas are
-    // used that access scat_za/aa_grid through the workspace.
-    // Later on, we need to reconstruct the original setting, hence backup
-    // that here.
-    scat_za_grid_orig = scat_za_grid;
-
-  Index nummu_new = 0;
-  // Loop over frequencies
-  for (Index f_index = 0; f_index < f_grid.nelem(); f_index++) {
-    // Wavelength [um]
-    Numeric wavelength;
-    wavelength = 1e6 * SPEED_OF_LIGHT / f_grid[f_index];
-
-    Matrix groundreflec = ground_reflec(f_index, joker, joker);
-    Tensor4 surfreflmat = surf_refl_mat(f_index, joker, joker, joker, joker);
-    Matrix surfemisvec = surf_emis_vec(f_index, joker, joker);
-    //Vector muvalues=mu_values;
-
-    // only update gas_extinct if there is any gas absorption at all (since
-    // vmr_field is not freq-dependent, gas_extinct will remain as above
-    // initialized (with 0) for all freqs, ie we can rely on that it wasn't
-    // changed.
-    if (vmr_field.nbooks() > 0) {
-      gas_optpropCalc(ws,
-                      gas_extinct,
-                      propmat_clearsky_agenda,
-                      t_field(Range(0, num_layers + 1), joker, joker),
-                      vmr_field(joker, Range(0, num_layers + 1), joker, joker),
-                      p_grid[Range(0, num_layers + 1)],
-                      f_grid[Range(f_index, 1)]);
-    }
-
-    Index pfct_failed = 0;
-    if (pndtot != 0) {
-      if (nummu_new < nummu) {
-        if (new_optprop) {
-          if (!auto_inc_nstreams)  // all freq calculated before. just copy
-                                   // here. but only if needed.
-          {
-            if (emis_vector_allf.nshelves() != 1) {
-              emis_vector = emis_vector_allf(
-                  Range(f_index, 1), joker, joker, joker, joker);
-              extinct_matrix = extinct_matrix_allf(
-                  Range(f_index, 1), joker, joker, joker, joker, joker);
-            }
-          } else {
-            par_optpropCalc2(emis_vector,
-                             extinct_matrix,
-                             //scatlayers,
-                             scat_data,
-                             scat_za_grid,
-                             f_index,
-                             pnd_field,
-                             t_field(Range(0, num_layers + 1), joker, joker),
-                             cloudbox_limits,
-                             stokes_dim);
-          }
-        } else {
-          par_optpropCalc(emis_vector(0, joker, joker, joker, joker),
-                          extinct_matrix(0, joker, joker, joker, joker, joker),
-                          //scatlayers,
-                          scat_data,
-                          scat_za_grid,
-                          f_index,
-                          pnd_field,
-                          t_field(Range(0, num_layers + 1), joker, joker),
-                          cloudbox_limits,
-                          stokes_dim,
-                          nummu,
-                          verbosity);
-        }
-        sca_optpropCalc(scatter_matrix,
-                        pfct_failed,
-                        emis_vector(0, joker, joker, joker, joker),
-                        extinct_matrix(0, joker, joker, joker, joker, joker),
-                        f_index,
-                        scat_data,
-                        pnd_field,
-                        stokes_dim,
-                        scat_za_grid,
-                        quad_weights,
-                        pfct_method,
-                        pfct_aa_grid_size,
-                        pfct_threshold,
-                        auto_inc_nstreams,
-                        verbosity);
-      } else {
-        pfct_failed = 1;
-      }
-    }
-
-    if (!pfct_failed) {
-#pragma omp critical(fortran_rt4)
-      {
-        // Call RT4
-        radtrano_(stokes_dim,
-                  nummu,
-                  nhza,
-                  max_delta_tau,
-                  quad_type.c_str(),
-                  surface_skin_t,
-                  ground_type.c_str(),
-                  ground_albedo[f_index],
-                  ground_index[f_index],
-                  groundreflec.get_c_array(),
-                  surfreflmat.get_c_array(),
-                  surfemisvec.get_c_array(),
-                  sky_temp,
-                  wavelength,
-                  num_layers,
-                  height.get_c_array(),
-                  temperatures.get_c_array(),
-                  gas_extinct.get_c_array(),
-                  num_scatlayers,
-                  scatlayers.get_c_array(),
-                  extinct_matrix.get_c_array(),
-                  emis_vector.get_c_array(),
-                  scatter_matrix.get_c_array(),
-                  //noutlevels,
-                  //outlevels.get_c_array(),
-                  mu_values.get_c_array(),
-                  up_rad.get_c_array(),
-                  down_rad.get_c_array());
-      }
-    } else  // if (auto_inc_nstreams)
-    {
-      if (nummu_new < nummu) nummu_new = nummu + 1;
-
-      Index nhstreams_new;
-      Vector mu_values_new, quad_weights_new, scat_aa_grid_new;
-      Tensor6 scatter_matrix_new;
-      Tensor6 extinct_matrix_new;
-      Tensor5 emis_vector_new;
-      Tensor4 surfreflmat_new;
-      Matrix surfemisvec_new;
-
-      while (pfct_failed && (2 * nummu_new) <= auto_inc_nstreams) {
-        // resize and recalc nstream-affected/determined variables:
-        //   - mu_values, quad_weights (resize & recalc)
-        nhstreams_new = nummu_new - nhza;
-        mu_values_new.resize(nummu_new);
-        mu_values_new = 0.;
-        quad_weights_new.resize(nummu_new);
-        quad_weights_new = 0.;
-        get_quad_angles(mu_values_new,
-                        quad_weights_new,
-                        scat_za_grid,
-                        scat_aa_grid_new,
-                        quad_type,
-                        nhstreams_new,
-                        nhza,
-                        nummu_new);
-        //   - resize & recalculate emis_vector, extinct_matrix (as input to scatter_matrix calc)
-        extinct_matrix_new.resize(
-            1, num_scatlayers, 2, nummu_new, stokes_dim, stokes_dim);
-        extinct_matrix_new = 0.;
-        emis_vector_new.resize(1, num_scatlayers, 2, nummu_new, stokes_dim);
-        emis_vector_new = 0.;
-        // FIXME: So far, outside-of-freq-loop calculated optprops will fall
-        // back to in-loop-calculated ones in case of auto-increasing stream
-        // numbers. There might be better options, but I (JM) couldn't come up
-        // with or decide for one so far (we could recalc over all freqs. but
-        // that would unnecessarily recalc lower-freq optprops, too, which are
-        // not needed anymore. which could likely take more time than we
-        // potentially safe through all-at-once temperature and direction
-        // interpolations.
-        if (new_optprop)
-          par_optpropCalc2(emis_vector_new,
-                           extinct_matrix_new,
-                           //scatlayers,
-                           scat_data,
-                           scat_za_grid,
-                           f_index,
-                           pnd_field,
-                           t_field(Range(0, num_layers + 1), joker, joker),
-                           cloudbox_limits,
-                           stokes_dim);
-        else
-          par_optpropCalc(
-              emis_vector_new(0, joker, joker, joker, joker),
-              extinct_matrix_new(0, joker, joker, joker, joker, joker),
-              //scatlayers,
-              scat_data,
-              scat_za_grid,
-              f_index,
-              pnd_field,
-              t_field(Range(0, num_layers + 1), joker, joker),
-              cloudbox_limits,
-              stokes_dim,
-              nummu_new,
-              verbosity);
-        //   - resize & recalc scatter_matrix
-        scatter_matrix_new.resize(
-            num_scatlayers, 4, nummu_new, stokes_dim, nummu_new, stokes_dim);
-        scatter_matrix_new = 0.;
-        pfct_failed = 0;
-        sca_optpropCalc(
-            scatter_matrix_new,
-            pfct_failed,
-            emis_vector_new(0, joker, joker, joker, joker),
-            extinct_matrix_new(0, joker, joker, joker, joker, joker),
-            f_index,
-            scat_data,
-            pnd_field,
-            stokes_dim,
-            scat_za_grid,
-            quad_weights_new,
-            pfct_method,
-            pfct_aa_grid_size,
-            pfct_threshold,
-            auto_inc_nstreams,
-            verbosity);
-
-        if (pfct_failed) nummu_new = nummu_new + 1;
-      }
-
-      if (pfct_failed) {
-        nummu_new = nummu_new - 1;
-        ostringstream os;
-        os << "Could not increase nstreams sufficiently (current: "
-           << 2 * nummu_new << ")\n"
-           << "to satisfy scattering matrix norm at f[" << f_index
-           << "]=" << f_grid[f_index] * 1e-9 << " GHz.\n";
-        if (!robust) {
-          // couldn't find a nstreams within the limits of auto_inc_nstremas
-          // (aka max. nstreams) that satisfies the scattering matrix norm.
-          // Hence fail completely.
-          os << "Try higher maximum number of allowed streams (ie. higher"
-             << " auto_inc_nstreams than " << auto_inc_nstreams << ").";
-          throw runtime_error(os.str());
-        } else {
-          CREATE_OUT1;
-          os << "Continuing with nstreams=" << 2 * nummu_new
-             << ". Output for this frequency might be erroneous.";
-          out1 << os.str();
-
-          nhstreams_new = nummu_new - nhza;
-          mu_values_new.resize(nummu_new);
-          mu_values_new = 0.;
-          quad_weights_new.resize(nummu_new);
-          quad_weights_new = 0.;
-          get_quad_angles(mu_values_new,
-                          quad_weights_new,
-                          scat_za_grid,
-                          scat_aa_grid_new,
-                          quad_type,
-                          nhstreams_new,
-                          nhza,
-                          nummu_new);
-          extinct_matrix_new.resize(
-              1, num_scatlayers, 2, nummu_new, stokes_dim, stokes_dim);
-          extinct_matrix_new = 0.;
-          emis_vector_new.resize(1, num_scatlayers, 2, nummu_new, stokes_dim);
-          emis_vector_new = 0.;
-          if (new_optprop)
-            par_optpropCalc2(emis_vector_new,
-                             extinct_matrix_new,
-                             //scatlayers,
-                             scat_data,
-                             scat_za_grid,
-                             f_index,
-                             pnd_field,
-                             t_field(Range(0, num_layers + 1), joker, joker),
-                             cloudbox_limits,
-                             stokes_dim);
-          else
-            par_optpropCalc(
-                emis_vector_new(0, joker, joker, joker, joker),
-                extinct_matrix_new(0, joker, joker, joker, joker, joker),
-                //scatlayers,
-                scat_data,
-                scat_za_grid,
-                f_index,
-                pnd_field,
-                t_field(Range(0, num_layers + 1), joker, joker),
-                cloudbox_limits,
-                stokes_dim,
-                nummu_new,
-                verbosity);
-          //   - resize & recalc scatter_matrix
-          scatter_matrix_new.resize(
-              num_scatlayers, 4, nummu_new, stokes_dim, nummu_new, stokes_dim);
-          scatter_matrix_new = 0.;
-          pfct_failed = -1;
-          sca_optpropCalc(
-              scatter_matrix_new,
-              pfct_failed,
-              emis_vector_new(0, joker, joker, joker, joker),
-              extinct_matrix_new(0, joker, joker, joker, joker, joker),
-              f_index,
-              scat_data,
-              pnd_field,
-              stokes_dim,
-              scat_za_grid,
-              quad_weights_new,
-              pfct_method,
-              pfct_aa_grid_size,
-              pfct_threshold,
-              0,
-              verbosity);
-        }
-      }
-
-      // resize and calc remaining nstream-affected variables:
-      //   - in case of surface_rtprop_agenda driven surface: surfreflmat, surfemisvec
-      if (ground_type == "A")  // surface_rtprop_agenda driven surface
-      {
-        Tensor5 srm_new(1, nummu_new, stokes_dim, nummu_new, stokes_dim, 0.);
-        Tensor3 sev_new(1, nummu_new, stokes_dim, 0.);
-        surf_optpropCalc(ws,
-                         srm_new,
-                         sev_new,
-                         surface_rtprop_agenda,
-                         f_grid[Range(f_index, 1)],
-                         scat_za_grid,
-                         mu_values_new,
-                         quad_weights_new,
-                         stokes_dim,
-                         surf_altitude);
-        surfreflmat_new = srm_new(0, joker, joker, joker, joker);
-        surfemisvec_new = sev_new(0, joker, joker);
-      }
-      //   - up/down_rad (resize only)
-      Tensor3 up_rad_new(num_layers + 1, nummu_new, stokes_dim, 0.);
-      Tensor3 down_rad_new(num_layers + 1, nummu_new, stokes_dim, 0.);
-      //
-      // run radtrano_
-#pragma omp critical(fortran_rt4)
-      {
-        // Call RT4
-        radtrano_(stokes_dim,
-                  nummu_new,
-                  nhza,
-                  max_delta_tau,
-                  quad_type.c_str(),
-                  surface_skin_t,
-                  ground_type.c_str(),
-                  ground_albedo[f_index],
-                  ground_index[f_index],
-                  groundreflec.get_c_array(),
-                  surfreflmat_new.get_c_array(),
-                  surfemisvec_new.get_c_array(),
-                  sky_temp,
-                  wavelength,
-                  num_layers,
-                  height.get_c_array(),
-                  temperatures.get_c_array(),
-                  gas_extinct.get_c_array(),
-                  num_scatlayers,
-                  scatlayers.get_c_array(),
-                  extinct_matrix_new(0, joker, joker, joker, joker, joker)
-                      .get_c_array(),
-                  emis_vector_new(0, joker, joker, joker, joker).get_c_array(),
-                  scatter_matrix_new.get_c_array(),
-                  //noutlevels,
-                  //outlevels.get_c_array(),
-                  mu_values_new.get_c_array(),
-                  up_rad_new.get_c_array(),
-                  down_rad_new.get_c_array());
-      }
-      // back-interpolate nstream_new fields to nstreams
-      //   (possible to use iyCloudboxInterp agenda? nja, not really a good
-      //   idea. too much overhead there (checking, 3D+2ang interpol). rather
-      //   use interp_order as additional user parameter.
-      //   extrapol issues shouldn't occur as we go from finer to coarser
-      //   angular grid)
-      //   - loop over nummu:
-      //     - determine weights per ummu ang (should be valid for both up and
-      //       down)
-      //     - loop over num_layers and stokes_dim:
-      //       - apply weights
-      for (Index j = 0; j < nummu; j++) {
-        GridPosPoly gp_za;
-        if (cos_za_interp) {
-          gridpos_poly(
-              gp_za, mu_values_new, mu_values[j], za_interp_order, 0.5);
-        } else {
-          gridpos_poly(gp_za,
-                       scat_za_grid[Range(0, nummu_new)],
-                       scat_za_grid_orig[j],
-                       za_interp_order,
-                       0.5);
-        }
-        Vector itw(gp_za.idx.nelem());
-        interpweights(itw, gp_za);
-
-        for (Index k = 0; k < num_layers + 1; k++)
-          for (Index ist = 0; ist < stokes_dim; ist++) {
-            up_rad(k, j, ist) = interp(itw, up_rad_new(k, joker, ist), gp_za);
-            down_rad(k, j, ist) =
-                interp(itw, down_rad_new(k, joker, ist), gp_za);
-          }
-      }
-
-      // reconstruct scat_za_grid
-      scat_za_grid = scat_za_grid_orig;
-    }
-
-    // RT4 rad output is in wavelength units, nominally in W/(m2 sr um), where
-    // wavelength input is required in um.
-    // FIXME: When using wavelength input in m, output should be in W/(m2 sr
-    // m). However, check this. So, at first we use wavelength in um. Then
-    // change and compare.
-    //
-    // FIXME: if ever we allow the cloudbox to be not directly at the surface
-    // (at atm level #0, respectively), the assigning from up/down_rad to
-    // doit_i_field needs to checked. there seems some offsetting going on
-    // (test example: TestDOIT.arts. if kept like below, doit_i_field at
-    // top-of-cloudbox seems to actually be from somewhere within the
-    // cloud(box) indicated by downwelling being to high and downwelling
-    // exhibiting a non-zero polarisation signature (which it wouldn't with
-    // only scalar gas abs above).
-    //
-    Numeric rad_l2f = wavelength / f_grid[f_index];
-    // down/up_rad contain the radiances in order from slant (90deg) to steep
-    // (0 and 180deg, respectively) streams,then the possible extra angle(s).
-    // We need to resort them properly into doit_i_field, such that order is
-    // from 0 to 180deg.
-    for (Index j = 0; j < nummu; j++)
-      for (Index k = 0; k < (cloudbox_limits[1] - cloudbox_limits[0] + 1); k++)
-        for (Index ist = 0; ist < stokes_dim; ist++) {
-          //doit_i_field(f_index, k, 0, 0, nummu+j, 0, ist) =
-          //  up_rad(num_layers-k,j,ist)*rad_l2f;
-          //doit_i_field(f_index, k, 0, 0, nummu-1-j, 0, ist) =
-          //  down_rad(num_layers-k,j,ist)*rad_l2f;
-          doit_i_field(f_index, k, 0, 0, nummu + j, 0, ist) =
-              up_rad(num_layers - k, j, ist) * rad_l2f;
-          doit_i_field(f_index, k, 0, 0, nummu - 1 - j, 0, ist) =
-              down_rad(num_layers - k, j, ist) * rad_l2f;
-        }
-  }
-}
-
-
-void run_rt4_new(Workspace& ws,
-                 // Output
-                 Tensor7& doit_i_field,
-                 Vector& scat_za_grid,
-                 // Input
-                 ConstVectorView f_grid,
-                 ConstVectorView p_grid,
-                 ConstTensor3View z_field,
-                 ConstTensor3View t_field,
-                 ConstTensor4View vmr_field,
-                 ConstTensor4View pnd_field,
-                 const ArrayOfArrayOfSingleScatteringData& scat_data,
-                 const Agenda& propmat_clearsky_agenda,
-                 const ArrayOfIndex& cloudbox_limits,
-                 const Index& stokes_dim,
-                 const Index& nummu,
-                 const Index& nhza,
-                 const String& ground_type,
-                 const Numeric& surface_skin_t,
-                 ConstVectorView ground_albedo,
-                 ConstTensor3View ground_reflec,
-                 ConstComplexVectorView ground_index,
-                 ConstTensor5View surf_refl_mat,
-                 ConstTensor3View surf_emis_vec,
-                 const Agenda& surface_rtprop_agenda,
-                 const Numeric& surf_altitude,
-                 const String& quad_type,
-                 Vector& mu_values,
-                 ConstVectorView quad_weights,
-                 const Index& auto_inc_nstreams,
-                 const Index& robust,
-                 const Index& za_interp_order,
-                 const Index& cos_za_interp,
-                 const String& pfct_method,
-                 const Index& pfct_aa_grid_size,
-                 const Numeric& pfct_threshold,
-                 const Numeric& max_delta_tau,
-                 const Verbosity& verbosity) {
   // Input variables for RT4
   Index num_layers = p_grid.nelem() - 1;
   /*
@@ -1067,16 +480,16 @@ void run_rt4_new(Workspace& ws,
         f_grid.nelem(), num_scatlayers, 2, nummu, stokes_dim, stokes_dim);
     emis_vector_allf.resize(
         f_grid.nelem(), num_scatlayers, 2, nummu, stokes_dim);
-    par_optpropCalc2(emis_vector_allf,
-                     extinct_matrix_allf,
-                     //scatlayers,
-                     scat_data,
-                     scat_za_grid,
-                     -1,
-                     pnd_field,
-                     t_field(Range(0, num_layers + 1), joker, joker),
-                     cloudbox_limits,
-                     stokes_dim);
+    par_optpropCalc(emis_vector_allf,
+                    extinct_matrix_allf,
+                    //scatlayers,
+                    scat_data,
+                    scat_za_grid,
+                    -1,
+                    pnd_field,
+                    t_field(Range(0, num_layers + 1), joker, joker),
+                    cloudbox_limits,
+                    stokes_dim);
     if (emis_vector_allf.nshelves() == 1)  // scat_data had just a single freq
                                            // point. copy into emis/ext here and
                                            // don't touch anymore later on.
@@ -1137,16 +550,16 @@ void run_rt4_new(Workspace& ws,
                 Range(f_index, 1), joker, joker, joker, joker, joker);
           }
         } else {
-          par_optpropCalc2(emis_vector,
-                           extinct_matrix,
-                           //scatlayers,
-                           scat_data,
-                           scat_za_grid,
-                           f_index,
-                           pnd_field,
-                           t_field(Range(0, num_layers + 1), joker, joker),
-                           cloudbox_limits,
-                           stokes_dim);
+          par_optpropCalc(emis_vector,
+                          extinct_matrix,
+                          //scatlayers,
+                          scat_data,
+                          scat_za_grid,
+                          f_index,
+                          pnd_field,
+                          t_field(Range(0, num_layers + 1), joker, joker),
+                          cloudbox_limits,
+                          stokes_dim);
         }
         sca_optpropCalc(scatter_matrix,
                         pfct_failed,
@@ -1244,16 +657,16 @@ void run_rt4_new(Workspace& ws,
         // not needed anymore. which could likely take more time than we
         // potentially safe through all-at-once temperature and direction
         // interpolations.
-        par_optpropCalc2(emis_vector_new,
-                         extinct_matrix_new,
-                         //scatlayers,
-                         scat_data,
-                         scat_za_grid,
-                         f_index,
-                         pnd_field,
-                         t_field(Range(0, num_layers + 1), joker, joker),
-                         cloudbox_limits,
-                         stokes_dim);
+        par_optpropCalc(emis_vector_new,
+                        extinct_matrix_new,
+                        //scatlayers,
+                        scat_data,
+                        scat_za_grid,
+                        f_index,
+                        pnd_field,
+                        t_field(Range(0, num_layers + 1), joker, joker),
+                        cloudbox_limits,
+                        stokes_dim);
 
         //   - resize & recalc scatter_matrix
         scatter_matrix_new.resize(
@@ -1531,9 +944,8 @@ void gas_optpropCalc(Workspace& ws,
   }
 }
 
-
-void par_optpropCalc(Tensor4View emis_vector,
-                     Tensor5View extinct_matrix,
+void par_optpropCalc(Tensor5View emis_vector,
+                     Tensor6View extinct_matrix,
                      //VectorView scatlayers,
                      const ArrayOfArrayOfSingleScatteringData& scat_data,
                      const Vector& scat_za_grid,
@@ -1541,130 +953,7 @@ void par_optpropCalc(Tensor4View emis_vector,
                      ConstTensor4View pnd_field,
                      ConstTensor3View t_field,
                      const ArrayOfIndex& cloudbox_limits,
-                     const Index& stokes_dim,
-                     const Index& nummu,
-                     const Verbosity& verbosity) {
-  // Initialization
-  extinct_matrix = 0.;
-  emis_vector = 0.;
-
-  const Index N_se = pnd_field.nbooks();
-  const Index Np_cloud = pnd_field.npages();
-
-  assert(emis_vector.nbooks() == Np_cloud - 1);
-  assert(extinct_matrix.nshelves() == Np_cloud - 1);
-
-  // Local variables to be used in agendas
-  ArrayOfStokesVector abs_vec_spt_local(N_se);
-  for (auto& sv : abs_vec_spt_local) {
-    sv = StokesVector(1, stokes_dim);
-    sv.SetZero();
-  }
-
-  ArrayOfPropagationMatrix ext_mat_spt_local(N_se);
-  for (auto& pm : ext_mat_spt_local) {
-    pm = PropagationMatrix(1, stokes_dim);
-    pm.SetZero();
-  }
-
-  StokesVector abs_vec_local(1, stokes_dim);
-  PropagationMatrix ext_mat_local(1, stokes_dim);
-
-  Numeric rtp_temperature_local;
-  Tensor4 ext_vector(Np_cloud, 2 * nummu, stokes_dim, stokes_dim, 0.);
-  Tensor3 abs_vector(Np_cloud, 2 * nummu, stokes_dim, 0.);
-  Vector aa_dummy(1, 0.);
-
-  // Calculate ext_mat and abs_vec for all pressure points in cloudbox
-  for (Index scat_p_index_local = 0; scat_p_index_local < Np_cloud;
-       scat_p_index_local++) {
-    rtp_temperature_local =
-        t_field(scat_p_index_local + cloudbox_limits[0], 0, 0);
-
-    for (Index iza = 0; iza < 2 * nummu; iza++) {
-      //Calculate optical properties for all individual scattering elements:
-      //
-      // FIXME: this might be better done PER scatt element
-      // why?
-      //   - for totally random, we only need to extract for 1 angle
-      //   - if T-dimension is 1, we only need to do once for all p-levels
-      opt_prop_sptFromScat_data(ext_mat_spt_local,
-                                abs_vec_spt_local,
-                                scat_data,
-                                1,
-                                scat_za_grid,
-                                aa_dummy,
-                                iza,
-                                0,
-                                f_index,
-                                rtp_temperature_local,
-                                pnd_field,
-                                scat_p_index_local,
-                                0,
-                                0,
-                                verbosity);
-
-      //Calculate bulk optical properties:
-      opt_prop_bulkCalc(ext_mat_local,
-                        abs_vec_local,
-                        ext_mat_spt_local,
-                        abs_vec_spt_local,
-                        pnd_field,
-                        scat_p_index_local,
-                        0,
-                        0,
-                        verbosity);
-
-      ext_mat_local.MatrixAtPosition(
-          ext_vector(scat_p_index_local, iza, joker, joker));
-      abs_vec_local.VectorAtPosition(
-          abs_vector(scat_p_index_local, iza, joker));
-    }
-  }
-
-  // Calculate layer averaged extinction and absorption
-  for (Index scat_p_index_local = 0; scat_p_index_local < Np_cloud - 1;
-       scat_p_index_local++) {
-    /*
-      if ( (ext_vector(scat_p_index_local,0,0,0)+
-            ext_vector(scat_p_index_local+1,0,0,0)) > 0. )
-        {
-          scatlayers[Np_cloud-2-cloudbox_limits[0]-scat_p_index_local] =
-            float(scat_p_index_local);
-*/
-    for (Index imu = 0; imu < nummu; imu++)
-      for (Index ist1 = 0; ist1 < stokes_dim; ist1++) {
-        for (Index ist2 = 0; ist2 < stokes_dim; ist2++) {
-          extinct_matrix(scat_p_index_local, 0, imu, ist2, ist1) =
-              .5 * (ext_vector(scat_p_index_local, imu, ist1, ist2) +
-                    ext_vector(scat_p_index_local + 1, imu, ist1, ist2));
-          extinct_matrix(scat_p_index_local, 1, imu, ist2, ist1) =
-              .5 *
-              (ext_vector(scat_p_index_local, nummu + imu, ist1, ist2) +
-               ext_vector(scat_p_index_local + 1, nummu + imu, ist1, ist2));
-        }
-        emis_vector(scat_p_index_local, 0, imu, ist1) =
-            .5 * (abs_vector(scat_p_index_local, imu, ist1) +
-                  abs_vector(scat_p_index_local + 1, imu, ist1));
-        emis_vector(scat_p_index_local, 1, imu, ist1) =
-            .5 * (abs_vector(scat_p_index_local, nummu + imu, ist1) +
-                  abs_vector(scat_p_index_local + 1, nummu + imu, ist1));
-      }
-    //        }
-  }
-}
-
-
-void par_optpropCalc2(Tensor5View emis_vector,
-                      Tensor6View extinct_matrix,
-                      //VectorView scatlayers,
-                      const ArrayOfArrayOfSingleScatteringData& scat_data,
-                      const Vector& scat_za_grid,
-                      const Index& f_index,
-                      ConstTensor4View pnd_field,
-                      ConstTensor3View t_field,
-                      const ArrayOfIndex& cloudbox_limits,
-                      const Index& stokes_dim) {
+                     const Index& stokes_dim) {
   // Initialization
   extinct_matrix = 0.;
   emis_vector = 0.;

--- a/src/rt4.h
+++ b/src/rt4.h
@@ -161,14 +161,12 @@ void get_rt4surf_props(  // Output
   \param[in]     cloudbox_limits Cloudbox limits
   \param[in]     stokes_dim Dimension of Stokes vector
   \param[in]     nummu Total number of single hemisphere angles with RT output.
-  \param[in]     nhza Number of single hemisphere additional angles with RT
-                 output.
+  \param[in]     nhza Number of single hemisphere additional angles with RT output.
   \param[in]     ground_type Surface reflection type flag.
-  \param[in]     surface_skin_t Surface skin temperature
+  \param[in]     surface_skin_t Surface scalar temperature
   \param[in]     ground_albedo Scalar surface albedo (for ground_type=L).
   \param[in]     ground_reflec Vector surface relfectivity (for ground_type=S).
-  \param[in]     ground_index Surface complex refractive index
-                 (for ground_type=F).
+  \param[in]     ground_index Surface complex refractive index (for ground_type=F).
   \param[in]     surf_refl_mat Surface reflection matrix (for ground_type=A).
   \param[in]     surf_emis_vec Surface emission vector (for ground_type=A).
   \param[in]     surface_rtprop_agenda Provides radiative properties of the
@@ -191,8 +189,6 @@ void get_rt4surf_props(  // Output
   \param[in]     pfct_threshold Requested scatter_matrix norm accuracy
                  (in terms of single scat albedo).
   \param[in]     max_delta_tau Maximum optical depth of infinitesimal layer
-  \param[in]     new_optprop Flag whether to use old (0) or new(1) optical
-                 property extraction scheme
   \param[in]     verbosity Verbosity setting
 
   \author Jana Mendrok
@@ -235,100 +231,7 @@ void run_rt4(Workspace& ws,
              const Index& pfct_aa_grid_size,
              const Numeric& pfct_threshold,
              const Numeric& max_delta_tau,
-             const Index& new_optprop,
              const Verbosity& verbosity);
-
-//! Runs RT4
-/*!
-  Prepares actual input variables for RT4, runs it, and sorts the output into
-  doit_i_field.
-
-  \param[in,out] ws Current workspace
-  \param[out]    doit_i_field Radiation field
-  \param[out]    scat_za_grid Zenith angle grid
-  \param[in]     f_grid Frequency grid
-  \param[in]     p_grid Pressure
-  \param[in]     z_field Field of geometrical altitudes
-  \param[in]     t_field Atmospheric temperature field
-  \param[in]     vmr_field VMR field
-  \param[in]     pnd_field PND field
-  \param[in]     scat_data Array of single scattering data
-  \param[in]     propmat_clearsky_agenda calculates the absorption coefficient
-                 matrix
-  \param[in]     cloudbox_limits Cloudbox limits
-  \param[in]     stokes_dim Dimension of Stokes vector
-  \param[in]     nummu Total number of single hemisphere angles with RT output.
-  \param[in]     nhza Number of single hemisphere additional angles with RT output.
-  \param[in]     ground_type Surface reflection type flag.
-  \param[in]     surface_skin_t Surface scalar temperature
-  \param[in]     ground_albedo Scalar surface albedo (for ground_type=L).
-  \param[in]     ground_reflec Vector surface relfectivity (for ground_type=S).
-  \param[in]     ground_index Surface complex refractive index (for ground_type=F).
-  \param[in]     surf_refl_mat Surface reflection matrix (for ground_type=A).
-  \param[in]     surf_emis_vec Surface emission vector (for ground_type=A).
-  \param[in]     surface_rtprop_agenda Provides radiative properties of the
-                 surface
-  \param[in]     surf_altitude Surface altitude (lowest level of z_field)
-  \param[in]     quad_type Quadrature method.
-  \param[in]     mu_values Quadrature angle cosines.
-  \param[in]     quad_weights Quadrature weights associated with mu_values.
-  \param[in]     auto_inc_nstreams Flag whether to internally increase nstreams
-  \param[in]     robust if auto_inc_nstreams>0,flag whether to not fail even if
-                 scattering matrix norm is not preserved when maximum stream
-                 number is reached
-  \param[in]     za_interp_order if auto_inc_nstreams>0, polar angle
-                 interpolation order
-  \param[in]     cos_za_interp if auto_inc_nstreams>0, flag whether to do polar
-                 angle interpolation in cosine (='mu') space
-  \param[in]     pfct_method Flag which method to apply to derive phase function
-  \param[in]     pfct_aa_grid_size Number of azimuthal angle grid points to
-                 consider in Fourier series decomposition of scattering matrix
-  \param[in]     pfct_threshold Requested scatter_matrix norm accuracy
-                 (in terms of single scat albedo).
-  \param[in]     max_delta_tau Maximum optical depth of infinitesimal layer
-  \param[in]     verbosity Verbosity setting
-
-  \author Jana Mendrok
-  \date   2017-02-22
-*/
-void run_rt4_new(Workspace& ws,
-    // Output
-                 Tensor7& doit_i_field,
-                 Vector& scat_za_grid,
-    // Input
-                 ConstVectorView f_grid,
-                 ConstVectorView p_grid,
-                 ConstTensor3View z_field,
-                 ConstTensor3View t_field,
-                 ConstTensor4View vmr_field,
-                 ConstTensor4View pnd_field,
-                 const ArrayOfArrayOfSingleScatteringData& scat_data,
-                 const Agenda& propmat_clearsky_agenda,
-                 const ArrayOfIndex& cloudbox_limits,
-                 const Index& stokes_dim,
-                 const Index& nummu,
-                 const Index& nhza,
-                 const String& ground_type,
-                 const Numeric& surface_skin_t,
-                 ConstVectorView ground_albedo,
-                 ConstTensor3View ground_reflec,
-                 ConstComplexVectorView ground_index,
-                 ConstTensor5View surf_refl_mat,
-                 ConstTensor3View surf_emis_vec,
-                 const Agenda& surface_rtprop_agenda,
-                 const Numeric& surf_altitude,
-                 const String& quad_type,
-                 Vector& mu_values,
-                 ConstVectorView quad_weights,
-                 const Index& auto_inc_nstreams,
-                 const Index& robust,
-                 const Index& za_interp_order,
-                 const Index& cos_za_interp,
-                 const String& pfct_method,
-                 const Index& pfct_aa_grid_size,
-                 const Numeric& pfct_threshold,
-                 const Numeric& max_delta_tau,
-                 const Verbosity& verbosity);
 
 //! Reset scat_za_grid such that it is consistent with ARTS
 /*!
@@ -375,6 +278,7 @@ void gas_optpropCalc(Workspace& ws,
                      ConstVectorView p_grid,
                      ConstVectorView f_mono);
 
+
 //! Calculates layer averaged particle extinction and absorption
 /*!
   Calculates layer averaged particle extinction and absorption (extinct_matrix
@@ -391,48 +295,11 @@ void gas_optpropCalc(Workspace& ws,
   \param[in]  t_field Atmospheric temperature field
   \param[in]  cloudbox_limits Cloudbox limits
   \param[in]  stokes_dim Dimension of Stokes vector
-  \param[in]  nummu Number of single hemisphere polar angles.
-  \param[in]  verbosity Verbosity setting
 
   \author Jana Mendrok
   \date   2016-08-08
 */
 void par_optpropCalc(  //Output
-    Tensor4View emis_vector,
-    Tensor5View extinct_matrix,
-    //VectorView scatlayers,
-    //Input
-    const ArrayOfArrayOfSingleScatteringData& scat_data,
-    const Vector& scat_za_grid,
-    const Index& f_index,
-    ConstTensor4View pnd_field,
-    ConstTensor3View t_field,
-    const ArrayOfIndex& cloudbox_limits,
-    const Index& stokes_dim,
-    const Index& nummu,
-    const Verbosity& verbosity);
-
-//! Calculates layer averaged particle extinction and absorption
-/*!
-  Calculates layer averaged particle extinction and absorption (extinct_matrix
-  and emis_vector)). These variables are required as input for the RT4 subroutine.
-
-  \param[out] emis_vector Layer averaged particle absorption for all particle
-              layers
-  \param[out] extinct_matrix  Layer averaged particle extinction for all
-              particle layers
-  \param[in]  scat_data Array of single scattering data
-  \param[in]  scat_za_grid Zenith angle grid
-  \param[in]  f_index Index of frequency grid point handeled
-  \param[in]  pnd_field PND field
-  \param[in]  t_field Atmospheric temperature field
-  \param[in]  cloudbox_limits Cloudbox limits
-  \param[in]  stokes_dim Dimension of Stokes vector
-
-  \author Jana Mendrok
-  \date   2016-08-08
-*/
-void par_optpropCalc2(  //Output
     Tensor5View emis_vector,
     Tensor6View extinct_matrix,
     //VectorView scatlayers,


### PR DESCRIPTION
In rt4.cc/h, removed par_optpropCalc, run_rt4  and renamed
par_optpropCalc2 and run_rt4_new to par_optpropCalc and run_rt4,
respectively. Accordingly, in m_rt4.cc, the calls of run_rt4 were
adjusted. Due to that, the generic input new_optprop in RT4_calc was
removed.