### PR TITLE
Initialize CovarianceMatrix in reading routine

### DIFF
--- a/src/xml_io_compound_types.cc
+++ b/src/xml_io_compound_types.cc
@@ -139,6 +139,7 @@ void xml_read_from_stream(istream& is_xml,
   tag.check_name("CovarianceMatrix");
   tag.get_attribute_value("n_blocks", n_blocks);
 
+  covmat = CovarianceMatrix();
   for (Index i = 0; i < n_blocks; i++) {
     tag.read_from_stream(is_xml);
     tag.check_name("Block");


### PR DESCRIPTION
Instead of replacing the contents of the WSV, the blocks from the file
were appended to it.

Fixes bug reported by Rita
https://www.mail-archive.com/arts_users.mi@lists.uni-hamburg.de/msg00311.html