### PR TITLE
Fix threadsafe initialization of da_dx

### DIFF
--- a/src/m_rte.cc
+++ b/src/m_rte.cc
@@ -778,7 +778,7 @@ void iyEmissionStandardParallel(
     Workspace l_ws(ws);
     // Loop ppath points and determine radiative properties
 #pragma omp parallel for if (!arts_omp_in_parallel()) \
-    firstprivate(l_ws, l_propmat_clearsky_agenda, a, B, dB_dT, S, dS_dx)
+    firstprivate(l_ws, l_propmat_clearsky_agenda, a, B, dB_dT, S, da_dx, dS_dx)
     for (Index ip = 0; ip < np; ip++) {
       get_stepwise_blackbody_radiation(
           B, dB_dT, ppvar_f(joker, ip), ppvar_t[ip], temperature_jacobian);


### PR DESCRIPTION
The elements of da_dx were initialized from several threads at once.
If you used iyEmissionStandardParallel to calculate Jacobians and your
program didn't crash, your results were most likely wrong.