### PR TITLE
Elevate uguide refs check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ dist: xenial
 
 matrix:
   include:
-    - name: User guide
+    - name: Build user guide PDFs
       addons:
         apt:
           sources:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,10 @@ enable_language(CXX)
 
 enable_testing ()
 
+########### Find Python ##########
+set(Python_ADDITIONAL_VERSIONS 3)
+find_package (PythonInterp REQUIRED)
+
 if (ENABLE_FORTRAN)
   enable_language (Fortran)
 

--- a/doc/uguide/CMakeLists.txt
+++ b/doc/uguide/CMakeLists.txt
@@ -90,10 +90,10 @@ else (PDFLATEX_COMPILER AND BIBTEX_COMPILER AND MAKEINDEX_COMPILER)
 endif (PDFLATEX_COMPILER AND BIBTEX_COMPILER AND MAKEINDEX_COMPILER)
 
 add_test(
-  NAME arts.slow.doc.uguide.refs
-  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/check_refs.py ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
+  NAME arts.doc.uguide.refs
+  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/check_refs.py ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR}
   )
 
 add_custom_target(check-uguide
-  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} DEPENDS arts arts_user.pdf arts_developer.pdf arts_theory.pdf)
+  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} DEPENDS arts)
 


### PR DESCRIPTION
Checking the user guide tex files for references to non-existent WSVs and WSMs is now included in `make check`.
Since this check is a Python script, cmake is now also requiring that a Python 3 interpreter is available (might be useful for other things in the future as well ;-) ).