### PR TITLE
Avoid setting derivative of N_0^* to zero when it shouldn't.

### DIFF
--- a/src/m_psd.cc
+++ b/src/m_psd.cc
@@ -856,7 +856,7 @@ void psdDelanoeEtAl14(Matrix& psd_data,
     }
 
     // Ensure that results are zero when IWC is zero.
-    if (iwc_p == 0.0) {
+    if ((!iwc_depend) && (iwc_p == 0.0)) {
       psd_data(0, joker) = 0.0;
       for (size_t i = 0; i < 2; ++i) {
         if (do_jac[i]) {


### PR DESCRIPTION
This fix is necessary when D_m and N_0^* are used as input to the PSD in which case iwc_p is 0. In this case the Jacobian should obviously not be set to 0.