### PR TITLE
Add the obligatory Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Travis](https://img.shields.io/travis/atmtools/arts/master.svg?label=Travis%20CI)](https://travis-ci.org/atmtools/arts)
+
 Welcome to ARTS
 ===============
 


### PR DESCRIPTION
Display the Travis build badge at the top of README.md.