### PR TITLE
Fixed calculation of smoothing error covariance matrix.

### DIFF
--- a/src/m_oem.cc
+++ b/src/m_oem.cc
@@ -1409,7 +1409,7 @@ void covmat_ssCalc(Matrix& covmat_ss,
   id_mat(tmp1);
   tmp1 -= avk;
 
-  mult(tmp2, covmat_sx, tmp1);
+  mult(tmp2, covmat_sx, transpose(tmp1));
   mult(covmat_ss, tmp1, tmp2);
 }
 


### PR DESCRIPTION
This fixes the incorrect calculation of the smoothing error as pointed out by Mathias Milz.