### PR TITLE
Partial fix for issue #41 (Finish iyActiveSingleScat2)

### DIFF
--- a/src/m_cloudradar.cc
+++ b/src/m_cloudradar.cc
@@ -1155,12 +1155,10 @@ void iyActiveSingleScat2(Workspace& ws,
       }
     }
   }
-
   // FIXME: Add the aux-variables back
-  // FIXME: Add the diy_dpath
 
   // Finalize analytical Jacobian
-  if (j_analytical_do and false)  // FIXME: remove false
+  if (j_analytical_do)
     rtmethods_jacobian_finalisation(ws,
                                     diy_dx,
                                     diy_dpath,

--- a/src/transmissionmatrix.cc
+++ b/src/transmissionmatrix.cc
@@ -1674,31 +1674,33 @@ ArrayOfArrayOfTransmissionMatrix cumulative_backscatter_derivative(
     for (Index iq = 0; iq < nq; iq++) {
       aoaotm[ip][iq].setZero();
 
-      switch (ns) {
-        case 4:
-          for (Index iv = 0; iv < nv; iv++)
-            for (Index id = 0; id < nd; id++)
-              aoaotm[ip][iq].Mat4(iv).noalias() +=
-                  aom[iq](id, ip) * matrix4(t(id, ip, iv, joker, joker));
-          break;
-        case 3:
-          for (Index iv = 0; iv < nv; iv++)
-            for (Index id = 0; id < nd; id++)
-              aoaotm[ip][iq].Mat3(iv).noalias() +=
-                  aom[iq](id, ip) * matrix3(t(id, ip, iv, joker, joker));
-          break;
-        case 2:
-          for (Index iv = 0; iv < nv; iv++)
-            for (Index id = 0; id < nd; id++)
-              aoaotm[ip][iq].Mat2(iv).noalias() +=
-                  aom[iq](id, ip) * matrix2(t(id, ip, iv, joker, joker));
-          break;
-        case 1:
-          for (Index iv = 0; iv < nv; iv++)
-            for (Index id = 0; id < nd; id++)
-              aoaotm[ip][iq].Mat1(iv).noalias() +=
-                  aom[iq](id, ip) * matrix1(t(id, ip, iv, joker, joker));
-          break;
+      if(not aom[iq].empty()) {
+        switch (ns) {
+          case 4:
+            for (Index iv = 0; iv < nv; iv++)
+              for (Index id = 0; id < nd; id++)
+                aoaotm[ip][iq].Mat4(iv).noalias() +=
+                    aom[iq](id, ip) * matrix4(t(id, ip, iv, joker, joker));
+            break;
+          case 3:
+            for (Index iv = 0; iv < nv; iv++)
+              for (Index id = 0; id < nd; id++)
+                aoaotm[ip][iq].Mat3(iv).noalias() +=
+                    aom[iq](id, ip) * matrix3(t(id, ip, iv, joker, joker));
+            break;
+          case 2:
+            for (Index iv = 0; iv < nv; iv++)
+              for (Index id = 0; id < nd; id++)
+                aoaotm[ip][iq].Mat2(iv).noalias() +=
+                    aom[iq](id, ip) * matrix2(t(id, ip, iv, joker, joker));
+            break;
+          case 1:
+            for (Index iv = 0; iv < nv; iv++)
+              for (Index id = 0; id < nd; id++)
+                aoaotm[ip][iq].Mat1(iv).noalias() +=
+                    aom[iq](id, ip) * matrix1(t(id, ip, iv, joker, joker));
+            break;
+        }
       }
     }
   }


### PR DESCRIPTION
@erikssonpatrick This makes iyActiveSingleScat2 produce the same forward results as iyActiveSingleScat.  The Jacobian output is very different though.

I am unsure how to read the Jacobian.  I think there are issues in my implementation of the backscatter solver that makes it differ from your implementation.  An easy way to play with this is to implement a new solver in set_backscatter_radiation_vector.  I am using my BackscatterSolver::Full implementation in this code but if I switch to BackscatterSolver::Commutative_PureReflectionJacobian the differences are much smaller between the two codes.

Still, in either case, your implementation have relatively small trailing values after the larger parts.  I cannot reproduce these trailers.  It is relatively simple to implement a new solver if you can spot the problem in set_backscatter_radiation_vector.  Just add an enum to BackscatterSolver and implement it in set_backscatter_radiation_vector.

Two more things: 1) The particulate derivative implementation does not follow the same logic as the LBL derivatives.  If a derivative is zero, I set them to zero.  Your derivatives are instead empty() matrices.  2)  The auxiliary values are not stored.  This needs to be re-added before removing the other function but is not so important before we understand the diff between the Jacobian.