### PR TITLE
Change so F is used if available for Zeeman effect

### DIFF
--- a/src/absorptionlines.h
+++ b/src/absorptionlines.h
@@ -887,9 +887,15 @@ public:
    * @param[in] type Type of Zeeman polarization
    */
   Index ZeemanCount(size_t k, Zeeman::Polarization type) const noexcept {
-    return Zeeman::nelem(UpperQuantumNumber(k, QuantumNumberType::J),
-                         LowerQuantumNumber(k, QuantumNumberType::J),
-                         type);
+    if (UpperQuantumNumber(k, QuantumNumberType::F).isDefined() and LowerQuantumNumber(k, QuantumNumberType::F).isDefined()) {
+      return Zeeman::nelem(UpperQuantumNumber(k, QuantumNumberType::F),
+                           LowerQuantumNumber(k, QuantumNumberType::F),
+                           type);
+    } else {
+      return Zeeman::nelem(UpperQuantumNumber(k, QuantumNumberType::J),
+                           LowerQuantumNumber(k, QuantumNumberType::J),
+                           type);
+    }
   }
   
   /** Returns the strength of a Zeeman split line
@@ -899,9 +905,15 @@ public:
    * @param[in] i Zeeman line count
    */
   Numeric ZeemanStrength(size_t k, Zeeman::Polarization type, Index i) const noexcept {
-    return mlines[k].Zeeman().Strength(UpperQuantumNumber(k, QuantumNumberType::J),
-                                       LowerQuantumNumber(k, QuantumNumberType::J),
-                                       type, i);
+    if (UpperQuantumNumber(k, QuantumNumberType::F).isDefined() and LowerQuantumNumber(k, QuantumNumberType::F).isDefined()) {
+      return mlines[k].Zeeman().Strength(UpperQuantumNumber(k, QuantumNumberType::F),
+                                         LowerQuantumNumber(k, QuantumNumberType::F),
+                                         type, i);
+    } else {
+      return mlines[k].Zeeman().Strength(UpperQuantumNumber(k, QuantumNumberType::J),
+                                         LowerQuantumNumber(k, QuantumNumberType::J),
+                                         type, i);
+    }
   }
   
   /** Returns the splitting of a Zeeman split line
@@ -911,9 +923,15 @@ public:
    * @param[in] i Zeeman line count
    */
   Numeric ZeemanSplitting(size_t k, Zeeman::Polarization type, Index i) const noexcept {
-    return mlines[k].Zeeman().Splitting(UpperQuantumNumber(k, QuantumNumberType::J),
-                                        LowerQuantumNumber(k, QuantumNumberType::J),
-                                        type, i);
+    if (UpperQuantumNumber(k, QuantumNumberType::F).isDefined() and LowerQuantumNumber(k, QuantumNumberType::F).isDefined()) {
+      return mlines[k].Zeeman().Splitting(UpperQuantumNumber(k, QuantumNumberType::F),
+                                          LowerQuantumNumber(k, QuantumNumberType::F),
+                                          type, i);
+    } else {
+      return mlines[k].Zeeman().Splitting(UpperQuantumNumber(k, QuantumNumberType::J),
+                                          LowerQuantumNumber(k, QuantumNumberType::J),
+                                          type, i);
+    }
   }
   
   /** Set Zeeman effect for all lines that have the correct quantum numbers */

