### PR TITLE
isnan is not implemented constexpr everywhere

### DIFF
--- a/src/zeemandata.h
+++ b/src/zeemandata.h
@@ -376,7 +376,7 @@ class Model {
   Model(const QuantumIdentifier& qid) noexcept;
 
   /** Returns true if the Model represents no Zeeman effect */
-  constexpr bool empty() const noexcept {
+  /* constexpr */ bool empty() const noexcept {
     return std::isnan(mdata.gu) and std::isnan(mdata.gl);
   }
 


### PR DESCRIPTION
Fix compile error with clang on macOS. Commented out constexpr until
isnan is available everywhere as constexpr.