### PR TITLE
Build 3rdparty dir in travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         - CC=gcc-9
         - CXX=g++-9
         - WITH_FORTRAN=0
-        - TARGETS="-C doc/uguide"
+        - TARGETDIRS="doc/uguide"
         - NOCHECK=1
     - name: LLVM 8 w/o Fortran
       dist: xenial
@@ -34,7 +34,7 @@ matrix:
         - CC=clang-8
         - CXX=clang++-8
         - WITH_FORTRAN=0
-        - TARGETS="-C src"
+        - TARGETDIRS="3rdparty src"
     - name: GCC 7 w/o Fortran
       addons:
         apt:
@@ -46,7 +46,7 @@ matrix:
         - CC=gcc-7
         - CXX=g++-7
         - WITH_FORTRAN=0
-        - TARGETS="-C src"
+        - TARGETDIRS="3rdparty src"
     - name: GCC 8 w/o Fortran
       addons:
         apt:
@@ -58,7 +58,7 @@ matrix:
         - CC=gcc-8
         - CXX=g++-8
         - WITH_FORTRAN=0
-        - TARGETS="-C src"
+        - TARGETDIRS="3rdparty src"
     - name: GCC 9 w/ Fortran
       addons:
         apt:
@@ -72,7 +72,7 @@ matrix:
         - CXX=g++-9
         - FC=gfortran-9
         - WITH_FORTRAN=1
-        - TARGETS="-C src"
+        - TARGETDIRS="3rdparty src"
 
 before_install:
   - sudo apt-get install -y zlib1g-dev libblas-dev liblapack-dev libfftw3-dev
@@ -81,6 +81,6 @@ script:
   - mkdir -p build
   - cd build
   - cmake -DENABLE_FORTRAN=${WITH_FORTRAN} -DENABLE_C_API=1 -DTEST_JOBS=2 ..
-  - make -j2 ${TARGETS}
+  - for TARGETDIR in ${TARGETDIRS}; do make -j2 -C ${TARGETDIR}; done
   - if [[ -z ${NOCHECK} ]]; then make check; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ before_install:
 script:
   - mkdir -p build
   - cd build
-  - cmake -DENABLE_FORTRAN=${WITH_FORTRAN} -DENABLE_C_API=1 -DTEST_JOBS=2 ..
+  - cmake -DENABLE_FORTRAN=${WITH_FORTRAN} -DTEST_JOBS=2 ..
   - for TARGETDIR in ${TARGETDIRS}; do make -j2 -C ${TARGETDIR}; done
   - if [[ -z ${NOCHECK} ]]; then make check; fi
 


### PR DESCRIPTION
Build additional targets that arts does not directly depend on, e.g. cdisort and tmatrix test executables.