### PR TITLE
Cleanup git ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,10 +8,10 @@
 /.idea
 /.mailmap
 /.vscode
+/3rdparty/wigner/fastwigxj/gen/
+/3rdparty/wigner/fastwigxj/obj/
 /3rdparty/wigner/wigxjpf/gen/
 /build*/
+/cmake-build-*/
 /controlfiles/**/*.rep
 heaptrack.*.gz
-3rdparty/wigner/fastwigxj/gen/
-3rdparty/wigner/fastwigxj/obj/
-cmake-build-debug


### PR DESCRIPTION
- Ignore all cmake-build-* directories.
- Sort alphabetically.
- Start full paths with /