### PR TITLE
Declare Matrix conversion operators as explicit.

### DIFF
--- a/3rdparty/invlib/src/invlib/interfaces/arts_wrapper.h
+++ b/3rdparty/invlib/src/invlib/interfaces/arts_wrapper.h
@@ -249,7 +249,7 @@ public:
         if (is_inverse_) {
             return covmat_.get_inverse();
         } else {
-            return static_cast<ArtsMatrix>(covmat_);
+            return static_cast<ArtsMatrix>(static_cast<const Matrix>(covmat_));
         }
     }
 

--- a/src/covariance_matrix.cc
+++ b/src/covariance_matrix.cc
@@ -123,7 +123,7 @@ MatrixView &operator+=(MatrixView &A, const Block &B) {
   if (B.get_matrix_type() == Block::MatrixType::dense) {
     Aview += B.get_dense();
   } else {
-    Aview += static_cast<Matrix>(B.get_sparse());
+    Aview += static_cast<const Matrix>(B.get_sparse());
   }
 
   Index i, j;
@@ -133,7 +133,7 @@ MatrixView &operator+=(MatrixView &A, const Block &B) {
     if (B.get_matrix_type() == Block::MatrixType::dense) {
       ATview += transpose(B.get_dense());
     } else {
-      ATview += transpose(static_cast<Matrix>(B.get_sparse()));
+      ATview += transpose(static_cast<const Matrix>(B.get_sparse()));
     }
   }
   return A;
@@ -152,7 +152,7 @@ CovarianceMatrix::operator Matrix() const {
     if (c.get_matrix_type() == Block::MatrixType::dense) {
       Aview = c.get_dense();
     } else {
-      Aview = c.get_sparse();
+      Aview = static_cast<const Matrix>(c.get_sparse());
     }
 
     Index ci, cj;
@@ -162,7 +162,7 @@ CovarianceMatrix::operator Matrix() const {
       if (c.get_matrix_type() == Block::MatrixType::dense) {
         ATview = transpose(c.get_dense());
       } else {
-        ATview = transpose(static_cast<Matrix>(c.get_sparse()));
+        ATview = transpose(static_cast<const Matrix>(c.get_sparse()));
       }
     }
   }
@@ -179,7 +179,7 @@ Matrix CovarianceMatrix::get_inverse() const {
     if (c.get_matrix_type() == Block::MatrixType::dense) {
       Aview = c.get_dense();
     } else {
-      Aview = c.get_sparse();
+      Aview = static_cast<const Matrix>(c.get_sparse());
     }
 
     Index ci, cj;
@@ -189,7 +189,7 @@ Matrix CovarianceMatrix::get_inverse() const {
       if (c.get_matrix_type() == Block::MatrixType::dense) {
         ATview = transpose(c.get_dense());
       } else {
-        ATview = transpose(static_cast<Matrix>(c.get_sparse()));
+        ATview = transpose(static_cast<const Matrix>(c.get_sparse()));
       }
     }
   }
@@ -463,7 +463,7 @@ void CovarianceMatrix::invert_correlation_block(
     if (blocks[i]->get_matrix_type() == Block::MatrixType::dense) {
       A_view = blocks[i]->get_dense();
     } else {
-      A_view = blocks[i]->get_sparse();
+      A_view = static_cast<const Matrix>(blocks[i]->get_sparse());
     }
   }
 

--- a/src/covariance_matrix.h
+++ b/src/covariance_matrix.h
@@ -224,7 +224,7 @@ class CovarianceMatrix {
 
   ~CovarianceMatrix() = default;
 
-  operator Matrix() const;
+  explicit operator Matrix() const;
   Matrix get_inverse() const;
 
   Index nrows() const;

--- a/src/matpackII.h
+++ b/src/matpackII.h
@@ -112,7 +112,7 @@ class Sparse {
   Sparse& operator/=(Numeric x);
 
   // Conversion to Dense Matrix:
-  operator Matrix() const;
+  explicit operator Matrix() const;
 
   // Matrix data access
   void list_elements(Vector& values,


### PR DESCRIPTION
Affects: Sparse and CovarianceMatrix classes.

Conversion operators of intricate types are better defined 'explicit'
to avoid unnoticed, unwanted, potentially expensive implicit
conversions.

This also happens to fix the internal compiler error with GCC 9 in
C++17 mode.

Additionally, ensure const-correctness in static_casts.