### PR TITLE
Fix noisiness during Workspace creation with API

### DIFF
--- a/src/messages.h
+++ b/src/messages.h
@@ -48,7 +48,7 @@
 
 class Verbosity {
  public:
-  Verbosity() : va(0), vs(1), vf(1), in_main_agenda(false) {}
+  Verbosity() : va(0), vs(0), vf(0), in_main_agenda(false) {}
 
   Verbosity(Index vagenda, Index vscreen, Index vfile)
       : va(vagenda), vs(vscreen), vf(vfile), in_main_agenda(false) {}


### PR DESCRIPTION
Change the default Verbosity to completely silent. Should not make a
difference for the ARTS executable since Verbosity is explicitly
initialized on startup. But silences the output of '- verbosityInit' when
creating a new Workspace in the Python API.

Fixes #73 reported by Richard.