### PR TITLE
Change number of threads at runtime

### DIFF
--- a/src/m_general.cc
+++ b/src/m_general.cc
@@ -490,6 +490,11 @@ void GetEnvironmentVariable(  // WS Generic Output:
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
+void GetNumberOfThreads(Index& nthreads, const Verbosity& /* verbosity */) {
+  nthreads = arts_omp_get_max_threads();
+}
+
+/* Workspace method: Doxygen documentation will be auto-generated */
 void GetEnvironmentVariable(  // WS Generic Output:
     Index& i,
     // WS Generic Input:
@@ -511,3 +516,17 @@ void GetEnvironmentVariable(  // WS Generic Output:
     throw std::runtime_error(os.str());
   }
 }
+
+/* Workspace method: Doxygen documentation will be auto-generated */
+#ifdef _OPENMP
+void SetNumberOfThreads(const Index& nthreads,
+                        const Verbosity& /* verbosity */) {
+  omp_set_num_threads((int)nthreads);
+}
+#else
+void SetNumberOfThreads(const Index& /* nthreads */,
+                        const Verbosity& verbosity) {
+  CREATE_OUT1;
+  out1 << "No OpenMP support. Can't change number of threads.\n";
+}
+#endif

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -6772,6 +6772,20 @@ void define_md_data_raw() {
       GIN_DESC("Name of environment variable.")));
 
   md_data_raw.push_back(
+      MdRecord(NAME("GetNumberOfThreads"),
+               DESCRIPTION("Returns the number of threads used by ARTS.\n"),
+               AUTHORS("Oliver Lemke"),
+               OUT(),
+               GOUT("nthreads"),
+               GOUT_TYPE("Index"),
+               GOUT_DESC("Number of threads."),
+               IN(),
+               GIN(),
+               GIN_TYPE(),
+               GIN_DEFAULT(),
+               GIN_DESC()));
+
+  md_data_raw.push_back(
       MdRecord(NAME("GriddedFieldGetName"),
                DESCRIPTION("Get the name of a GriddedField.\n"
                            "\n"
@@ -17132,6 +17146,20 @@ void define_md_data_raw() {
       GIN_DEFAULT(NODEF, "1"),
       GIN_DESC("Quantum numbers that are defined for the band",
                "Flag to check if only global quantum numbers should be used")));
+
+  md_data_raw.push_back(
+      MdRecord(NAME("SetNumberOfThreads"),
+               DESCRIPTION("Change the number of threads used by ARTS.\n"),
+               AUTHORS("Oliver Lemke"),
+               OUT(),
+               GOUT(),
+               GOUT_TYPE(),
+               GOUT_DESC(),
+               IN(),
+               GIN("nthreads"),
+               GIN_TYPE("Index"),
+               GIN_DEFAULT(NODEF),
+               GIN_DESC("Number of threads.")));
 
   md_data_raw.push_back(MdRecord(
       NAME("SparseSparseMultiply"),


### PR DESCRIPTION
Enables dynamically changing the number of threads used by ARTS at
runtime. This is especially targeted at the Python API. Before, the
number of threads couldn't be changed after the first import of the ARTS
workspace Python module.