### PR TITLE
Fix naming bug and add method to reduce calculations of unused parame…

### DIFF
--- a/src/absorptionlines.h
+++ b/src/absorptionlines.h
@@ -676,8 +676,8 @@ public:
    * @param[in] sl A single line
    */
   void AppendSingleLine(SingleLine&& sl) {
-    if(NumBroadeners() not_eq sl.LowerQuantumElems() or
-       NumBroadeners() not_eq sl.UpperQuantumElems())
+    if(NumLocalQuanta() not_eq sl.LowerQuantumElems() or
+       NumLocalQuanta() not_eq sl.UpperQuantumElems())
       throw std::runtime_error("Error calling appending function, bad size of quantum numbers");
     
     if(NumLines() not_eq 0 and 
@@ -700,8 +700,8 @@ public:
    * @param[in] sl A single line
    */
   void AppendSingleLine(const SingleLine& sl) {
-    if(NumBroadeners() not_eq sl.LowerQuantumElems() or
-       NumBroadeners() not_eq sl.UpperQuantumElems())
+    if(NumLocalQuanta() not_eq sl.LowerQuantumElems() or
+       NumLocalQuanta() not_eq sl.UpperQuantumElems())
       throw std::runtime_error("Error calling appending function, bad size of quantum numbers");
     
     if(NumLines() not_eq 0 and 
@@ -836,7 +836,10 @@ public:
   std::vector<SingleLine>& AllLines() noexcept {return mlines;}
   
   /** Number of broadening species */
-  Index NumBroadeners() const noexcept {return Index(mlocalquanta.size());}
+  Index NumBroadeners() const noexcept {return Index(mbroadeningspecies.nelem());}
+  
+  /** Number of local quantum numbers */
+  Index NumLocalQuanta() const noexcept {return Index(mlocalquanta.size());}
   
   /** Remove quantum numbers that are not used by even a single line
    */

--- a/src/lineshapemodel.h
+++ b/src/lineshapemodel.h
@@ -303,6 +303,30 @@ inline Numeric& SingleModelParameter(ModelParameters& mp, const String& type) {
   std::terminate();
 }
 
+inline bool modelparameterEmpty(const ModelParameters mp) noexcept {
+  switch(mp.type) {
+    case TemperatureModel::None:   // 0
+      return true;
+    case TemperatureModel::T0:     // Constant, X0
+      return (mp.X0 == 0);
+    case TemperatureModel::T1:     // Standard, X0 * (T0/T) ^ X1
+      return (mp.X0 == 0);
+    case TemperatureModel::T2:     // X0 * (T0/T) ^ X1 * (1 + X2 * log(T/T0));
+      return (mp.X0 == 0);
+    case TemperatureModel::T3:     // X0 + X1 * (T - T0)
+      return (mp.X0 == 0 and mp.X1 == 0);
+    case TemperatureModel::T4:     // (X0 + X1 * (T0/T - 1)) * (T0/T)^X2;
+      return (mp.X0 == 0 and mp.X1 == 0);
+    case TemperatureModel::T5:     // X0 * (T0/T)^(0.25 + 1.5*X1)
+      return (mp.X0 == 0);
+    case TemperatureModel::LM_AER: // X(200) = X0; X(250) = X1; X(298) = X2; X(340) = X3;  Linear interpolation in between
+      return (mp.X0 == 0 and mp.X1 == 0 and mp.X2 == 0 and mp.X3 == 0);
+    case TemperatureModel::DPL:    // X0 * (T0/T) ^ X1 + X2 * (T0/T) ^ X3
+      return (mp.X0 == 0 and mp.X2 == 0);
+  }
+  std::terminate();
+}
+
 /** Output operator for ModelParameters */
 inline std::ostream& operator<<(std::ostream& os, const ModelParameters& mp) {
   os << temperaturemodel2string(mp.type) << ' ' << mp.X0 << ' ' << mp.X1 << ' '

--- a/src/m_absorptionlines.cc
+++ b/src/m_absorptionlines.cc
@@ -1076,6 +1076,37 @@ void abs_linesDeleteLinesWithBadOrHighChangingJs(ArrayOfAbsorptionLines& abs_lin
   out2 << "Deleted " << i << " lines.\n";
 }
 
+/* Workspace method: Doxygen documentation will be auto-generated */
+void abs_linesSetEmptyBroadeningParametersToEmpty(ArrayOfAbsorptionLines& abs_lines, const Verbosity& /*verbosity*/)
+{
+  for (auto& band: abs_lines) {
+    std::array<bool, LineShape::nVars> var_is_empty;
+    
+    // Species by species can be empty, so loop each species by themselves
+    for (Index ispec=0; ispec<band.NumBroadeners(); ispec++) {
+      var_is_empty.fill(true);
+      
+      // Check if any variable in this band for any line is non-empty
+      for (Index iline=0; iline<band.NumLines(); iline++) {
+        for (Index ivar=0; ivar < LineShape::nVars; ivar++) {
+          if (not LineShape::modelparameterEmpty(band.Line(iline).LineShape().Data()[ispec].Data()[ivar])) {
+            var_is_empty[ivar] = false;
+          }
+        }
+      }
+      
+      // Remove empty variables from the writing.  This will also speed up some calculations
+      for (Index iline=0; iline<band.NumLines(); iline++) {
+        for (Index ivar=0; ivar < LineShape::nVars; ivar++) {
+          if (var_is_empty[ivar]) {
+            band.Line(iline).LineShape().Data()[ispec].Data()[ivar].type = LineShape::TemperatureModel::None;
+          }
+        }
+      }
+    }
+  }
+}
+
 /////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////// Change of style of computations for whole bands
 /////////////////////////////////////////////////////////////////////////////////////

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -581,6 +581,23 @@ void define_md_data_raw() {
           "Index to indicate if dv is to be left as zero")));
 
   md_data_raw.push_back(
+      MdRecord(NAME("abs_linesSetEmptyBroadeningParametersToEmpty"),
+               DESCRIPTION("Sets a broadening parameter to empty if it is efficiently empty\n"
+                           "\n"
+                           "This will not save RAM but it will save disk space (reading time),\n"
+                           "and computational time by not doing unecessary calculations\n"),
+               AUTHORS("Richard Larsson"),
+               OUT("abs_lines"),
+               GOUT(),
+               GOUT_TYPE(),
+               GOUT_DESC(),
+               IN("abs_lines"),
+               GIN(),
+               GIN_TYPE(),
+               GIN_DEFAULT(),
+               GIN_DESC()));
+
+  md_data_raw.push_back(
       MdRecord(NAME("abs_linesSetNormalization"),
                DESCRIPTION("Sets normalization type for all lines.\n"
                            "\n"


### PR DESCRIPTION
…ters

There was a naming bug in AbsorptionLines.  I accidentally refer to
NumBroadeners() and used it for number of local quantum numbers.
This is fixed.  In addition, abs_linesSetEmptyBroadeningParametersToEmpty
has been added to remove broadening parameters within a band if ALL of
those parameters can only ever return zeroes.  This only reduces Hitran
in arts-xml-data by 1% if its size, but species like O2 might benefit
in calculation speed since they don't see any pressure shift and thus
need to call std::pow() only half as many times as if the pressure
shift is computed as zero