### PR TITLE
Silence test covariance warnings

### DIFF
--- a/src/test_covariance_matrix.cc
+++ b/src/test_covariance_matrix.cc
@@ -531,6 +531,10 @@ void test_workspace_methods() {
  * performed using a normal covariance matrix.
  */
 namespace {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wconversion"
+
 #include "invlib/algebra.h"
 #include "invlib/interfaces/arts_wrapper.h"
 
@@ -589,6 +593,8 @@ Numeric test_invlib_wrapper(Index n_tests) {
   }
   return e;
 }
+
+#pragma GCC diagnostic pop
 }  // namespace
 
 int main() {

--- a/src/test_covariance_matrix.cc
+++ b/src/test_covariance_matrix.cc
@@ -460,7 +460,7 @@ void test_workspace_methods() {
     covmat_seAddBlock(covmat, A, 3, 3, Verbosity());
     // This should fail.
     assert(false);
-  } catch (std::runtime_error) {
+  } catch (const std::runtime_error&) {
   }
 
   covmat_seAddBlock(covmat, A, 0, 1, Verbosity());
@@ -471,7 +471,7 @@ void test_workspace_methods() {
     covmat_seAddBlock(covmat, B, 1, 2, Verbosity());
     // This should fail.
     assert(false);
-  } catch (std::runtime_error) {
+  } catch (const std::runtime_error&) {
   }
 
   covmat_seAddInverseBlock(covmat, A, 0, 1, Verbosity());
@@ -480,7 +480,7 @@ void test_workspace_methods() {
     covmat_seAddInverseBlock(covmat, B, 3, 3, Verbosity());
     // This should fail.
     assert(false);
-  } catch (std::runtime_error) {
+  } catch (const std::runtime_error&) {
   }
 
   // covmat_sxSet
@@ -509,7 +509,7 @@ void test_workspace_methods() {
     covmat_sxAddBlock(covmat, rqs, A_sparse, 0, 1, Verbosity());
     // This should fail.
     assert(false);
-  } catch (std::runtime_error) {
+  } catch (const std::runtime_error&) {
   }
 
   covmat_sxAddBlock(covmat, rqs, C, 0, 1, Verbosity());
@@ -519,7 +519,7 @@ void test_workspace_methods() {
     covmat_sxAddInverseBlock(covmat, rqs, C, 1, 1, Verbosity());
     // This should fail.
     assert(false);
-  } catch (std::runtime_error) {
+  } catch (const std::runtime_error&) {
   }
 }
 


### PR DESCRIPTION
Compiling test_covariance_matrix with GCC outputs quite a few warnings. The ones about exceptions being caught by value was an easy fix. But there are several warnings about type conversions and a lot about unused functions in ArtsWrapper (which should not even be thrown IMHO). I failed to properly fix them. The workaround implemented here is temporarily disabling those warnings for GCC via pragma inside the affected code.
@simonpf if you have an idea how to fix the warnings properly, I'd appreciate any help. You can see the warnings [starting at line 1985 in this build log](https://travis-ci.org/atmtools/arts/jobs/603814087#L1985). They occur with all 3 tested gcc versions.