### PR TITLE
Access to empty array if jacobian_do = 0

### DIFF
--- a/src/transmissionmatrix.cc
+++ b/src/transmissionmatrix.cc
@@ -1383,8 +1383,10 @@ void stepwise_source(RadiationVector& J,
   for (Index i = 0; i < K.NumberOfFrequencies(); i++) {
     if (K.IsRotational(i)) {
       J.SetZero(i);
-      for (Index j = 0; j < jacobian_quantities.nelem(); j++)
-        if (jacobian_quantities[j].Analytical()) dJ[j].SetZero(i);
+      if (jacobian_do) {
+        for (Index j = 0; j < jacobian_quantities.nelem(); j++)
+          if (jacobian_quantities[j].Analytical()) dJ[j].SetZero(i);
+      }
     } else {
       J.setSource(a, B, S, i);
       switch (J.StokesDim()) {


### PR DESCRIPTION
This was reported by Rita Edit  Kajtar on the ARTS mailing list and I tracked it down to a missing check for jacobian_do in stepwise_source causing access to an array of size 0.

What I don't know, however, is why this didn't show up before.

Maybe one of those who are more familiar with this part of the code can check if this is a valid fix.