--- a/src/m_checked.cc
+++ b/src/m_checked.cc
@@ -931,17 +931,19 @@ void lbl_checkedCalc(Index& lbl_checked,
     if (any_zeeman) {
       for (auto& band: lines) {
         for (Index k=0; k<band.NumLines(); k++) {
+          auto Fu = band.UpperQuantumNumber(k, QuantumNumberType::F);
+          auto Fl = band.LowerQuantumNumber(k, QuantumNumberType::F);
           auto Ju = band.UpperQuantumNumber(k, QuantumNumberType::J);
           auto Jl = band.LowerQuantumNumber(k, QuantumNumberType::J);
           auto Ze = band.Line(k).Zeeman();
-          if (Ju.isUndefined()) {
-            throw std::runtime_error("Bad upper state J(s).\n");
-          } else if (Jl.isUndefined()) {
-            throw std::runtime_error("Bad lower state J(s).\n");
-          } else if (not is_wigner3_ready(Ju)) {
-            throw std::runtime_error("Bad Wigner numbers for lower state J.  Try increasing the Wigner memory allocation.\n");
-          } else if (not is_wigner3_ready(Jl)) {
-            throw std::runtime_error("Bad Wigner numbers for lower state J.  Try increasing the Wigner memory allocation.\n");
+          if (Fu.isUndefined() and Ju.isUndefined()) {
+            throw std::runtime_error("Bad upper state F(s) or J(s).\n");
+          } else if (Fl.isUndefined() and Jl.isUndefined()) {
+            throw std::runtime_error("Bad lower state F(s) or J(s).\n");
+          } else if (not is_wigner3_ready(Fu.isUndefined() ? Ju : Fu)) {
+            throw std::runtime_error("Bad Wigner numbers for lower state F or J.  Try increasing the Wigner memory allocation.\n");
+          } else if (not is_wigner3_ready(Fl.isUndefined() ? Jl : Fl)) {
+            throw std::runtime_error("Bad Wigner numbers for lower state F or J.  Try increasing the Wigner memory allocation.\n");
           } else if (Ze.gu() == 0 ? false : not std::isnormal(Ze.gu())) {
             throw std::runtime_error("Bad value(s) in the upper Zeeman data not allowed when modeling Zeeman effect.\n");
           } else if (Ze.gl() == 0 ? false : not std::isnormal(Ze.gl())) {

--- a/src/zeeman.cc
+++ b/src/zeeman.cc
@@ -220,10 +220,10 @@ void zeeman_on_the_fly(
         // Constants for these lines
         const Numeric QT0 = single_partition_function(band.T0(),
                                                       partition_functions.getParamType(band.QuantumIdentity()),
-                                                    partition_functions.getParam(band.QuantumIdentity()));
-        const Numeric QT = single_partition_function(rtp_temperature,
-                                                      partition_functions.getParamType(band.QuantumIdentity()),
                                                       partition_functions.getParam(band.QuantumIdentity()));
+        const Numeric QT = single_partition_function(rtp_temperature,
+                                                     partition_functions.getParamType(band.QuantumIdentity()),
+                                                     partition_functions.getParam(band.QuantumIdentity()));
         const Numeric dQTdT = dsingle_partition_function_dT(QT, rtp_temperature, temperature_perturbation(jacobian_quantities),
                                                             partition_functions.getParamType(band.QuantumIdentity()),
                                                             partition_functions.getParam(band.QuantumIdentity()));

--- a/src/zeeman.cc
+++ b/src/zeeman.cc
@@ -84,9 +84,12 @@ bool any_negative(const Tensor4& var) {
 
 bool good_J(const AbsorptionLines& band) {
   for (Index i=0; i<band.NumLines(); i++) {
+    auto Fl = band.LowerQuantumNumber(i, QuantumNumberType::F);
+    auto Fu = band.UpperQuantumNumber(i, QuantumNumberType::F);
     auto Jl = band.LowerQuantumNumber(i, QuantumNumberType::J);
     auto Ju = band.UpperQuantumNumber(i, QuantumNumberType::J);
-    if (Jl.isUndefined() or Ju.isUndefined() or 1 < abs(Jl - Ju)) {
+    if ((Fl.isUndefined() or Fu.isUndefined() or 1 < abs(Fl - Fu)) and
+        (Jl.isUndefined() or Ju.isUndefined() or 1 < abs(Jl - Ju))) {
       return false;
     }
   }


### PR DESCRIPTION
Also fix a few comments and indentation issues

This is because when F is available the line is split into [-F ··· F] branches.

Note that this work is done on my laptop where the OEM test always fails.  It produces the runtime error that all VMR should be above 0, and then lists a lot of "nan".  I don't think anything has changed for the OEM code but I hope this other bug gets fixed somehow...