### PR TITLE
ARTS classes by C-pointer in python

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,7 +90,7 @@ set_source_files_properties (m_oem.cc PROPERTIES
 ########### next target ###############
 
 if (C_API)
-add_library (arts_api SHARED arts_api.cc interactive_workspace.cc)
+add_library (arts_api SHARED arts_api.cc interactive_workspace.cc arts_api_classes.cc)
 add_dependencies (arts arts_api)
 set_target_properties(arts_api PROPERTIES SUFFIX .so)
 target_link_libraries (arts_api ${ALL_ARTS_LIBRARIES})

--- a/src/abs_species_tags.h
+++ b/src/abs_species_tags.h
@@ -62,6 +62,9 @@ class SpeciesTag {
 
   /** Molecular species index. */
   Index Species() const { return mspecies; }
+  
+  /** Set molecular species index. */
+  void Species(Index x) { mspecies = x; }
 
   /** Molecular species index. */
   Index BathSpecies() const { return mcia_second; }
@@ -82,20 +85,37 @@ class SpeciesTag {
       If this is equal to the number of isotopologues (one more than
       allowed) it means all isotopologues of this species. */
   Index Isotopologue() const { return misotopologue; }
+  
+  /** Isotopologue species index */
+  void Isotopologue(Index x) { misotopologue = x; }
 
   /** The lower line center frequency in Hz.
       If this is <0 it means no lower limit. */
   Numeric Lf() const { return mlf; }
 
+  /** The lower line center frequency in Hz.
+      If this is <0 it means no lower limit. */
+  void Lf(Numeric x) { mlf = x; }
+
   /** The upper line center frequency in Hz:
       If this is <0 it means no upper limit. */
   Numeric Uf() const { return muf; }
 
+  /** The upper line center frequency in Hz:
+      If this is <0 it means no upper limit. */
+  void Uf(Numeric x) { muf = x; }
+
   /** Species index of the 2nd CIA species */
   Index CIASecond() const { return mcia_second; }
+  
+  /** Species index of the 2nd CIA species */
+  void CIASecond(Index x) { mcia_second = x; }
 
   /** CIA dataset index inside this CIA file. */
   Index CIADataset() const { return mcia_dataset; }
+  
+  /** CIA dataset index inside this CIA file. */
+  void CIADataset(Index x) { mcia_dataset = x; }
 
   //! Comparison operator for species tags.
   /*!
@@ -138,6 +158,11 @@ class SpeciesTag {
    
    See private member mtype for more explanations.   */
   Index Type() const { return mtype; }
+
+  /** Return the type of this tag.
+   
+   See private member mtype for more explanations.   */
+  void Type(Index x) { mtype = x; }
 
  private:
   //! Molecular species index.

--- a/src/absorptionlines.cc
+++ b/src/absorptionlines.cc
@@ -3540,3 +3540,30 @@ Absorption::SingleLineExternal Absorption::ReadFromJplStream(istream& is)
   data.bad = false;
   return data;
 }
+
+
+
+bool Absorption::Lines::OK() const noexcept
+{
+  const Index nq = mlocalquanta.size();
+  const Index nb = mbroadeningspecies.nelem();
+  
+  // Test that self and bath is covered by the range if set positive
+  if (nb < (Index(mselfbroadening) + Index(mbathbroadening)))
+    return false;
+ 
+  // Test that the temperature is physical
+  if (mT0 <= 0)
+    return false;
+  
+  // Test that all lines have the correct sized line shape model
+  if (std::any_of(mlines.cbegin(), mlines.cend(), [nb](auto& line){return line.LineShapeElems() != nb;}))
+    return false;
+  
+  // Test that all lines have the correct sized local quantum numbers
+  if (std::any_of(mlines.cbegin(), mlines.cend(), [nq](auto& line){return line.LowerQuantumElems() != nq or line.UpperQuantumElems() != nq;}))
+    return false;
+  
+  // Otherwise everything is fine!
+  return true;
+}

--- a/src/absorptionlines.h
+++ b/src/absorptionlines.h
@@ -46,7 +46,7 @@ namespace Absorption {
  * 
  * Each type but None has to have an implemented effect
  */
-enum class MirroringType {
+enum class MirroringType : Index {
   None,             // No mirroring
   Lorentz,          // Mirror, but use Lorentz line shape
   SameAsLineShape,  // Mirror using the same line shape
@@ -94,7 +94,7 @@ inline String mirroringtype2metadatastring(MirroringType in) {
  *
  * Each type but None has to have an implemented effect
  */
-enum class NormalizationType {
+enum class NormalizationType : Index {
   None,  // Do not renormalize the line shape
   VVH,   // Renormalize with Van Vleck and Huber specifications
   VVW,   // Renormalize with Van Vleck and Weiskopf specifications
@@ -145,7 +145,7 @@ inline String normalizationtype2metadatastring(NormalizationType in) {
  *
  * The types here might require that different data is available at runtime absorption calculations
  */
-enum class PopulationType {
+enum class PopulationType : Index {
   ByLTE,                          // Assume line is in LTE
   ByRelmatMendazaLTE,             // Assume line is in LTE but requires Relaxation matrix calculations - follows Mendaza method
   ByRelmatHartmannLTE,            // Assume line is in LTE but requires Relaxation matrix calculations - follows Hartmann method
@@ -204,7 +204,7 @@ inline bool relaxationtype_relmat(PopulationType in) {
 }
 
 /** Describes the type of cutoff calculations */
-enum class CutoffType {
+enum class CutoffType : Index {
   None,                // No cutoff frequency at all
   LineByLineOffset,    // The cutoff frequency is at SingleLine::F0 plus the cutoff frequency
   BandFixedFrequency,  // The curoff frequency is the cutoff frequency for all SingleLine(s)
@@ -1228,8 +1228,18 @@ public:
     return mbroadeningspecies;
   }
   
+  /** Returns the broadening species */
+  ArrayOfSpeciesTag& BroadeningSpecies() noexcept {
+    return mbroadeningspecies;
+  }
+  
   /** Returns self broadening status */
   bool Self() const noexcept {
+    return mselfbroadening;
+  }
+  
+  /** Returns self broadening status */
+  bool& Self() noexcept {
     return mselfbroadening;
   }
   
@@ -1238,8 +1248,18 @@ public:
     return mbathbroadening;
   }
   
+  /** Returns bath broadening status */
+  bool& Bath() noexcept {
+    return mbathbroadening;
+  }
+  
   /** Returns identity status */
   const QuantumIdentifier& QuantumIdentity() const noexcept {
+    return mquantumidentity;
+  }
+  
+  /** Returns identity status */
+  QuantumIdentifier& QuantumIdentity() noexcept {
     return mquantumidentity;
   }
   

--- a/src/absorptionlines.h
+++ b/src/absorptionlines.h
@@ -1328,6 +1328,8 @@ public:
       line.write(os);
     return os;
   }
+  
+  bool OK() const noexcept;
 };  // Lines
 
 std::ostream& operator<<(std::ostream&, const Lines&);

--- a/src/absorptionlines.h
+++ b/src/absorptionlines.h
@@ -1223,6 +1223,11 @@ public:
     return mlocalquanta;
   }
   
+  /** Returns local quantum numbers */
+  std::vector<QuantumNumberType>& LocalQuanta() noexcept {
+    return mlocalquanta;
+  }
+  
   /** Returns the broadening species */
   const ArrayOfSpeciesTag& BroadeningSpecies() const noexcept {
     return mbroadeningspecies;

--- a/src/arts_api_classes.cc
+++ b/src/arts_api_classes.cc
@@ -117,6 +117,15 @@ void printLineShapeModelParameters(void * data)
   std::cout << (*static_cast<LineShape::ModelParameters *>(data)) << std::endl;
 }
 
+Index getLineShapeModelParametersType(char * data)
+{
+  try {
+    return Index(LineShape::string2temperaturemodel(data));
+  } catch (std::runtime_error& e) {
+    return -1;
+  }
+}
+
 
 void * createLineShapeSingleSpeciesModel()
 {
@@ -422,7 +431,27 @@ Index getQuantumIdentifierType(void * data)
     return Index(static_cast<QuantumIdentifier *>(data)->Type());
 }
 
-Index setQuantumIdentifierType(void * data, char * str)
+Index setQuantumIdentifierTypeFromIndex(void * data, Index ind)
+{
+    if (QuantumIdentifier::ENERGY_LEVEL == ind) {
+        static_cast<QuantumIdentifier *>(data)->SetEnergyLevel(static_cast<QuantumIdentifier *>(data)->EnergyLevelQuantumNumbers());
+        return EXIT_SUCCESS;
+    } else if (QuantumIdentifier::TRANSITION == ind) {
+        static_cast<QuantumIdentifier *>(data)->SetTransition();
+        return EXIT_SUCCESS;
+    } 
+    else if (QuantumIdentifier::ALL == ind) {
+        static_cast<QuantumIdentifier *>(data)->SetAll();
+        return EXIT_SUCCESS;
+    } 
+    else if (QuantumIdentifier::NONE == ind) {
+        static_cast<QuantumIdentifier *>(data)->SetNone();
+        return EXIT_SUCCESS;
+    } else
+        return EXIT_FAILURE;
+}
+
+Index setQuantumIdentifierTypeFromString(void * data, char * str)
 {
     if (std::string("ENERGY_LEVEL") == str) {
         static_cast<QuantumIdentifier *>(data)->SetEnergyLevel(static_cast<QuantumIdentifier *>(data)->EnergyLevelQuantumNumbers());
@@ -469,12 +498,12 @@ Index validIsotopologue(Index spec, Index isot)
 {
     auto& species = global_data::species_data[spec];
     if (isot >= 0 and isot < species.Isotopologue().nelem()) {
-        if (not species.Isotopologue()[isot].isContinuum())
+        if (not species.Isotopologue()[isot].isContinuum()) {
             return EXIT_SUCCESS;
-        else
-            return EXIT_FAILURE;
-    } else
-        return EXIT_FAILURE;
+        }
+    }
+    
+    return EXIT_FAILURE;
 }
 
 void setQuantumIdentifierIsotopologue(void * data, Index isot)
@@ -513,9 +542,14 @@ void printSpeciesTag(void * data)
     std::cout << (*static_cast<SpeciesTag *>(data)) << std::endl;
 }
 
-void setSpeciesTag(void * data, char * newdata)
+Index setSpeciesTag(void * data, char * newdata)
 {
-    *static_cast<SpeciesTag *>(data) = SpeciesTag(newdata);
+    try {
+      *static_cast<SpeciesTag *>(data) = SpeciesTag(newdata);
+      return EXIT_SUCCESS;
+    } catch(std::exception& e) {
+      return EXIT_FAILURE;
+    }
 }
 
 Index getSpeciesTagSpecies(void * data)
@@ -599,9 +633,14 @@ Index getAbsorptionLinesCutoffType(void * data)
     return Index(static_cast<Absorption::Lines *>(data)->Cutoff());
 }
 
-void getAbsorptionLinesCutoffType(void * data, Index newdata)
+Index setAbsorptionLinesCutoffType(void * data, char * newdata)
 {
-    static_cast<Absorption::Lines *>(data)->Cutoff(Absorption::CutoffType(newdata));
+    try {
+      static_cast<Absorption::Lines *>(data)->Cutoff(Absorption::string2cutofftype(newdata));
+      return EXIT_SUCCESS;
+    } catch(const std::exception& e) {
+      return EXIT_FAILURE;
+    }
 }
 
 Index getAbsorptionLinesMirroringType(void * data)
@@ -609,9 +648,29 @@ Index getAbsorptionLinesMirroringType(void * data)
     return Index(static_cast<Absorption::Lines *>(data)->Mirroring());
 }
 
+Index setAbsorptionLinesMirroringType(void * data, char * newdata)
+{
+    try {
+      static_cast<Absorption::Lines *>(data)->Mirroring(Absorption::string2mirroringtype(newdata));
+      return EXIT_SUCCESS;
+    } catch(const std::exception& e) {
+      return EXIT_FAILURE;
+    }
+}
+
 Index getAbsorptionLinesPopulationType(void * data)
 {
     return Index(static_cast<Absorption::Lines *>(data)->Population());
+}
+
+Index setAbsorptionLinesPopulationType(void * data, char * newdata)
+{
+    try {
+      static_cast<Absorption::Lines *>(data)->Population(Absorption::string2populationtype(newdata));
+      return EXIT_SUCCESS;
+    } catch(const std::exception& e) {
+      return EXIT_FAILURE;
+    }
 }
 
 Index getAbsorptionLinesNormalizationType(void * data)
@@ -619,9 +678,29 @@ Index getAbsorptionLinesNormalizationType(void * data)
     return Index(static_cast<Absorption::Lines *>(data)->Normalization());
 }
 
+Index setAbsorptionLinesNormalizationType(void * data, char * newdata)
+{
+    try {
+      static_cast<Absorption::Lines *>(data)->Normalization(Absorption::string2normalizationtype(newdata));
+      return EXIT_SUCCESS;
+    } catch(const std::exception& e) {
+      return EXIT_FAILURE;
+    }
+}
+
 Index getAbsorptionLinesLineShapeType(void * data)
 {
     return Index(static_cast<Absorption::Lines *>(data)->LineShapeType());
+}
+
+Index setAbsorptionLinesLineShapeType(void * data, char * newdata)
+{
+    try {
+      static_cast<Absorption::Lines *>(data)->LineShapeType(LineShape::string2shapetype(newdata));
+      return EXIT_SUCCESS;
+    } catch(const std::exception& e) {
+      return EXIT_FAILURE;
+    }
 }
 
 Numeric getAbsorptionLinesT0(void * data)
@@ -629,9 +708,19 @@ Numeric getAbsorptionLinesT0(void * data)
     return static_cast<Absorption::Lines *>(data)->T0();
 }
 
+void setAbsorptionLinesT0(void * data, Numeric newdata)
+{
+    static_cast<Absorption::Lines *>(data)->T0(newdata);
+}
+
 Numeric getAbsorptionLinesCutoffFrequency(void * data)
 {
     return static_cast<Absorption::Lines *>(data)->CutoffFreqValue();
+}
+
+void setAbsorptionLinesCutoffFrequency(void * data, Numeric newdata)
+{
+  static_cast<Absorption::Lines *>(data)->CutoffFreqValue(newdata);
 }
 
 Numeric getAbsorptionLinesLinemixingLimit(void * data)
@@ -639,9 +728,19 @@ Numeric getAbsorptionLinesLinemixingLimit(void * data)
     return static_cast<Absorption::Lines *>(data)->LinemixingLimit();
 }
 
+void setAbsorptionLinesLinemixingLimit(void * data, Numeric newdata)
+{
+    static_cast<Absorption::Lines *>(data)->LinemixingLimit(newdata);
+}
+
 void * getAbsorptionLinesQuantumIdentifier(void * data)
 {
     return &static_cast<Absorption::Lines *>(data)->QuantumIdentity();
+}
+
+void resizeAbsorptionLinesLocalQuantumNumber(Index n, void * data)
+{
+  static_cast<Absorption::Lines *>(data)->LocalQuanta().resize(n);
 }
 
 Index getAbsorptionLinesLocalQuantumNumber(Index i, void * data)
@@ -649,9 +748,19 @@ Index getAbsorptionLinesLocalQuantumNumber(Index i, void * data)
     return Index(static_cast<Absorption::Lines *>(data)->LocalQuanta()[i]);
 }
 
+void setAbsorptionLinesLocalQuantumNumber(Index i, void * data, Index newdata)
+{
+    static_cast<Absorption::Lines *>(data)->LocalQuanta()[i] = QuantumNumberType(newdata);
+}
+
 Index getAbsorptionLinesLocalQuantumNumberCount(void * data)
 {
     return static_cast<Absorption::Lines *>(data)->NumLocalQuanta();
+}
+
+void resizeAbsorptionLinesSpeciesTag(Index n, void * data)
+{
+    static_cast<Absorption::Lines *>(data)->BroadeningSpecies().resize(n);
 }
 
 void * getAbsorptionLinesSpeciesTag(Index i, void * data)
@@ -662,6 +771,11 @@ void * getAbsorptionLinesSpeciesTag(Index i, void * data)
 Index getAbsorptionLinesSpeciesTagCount(void * data)
 {
     return static_cast<Absorption::Lines *>(data)->NumBroadeners();
+}
+
+void resizeAbsorptionLinesSingleLine(Index n, void * data)
+{
+  static_cast<Absorption::Lines *>(data)->AllLines().resize(n);
 }
 
 void * getAbsorptionLinesSingleLine(Index i, void * data)

--- a/src/arts_api_classes.cc
+++ b/src/arts_api_classes.cc
@@ -1,0 +1,675 @@
+/* Copyright (C) 2020 Richard Larsson <larsson@mps.mpg.de>
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+   USA. */
+
+////////////////////////////////////////////////////////////////////////////
+//   File description
+////////////////////////////////////////////////////////////////////////////
+/*!
+  \file   arts_api_classes.cc
+  \author Richard Larsson <larsson@mps.mpg.de>
+  \date   2020-03-12
+
+  \brief This file contains all declarations of the ARTS C API class interface.
+*/
+
+#include "arts_api_classes.h"
+
+#include "absorption.h"
+#include "absorptionlines.h"
+#include "global_data.h"
+#include "lineshapemodel.h"
+#include "quantum.h"
+#include "zeemandata.h"
+  
+void * createZeemanModel()
+{
+  return new Zeeman::Model;
+}
+
+void deleteZeemanModel(void * data)
+{
+  delete static_cast<Zeeman::Model *>(data);
+}
+
+void printZeemanModel(void * data)
+{
+  std::cout << (*static_cast<Zeeman::Model *>(data)) << std::endl;
+}
+
+Numeric getZeemanModelGU(void * data)
+{
+  return static_cast<Zeeman::Model *>(data)->gu();
+}
+
+Numeric getZeemanModelGL(void * data)
+{
+  return static_cast<Zeeman::Model *>(data)->gl();
+}
+
+void setZeemanModelGU(void * data, Numeric newdata)
+{
+  static_cast<Zeeman::Model *>(data)->gu() = newdata;
+}
+
+void setZeemanModelGL(void * data, Numeric newdata)
+{
+  static_cast<Zeeman::Model *>(data)->gl() = newdata;
+}
+
+
+void * createRational()
+{
+  return new Rational;
+}
+
+void deleteRational(void * data)
+{
+  delete static_cast<Rational *>(data);
+}
+
+void printRational(void * data)
+{
+  std::cout << (*static_cast<Rational *>(data)) << std::endl;
+}
+
+Index getRationalNom(void * data)
+{
+  return static_cast<Rational *>(data)->Nom();
+}
+
+Index getRationalDenom(void * data)
+{
+  return static_cast<Rational *>(data)->Denom();
+}
+
+void setRationalNom(void * data, Index newdata)
+{
+  static_cast<Rational *>(data)->Nom() = newdata;
+}
+
+void setRationalDenom(void * data, Index newdata)
+{
+  static_cast<Rational *>(data)->Denom() = newdata;
+}
+
+void simplifyRational(void * data)
+{
+  static_cast<Rational *>(data)->simplify_in_place();
+}
+
+
+void printLineShapeModelParameters(void * data)
+{
+  std::cout << (*static_cast<LineShape::ModelParameters *>(data)) << std::endl;
+}
+
+
+void * createLineShapeSingleSpeciesModel()
+{
+  return new LineShape::SingleSpeciesModel;
+}
+
+void deleteLineShapeSingleSpeciesModel(void * data)
+{
+  delete static_cast<LineShape::SingleSpeciesModel *>(data);
+}
+
+void printLineShapeSingleSpeciesModel(void * data)
+{
+  std::cout << (*static_cast<LineShape::SingleSpeciesModel *>(data)) << std::endl;
+}
+
+void * getLineShapeSingleSpeciesModelG0(void * data)
+{
+  return &static_cast<LineShape::SingleSpeciesModel *>(data)->G0();
+}
+
+void setLineShapeSingleSpeciesModelG0(void * data, void * newdata)
+{
+  static_cast<LineShape::SingleSpeciesModel *>(data)->G0() = *static_cast<LineShape::ModelParameters *>(newdata);
+}
+
+void * getLineShapeSingleSpeciesModelD0(void * data)
+{
+  return &static_cast<LineShape::SingleSpeciesModel *>(data)->D0();
+}
+
+void setLineShapeSingleSpeciesModelD0(void * data, void * newdata)
+{
+  static_cast<LineShape::SingleSpeciesModel *>(data)->D0() = *static_cast<LineShape::ModelParameters *>(newdata);
+}
+
+void * getLineShapeSingleSpeciesModelG2(void * data)
+{
+  return &static_cast<LineShape::SingleSpeciesModel *>(data)->G2();
+}
+
+void setLineShapeSingleSpeciesModelG2(void * data, void * newdata)
+{
+  static_cast<LineShape::SingleSpeciesModel *>(data)->G2() = *static_cast<LineShape::ModelParameters *>(newdata);
+}
+
+void * getLineShapeSingleSpeciesModelD2(void * data)
+{
+  return &static_cast<LineShape::SingleSpeciesModel *>(data)->D2();
+}
+
+void setLineShapeSingleSpeciesModelD2(void * data, void * newdata)
+{
+  static_cast<LineShape::SingleSpeciesModel *>(data)->D2() = *static_cast<LineShape::ModelParameters *>(newdata);
+}
+
+void * getLineShapeSingleSpeciesModelFVC(void * data)
+{
+  return &static_cast<LineShape::SingleSpeciesModel *>(data)->FVC();
+}
+
+void setLineShapeSingleSpeciesModelFVC(void * data, void * newdata)
+{
+  static_cast<LineShape::SingleSpeciesModel *>(data)->FVC() = *static_cast<LineShape::ModelParameters *>(newdata);
+}
+
+void * getLineShapeSingleSpeciesModelETA(void * data)
+{
+  return &static_cast<LineShape::SingleSpeciesModel *>(data)->ETA();
+}
+
+void setLineShapeSingleSpeciesModelETA(void * data, void * newdata)
+{
+  static_cast<LineShape::SingleSpeciesModel *>(data)->ETA() = *static_cast<LineShape::ModelParameters *>(newdata);
+}
+
+void * getLineShapeSingleSpeciesModelY(void * data)
+{
+  return &static_cast<LineShape::SingleSpeciesModel *>(data)->Y();
+}
+
+void setLineShapeSingleSpeciesModelY(void * data, void * newdata)
+{
+  static_cast<LineShape::SingleSpeciesModel *>(data)->Y() = *static_cast<LineShape::ModelParameters *>(newdata);
+}
+
+void * getLineShapeSingleSpeciesModelG(void * data)
+{
+  return &static_cast<LineShape::SingleSpeciesModel *>(data)->G();
+}
+
+void setLineShapeSingleSpeciesModelG(void * data, void * newdata)
+{
+  static_cast<LineShape::SingleSpeciesModel *>(data)->G() = *static_cast<LineShape::ModelParameters *>(newdata);
+}
+
+void * getLineShapeSingleSpeciesModelDV(void * data)
+{
+  return &static_cast<LineShape::SingleSpeciesModel *>(data)->DV();
+}
+
+void setLineShapeSingleSpeciesModelDV(void * data, void * newdata)
+{
+  static_cast<LineShape::SingleSpeciesModel *>(data)->DV() = *static_cast<LineShape::ModelParameters *>(newdata);
+}
+
+
+void * createLineShapeModel()
+{
+  return new LineShape::Model;
+}
+
+void deleteLineShapeModel(void * data)
+{
+  delete static_cast<LineShape::Model *>(data);
+}
+
+void printLineShapeModel(void * data)
+{
+  std::cout << (*static_cast<LineShape::Model *>(data)) << std::endl;
+}
+
+Index sizeLineShapeModel(void * data)
+{
+  return static_cast<LineShape::Model *>(data)->nelem();
+}
+
+void resizeLineShapeModel(Index n, void * data)
+{
+  static_cast<LineShape::Model *>(data)->resize(n);
+}
+
+void * getLineShapeModelSingleSpeciesModel(Index i, void * data)
+{
+  return &static_cast<LineShape::Model *>(data)->Data()[i];
+}
+
+
+void * createAbsorptionSingleLine()
+{
+  return new Absorption::SingleLine;
+}
+
+void deleteAbsorptionSingleLine(void * data)
+{
+  delete static_cast<Absorption::SingleLine *>(data);
+}
+
+void printAbsorptionSingleLine(void * data)
+{
+  std::cout << (*static_cast<Absorption::SingleLine *>(data)) << std::endl;
+}
+
+Numeric getAbsorptionSingleLineF0(void * data)
+{
+  return static_cast<Absorption::SingleLine *>(data)->F0();
+}
+
+Numeric getAbsorptionSingleLineI0(void * data)
+{
+  return static_cast<Absorption::SingleLine *>(data)->I0();
+}
+
+Numeric getAbsorptionSingleLineE0(void * data)
+{
+  return static_cast<Absorption::SingleLine *>(data)->E0();
+}
+
+Numeric getAbsorptionSingleLineGL(void * data)
+{
+  return static_cast<Absorption::SingleLine *>(data)->g_low();
+}
+
+Numeric getAbsorptionSingleLineGU(void * data)
+{
+  return static_cast<Absorption::SingleLine *>(data)->g_upp();
+}
+
+Numeric getAbsorptionSingleLineA(void * data)
+{
+  return static_cast<Absorption::SingleLine *>(data)->A();
+}
+
+void setAbsorptionSingleLineF0(void * data, Numeric newdata)
+{
+  static_cast<Absorption::SingleLine *>(data)->F0() = newdata;
+}
+
+void setAbsorptionSingleLineI0(void * data, Numeric newdata)
+{
+  static_cast<Absorption::SingleLine *>(data)->I0() = newdata;
+}
+
+void setAbsorptionSingleLineE0(void * data, Numeric newdata)
+{
+  static_cast<Absorption::SingleLine *>(data)->E0() = newdata;
+}
+
+void setAbsorptionSingleLineGL(void * data, Numeric newdata)
+{
+  static_cast<Absorption::SingleLine *>(data)->g_low() = newdata;
+}
+
+void setAbsorptionSingleLineGU(void * data, Numeric newdata)
+{
+  static_cast<Absorption::SingleLine *>(data)->g_upp() = newdata;
+}
+
+void setAbsorptionSingleLineA(void * data, Numeric newdata)
+{
+  static_cast<Absorption::SingleLine *>(data)->A() = newdata;
+}
+
+void * getAbsorptionSingleLineZeemanModel(void * data)
+{
+  return &static_cast<Absorption::SingleLine *>(data)->Zeeman();
+}
+
+void * getAbsorptionSingleLineLineShapeModel(void * data)
+{
+  return &static_cast<Absorption::SingleLine *>(data)->LineShape();
+}
+
+Index sizeAbsorptionSingleLineLowerQuantas(void * data)
+{
+  return static_cast<Absorption::SingleLine *>(data)->LowerQuantumNumbers().size();
+}
+
+Index sizeAbsorptionSingleLineUpperQuantas(void * data)
+{
+  return static_cast<Absorption::SingleLine *>(data)->UpperQuantumNumbers().size();
+}
+
+void resizeAbsorptionSingleLineLowerQuantas(Index n, void * data)
+{
+  static_cast<Absorption::SingleLine *>(data)->LowerQuantumNumbers().resize(n);
+}
+
+void resizeAbsorptionSingleLineUpperQuantas(Index n, void * data)
+{
+  static_cast<Absorption::SingleLine *>(data)->UpperQuantumNumbers().resize(n);
+}
+
+void * getAbsorptionSingleLineLowerQuanta(Index i, void * data)
+{
+  return &static_cast<Absorption::SingleLine *>(data)->LowerQuantumNumbers()[i];
+}
+
+void * getAbsorptionSingleLineUpperQuanta(Index i, void * data)
+{
+  return &static_cast<Absorption::SingleLine *>(data)->UpperQuantumNumbers()[i];
+}
+
+
+void * createQuantumNumbers()
+{
+  return new QuantumNumbers;
+}
+
+void deleteQuantumNumbers(void * data)
+{
+  delete static_cast<QuantumNumbers *>(data);
+}
+
+void printQuantumNumbers(void * data)
+{
+  std::cout << (*static_cast<QuantumNumbers *>(data)) << std::endl;
+}
+
+Index getQuantumNumbersMaxNumber()
+{
+    return Index(QuantumNumberType::FINAL_ENTRY);
+}
+
+void * getQuantumNumbersNumber(Index i, void * data)
+{
+    return &static_cast<QuantumNumbers *>(data)->operator[](i);
+}
+
+Index string2quantumnumbersindex(char * str)
+{
+    return Index(string2quantumnumbertype(str));
+}
+
+
+void * createQuantumIdentifier()
+{
+  return new QuantumIdentifier;
+}
+
+void deleteQuantumIdentifier(void * data)
+{
+  delete static_cast<QuantumIdentifier *>(data);
+}
+
+void printQuantumIdentifier(void * data)
+{
+  std::cout << (*static_cast<QuantumIdentifier *>(data)) << std::endl;
+}
+
+Index getQuantumIdentifierType(void * data)
+{
+    return Index(static_cast<QuantumIdentifier *>(data)->Type());
+}
+
+Index setQuantumIdentifierType(void * data, char * str)
+{
+    if (std::string("ENERGY_LEVEL") == str) {
+        static_cast<QuantumIdentifier *>(data)->SetEnergyLevel(static_cast<QuantumIdentifier *>(data)->EnergyLevelQuantumNumbers());
+        return EXIT_SUCCESS;
+    } else if (std::string("TRANSITION") == str) {
+        static_cast<QuantumIdentifier *>(data)->SetTransition();
+        return EXIT_SUCCESS;
+    } 
+    else if (std::string("ALL") == str) {
+        static_cast<QuantumIdentifier *>(data)->SetAll();
+        return EXIT_SUCCESS;
+    } 
+    else if (std::string("NONE") == str) {
+        static_cast<QuantumIdentifier *>(data)->SetNone();
+        return EXIT_SUCCESS;
+    } else
+        return EXIT_FAILURE;
+}
+
+Index getQuantumIdentifierSpecies(void * data)
+{
+    return static_cast<QuantumIdentifier *>(data)->Species();
+}
+
+Index validSpecies(Index spec)
+{
+    if (spec >= 0 and spec < global_data::species_data.nelem())
+        return EXIT_SUCCESS;
+    else
+        return EXIT_FAILURE;
+}
+
+void setQuantumIdentifierSpecies(void * data, Index spec)
+{
+    static_cast<QuantumIdentifier *>(data)->Species() = spec;
+}
+
+Index getQuantumIdentifierIsotopologue(void * data)
+{
+    return static_cast<QuantumIdentifier *>(data)->Isotopologue();
+}
+
+Index validIsotopologue(Index spec, Index isot)
+{
+    auto& species = global_data::species_data[spec];
+    if (isot >= 0 and isot < species.Isotopologue().nelem()) {
+        if (not species.Isotopologue()[isot].isContinuum())
+            return EXIT_SUCCESS;
+        else
+            return EXIT_FAILURE;
+    } else
+        return EXIT_FAILURE;
+}
+
+void setQuantumIdentifierIsotopologue(void * data, Index isot)
+{
+    static_cast<QuantumIdentifier *>(data)->Isotopologue() = isot;
+}
+
+void * getQuantumIdentifierLevelQuantumNumbers(void * data)
+{
+    return &static_cast<QuantumIdentifier *>(data) ->EnergyLevelQuantumNumbers();
+}
+
+void * getQuantumIdentifierLowerQuantumNumbers(void * data)
+{
+    return &static_cast<QuantumIdentifier *>(data) ->LowerQuantumNumbers();
+}
+
+void * getQuantumIdentifierUpperQuantumNumbers(void * data)
+{
+    return &static_cast<QuantumIdentifier *>(data) ->UpperQuantumNumbers();
+}
+
+
+void * createSpeciesTag()
+{
+  return new SpeciesTag;
+}
+
+void deleteSpeciesTag(void * data)
+{
+    delete static_cast<SpeciesTag *>(data);
+}
+
+void printSpeciesTag(void * data)
+{
+    std::cout << (*static_cast<SpeciesTag *>(data)) << std::endl;
+}
+
+void setSpeciesTag(void * data, char * newdata)
+{
+    *static_cast<SpeciesTag *>(data) = SpeciesTag(newdata);
+}
+
+Index getSpeciesTagSpecies(void * data)
+{
+    return static_cast<SpeciesTag *>(data)->Species();
+}
+
+Index getSpeciesTagIsotopologue(void * data)
+{
+    return static_cast<SpeciesTag *>(data)->Isotopologue();
+}
+
+Numeric getSpeciesTagLowerFrequency(void * data)
+{
+    return static_cast<SpeciesTag *>(data)->Lf();
+}
+
+Numeric getSpeciesTagUpperFrequency(void * data)
+{
+    return static_cast<SpeciesTag *>(data)->Uf();
+}
+
+Index getSpeciesTagType(void * data)
+{
+    return static_cast<SpeciesTag *>(data)->Type();
+}
+
+Index getSpeciesTagCIASecond(void * data)
+{
+    return static_cast<SpeciesTag *>(data)->CIASecond();
+}
+
+Index getSpeciesTagCIADataset(void * data)
+{
+    return static_cast<SpeciesTag *>(data)->CIADataset();
+}
+
+
+void * createAbsorptionLines()
+{
+  return new Absorption::Lines;
+}
+
+void deleteAbsorptionLines(void * data)
+{
+    delete static_cast<Absorption::Lines *>(data);
+}
+
+void printAbsorptionLines(void * data)
+{
+    std::cout << (*static_cast<Absorption::Lines *>(data)) << std::endl;
+}
+
+void printmetaAbsorptionLines(void * data)
+{
+    std::cout << static_cast<Absorption::Lines *>(data)->MetaData() << std::endl;
+}
+
+bool getAbsorptionLinesSelfBroadening(void * data)
+{
+    return static_cast<Absorption::Lines *>(data)->Self();
+}
+
+void setAbsorptionLinesSelfBroadening(void * data, bool newdata)
+{
+    static_cast<Absorption::Lines *>(data)->Self() = newdata;
+}
+
+bool getAbsorptionLinesBathBroadening(void * data)
+{
+    return static_cast<Absorption::Lines *>(data)->Bath();
+}
+
+void setAbsorptionLinesBathBroadening(void * data, bool newdata)
+{
+    static_cast<Absorption::Lines *>(data)->Bath() = newdata;
+}
+
+Index getAbsorptionLinesCutoffType(void * data)
+{
+    return Index(static_cast<Absorption::Lines *>(data)->Cutoff());
+}
+
+void getAbsorptionLinesCutoffType(void * data, Index newdata)
+{
+    static_cast<Absorption::Lines *>(data)->Cutoff(Absorption::CutoffType(newdata));
+}
+
+Index getAbsorptionLinesMirroringType(void * data)
+{
+    return Index(static_cast<Absorption::Lines *>(data)->Mirroring());
+}
+
+Index getAbsorptionLinesPopulationType(void * data)
+{
+    return Index(static_cast<Absorption::Lines *>(data)->Population());
+}
+
+Index getAbsorptionLinesNormalizationType(void * data)
+{
+    return Index(static_cast<Absorption::Lines *>(data)->Normalization());
+}
+
+Index getAbsorptionLinesLineShapeType(void * data)
+{
+    return Index(static_cast<Absorption::Lines *>(data)->LineShapeType());
+}
+
+Numeric getAbsorptionLinesT0(void * data)
+{
+    return static_cast<Absorption::Lines *>(data)->T0();
+}
+
+Numeric getAbsorptionLinesCutoffFrequency(void * data)
+{
+    return static_cast<Absorption::Lines *>(data)->CutoffFreqValue();
+}
+
+Numeric getAbsorptionLinesLinemixingLimit(void * data)
+{
+    return static_cast<Absorption::Lines *>(data)->LinemixingLimit();
+}
+
+void * getAbsorptionLinesQuantumIdentifier(void * data)
+{
+    return &static_cast<Absorption::Lines *>(data)->QuantumIdentity();
+}
+
+Index getAbsorptionLinesLocalQuantumNumber(Index i, void * data)
+{
+    return Index(static_cast<Absorption::Lines *>(data)->LocalQuanta()[i]);
+}
+
+Index getAbsorptionLinesLocalQuantumNumberCount(void * data)
+{
+    return static_cast<Absorption::Lines *>(data)->NumLocalQuanta();
+}
+
+void * getAbsorptionLinesSpeciesTag(Index i, void * data)
+{
+    return &static_cast<Absorption::Lines *>(data)->BroadeningSpecies()[i];
+}
+
+Index getAbsorptionLinesSpeciesTagCount(void * data)
+{
+    return static_cast<Absorption::Lines *>(data)->NumBroadeners();
+}
+
+void * getAbsorptionLinesSingleLine(Index i, void * data)
+{
+    return &static_cast<Absorption::Lines *>(data)->Line(i);
+}
+
+Index getAbsorptionLinesSingleLineCount(void * data)
+{
+    return static_cast<Absorption::Lines *>(data)->NumLines();
+}

--- a/src/arts_api_classes.cc
+++ b/src/arts_api_classes.cc
@@ -587,6 +587,41 @@ Index getSpeciesTagCIADataset(void * data)
     return static_cast<SpeciesTag *>(data)->CIADataset();
 }
 
+void setSpeciesTagSpecies(void * data, Index newdata)
+{
+  static_cast<SpeciesTag *>(data)->Species(newdata);
+}
+
+void setSpeciesTagIsotopologue(void * data, Index newdata)
+{
+  static_cast<SpeciesTag *>(data)->Isotopologue(newdata);
+}
+
+void setSpeciesTagLowerFrequency(void * data, Numeric newdata)
+{
+  static_cast<SpeciesTag *>(data)->Lf(newdata);
+}
+
+void setSpeciesTagUpperFrequency(void * data, Numeric newdata)
+{
+  static_cast<SpeciesTag *>(data)->Uf(newdata);
+}
+
+void setSpeciesTagType(void * data, Index newdata)
+{
+  static_cast<SpeciesTag *>(data)->Type(newdata);
+}
+
+void setSpeciesTagCIASecond(void * data, Index newdata)
+{
+  static_cast<SpeciesTag *>(data)->CIASecond(newdata);
+}
+
+void setSpeciesTagCIADataset(void * data, Index newdata)
+{
+  static_cast<SpeciesTag *>(data)->CIADataset(newdata);
+}
+
 
 void * createAbsorptionLines()
 {
@@ -643,6 +678,11 @@ Index setAbsorptionLinesCutoffType(void * data, char * newdata)
     }
 }
 
+void setAbsorptionLinesCutoffTypeByIndex(void * data, Index newdata)
+{
+  static_cast<Absorption::Lines *>(data)->Cutoff(Absorption::CutoffType(newdata));
+}
+
 Index getAbsorptionLinesMirroringType(void * data)
 {
     return Index(static_cast<Absorption::Lines *>(data)->Mirroring());
@@ -656,6 +696,11 @@ Index setAbsorptionLinesMirroringType(void * data, char * newdata)
     } catch(const std::exception& e) {
       return EXIT_FAILURE;
     }
+}
+
+void setAbsorptionLinesMirroringTypeByIndex(void * data, Index newdata)
+{
+  static_cast<Absorption::Lines *>(data)->Mirroring(Absorption::MirroringType(newdata));
 }
 
 Index getAbsorptionLinesPopulationType(void * data)
@@ -673,6 +718,11 @@ Index setAbsorptionLinesPopulationType(void * data, char * newdata)
     }
 }
 
+void setAbsorptionLinesPopulationTypeByIndex(void * data, Index newdata)
+{
+  static_cast<Absorption::Lines *>(data)->Population(Absorption::PopulationType(newdata));
+}
+
 Index getAbsorptionLinesNormalizationType(void * data)
 {
     return Index(static_cast<Absorption::Lines *>(data)->Normalization());
@@ -688,6 +738,11 @@ Index setAbsorptionLinesNormalizationType(void * data, char * newdata)
     }
 }
 
+void setAbsorptionLinesNormalizationTypeByIndex(void * data, Index newdata)
+{
+  static_cast<Absorption::Lines *>(data)->Normalization(Absorption::NormalizationType(newdata));
+}
+
 Index getAbsorptionLinesLineShapeType(void * data)
 {
     return Index(static_cast<Absorption::Lines *>(data)->LineShapeType());
@@ -701,6 +756,11 @@ Index setAbsorptionLinesLineShapeType(void * data, char * newdata)
     } catch(const std::exception& e) {
       return EXIT_FAILURE;
     }
+}
+
+void setAbsorptionLinesLineShapeTypeByIndex(void * data, Index newdata)
+{
+  static_cast<Absorption::Lines *>(data)->LineShapeType(LineShape::Type(newdata));
 }
 
 Numeric getAbsorptionLinesT0(void * data)
@@ -786,4 +846,12 @@ void * getAbsorptionLinesSingleLine(Index i, void * data)
 Index getAbsorptionLinesSingleLineCount(void * data)
 {
     return static_cast<Absorption::Lines *>(data)->NumLines();
+}
+
+Index isAbsorptionLinesOK(void * data)
+{
+  if (static_cast<Absorption::Lines *>(data) -> OK())
+    return 1;
+  else
+    return 0;
 }

--- a/src/arts_api_classes.h
+++ b/src/arts_api_classes.h
@@ -60,6 +60,7 @@ extern "C" {
   
   // LineShape::ModelParameters
   DLL_PUBLIC void printLineShapeModelParameters(void *);
+  DLL_PUBLIC Index getLineShapeModelParametersType(char *);
   
   // LineShape::SingleSpeciesModel
   DLL_PUBLIC void * createLineShapeSingleSpeciesModel();
@@ -127,7 +128,9 @@ extern "C" {
   DLL_PUBLIC void * createQuantumIdentifier();
   DLL_PUBLIC void deleteQuantumIdentifier(void *);
   DLL_PUBLIC void printQuantumIdentifier(void *);
-  DLL_PUBLIC Index setQuantumIdentifierType(void *, char *);
+  DLL_PUBLIC Index getQuantumIdentifierType(void *);
+  DLL_PUBLIC Index setQuantumIdentifierTypeFromString(void *, char *);
+  DLL_PUBLIC Index setQuantumIdentifierTypeFromIndex(void *, Index);
   DLL_PUBLIC Index getQuantumIdentifierSpecies(void *);
   DLL_PUBLIC void setQuantumIdentifierSpecies(void *, Index);
   DLL_PUBLIC Index getQuantumIdentifierIsotopologue(void *);
@@ -140,7 +143,7 @@ extern "C" {
   DLL_PUBLIC void * createSpeciesTag();
   DLL_PUBLIC void deleteSpeciesTag(void *);
   DLL_PUBLIC void printSpeciesTag(void *);
-  DLL_PUBLIC void setSpeciesTag(void *, char *);
+  DLL_PUBLIC Index setSpeciesTag(void *, char *);
   DLL_PUBLIC Index getSpeciesTagSpecies(void *);
   DLL_PUBLIC Index getSpeciesTagIsotopologue(void *);
   DLL_PUBLIC Numeric getSpeciesTagLowerFrequency(void *);
@@ -159,19 +162,31 @@ extern "C" {
   DLL_PUBLIC bool getAbsorptionLinesBathBroadening(void *);
   DLL_PUBLIC void setAbsorptionLinesBathBroadening(void *, bool);
   DLL_PUBLIC Index getAbsorptionLinesCutoffType(void *);
-  DLL_PUBLIC void setAbsorptionLinesCutoffType(void *, Index);
+  DLL_PUBLIC Index setAbsorptionLinesCutoffType(void *, char *);
   DLL_PUBLIC Index getAbsorptionLinesMirroringType(void *);
+  DLL_PUBLIC Index setAbsorptionLinesMirroringType(void *, char *);
   DLL_PUBLIC Index getAbsorptionLinesPopulationType(void *);
+  DLL_PUBLIC Index setAbsorptionLinesPopulationType(void *, char *);
   DLL_PUBLIC Index getAbsorptionLinesNormalizationType(void *);
+  DLL_PUBLIC Index setAbsorptionLinesNormalizationType(void *, char *);
   DLL_PUBLIC Index getAbsorptionLinesLineShapeType(void *);
+  DLL_PUBLIC Index setAbsorptionLinesLineShapeType(void *, char *);
   DLL_PUBLIC Numeric getAbsorptionLinesT0(void *);
+  DLL_PUBLIC void setAbsorptionLinesT0(void *, Numeric);
   DLL_PUBLIC Numeric getAbsorptionLinesCutoffFrequency(void *);
+  DLL_PUBLIC void setAbsorptionLinesCutoffFrequency(void *, Numeric);
   DLL_PUBLIC Numeric getAbsorptionLinesLinemixingLimit(void *);
+  DLL_PUBLIC void setAbsorptionLinesLinemixingLimit(void *, Numeric);
   DLL_PUBLIC void * getAbsorptionLinesQuantumIdentifier(void *);
+  DLL_PUBLIC void resizeAbsorptionLinesLocalQuantumNumber(Index, void *);
   DLL_PUBLIC Index getAbsorptionLinesLocalQuantumNumber(Index, void *);
+  DLL_PUBLIC void setAbsorptionLinesLocalQuantumNumber(Index, void *, Index);
   DLL_PUBLIC Index getAbsorptionLinesLocalQuantumNumberCount(void *);
+  DLL_PUBLIC void resizeAbsorptionLinesSpeciesTag(Index, void *);
   DLL_PUBLIC void * getAbsorptionLinesSpeciesTag(Index, void *);
   DLL_PUBLIC Index getAbsorptionLinesSpeciesTagCount(void *);
+  
+  DLL_PUBLIC void resizeAbsorptionLinesSingleLine(Index, void *);
   DLL_PUBLIC void * getAbsorptionLinesSingleLine(Index, void *);
   DLL_PUBLIC Index getAbsorptionLinesSingleLineCount(void *);
   

--- a/src/arts_api_classes.h
+++ b/src/arts_api_classes.h
@@ -1,0 +1,191 @@
+/* Copyright (C) 2020 Richard Larsson <larsson@mps.mpg.de>
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License as
+   published by the Free Software Foundation; either version 2 of the
+   License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+   USA. */
+
+////////////////////////////////////////////////////////////////////////////
+//   File description
+////////////////////////////////////////////////////////////////////////////
+/*!
+  \file   arts_api_classes.h
+  \author Richard Larsson <larsson@mps.mpg.de>
+  \date   2020-03-12
+
+  \brief This file contains all declarations of the ARTS C API class interface.
+*/
+
+#ifndef _ARTS_ARTS_API_CLASS_H_
+#define _ARTS_ARTS_API_CLASS_H_
+
+#include "matpack.h"
+
+#ifndef DLL_PUBLIC
+#define DLL_PUBLIC __attribute__((visibility("default")))
+#define REMOVE_DLL_PUBLIC 1
+#else
+#define REMOVE_DLL_PUBLIC 0
+#endif
+
+extern "C" {
+  // Zeeman::Model
+  DLL_PUBLIC void * createZeemanModel();
+  DLL_PUBLIC void deleteZeemanModel(void *);
+  DLL_PUBLIC Numeric getZeemanModelGU(void *);
+  DLL_PUBLIC Numeric getZeemanModelGL(void *);
+  DLL_PUBLIC void setZeemanModelGU(void *, Numeric);
+  DLL_PUBLIC void setZeemanModelGL(void *, Numeric);
+  DLL_PUBLIC void printZeemanModel(void *);
+  
+  // Rational
+  DLL_PUBLIC void * createRational();
+  DLL_PUBLIC void deleteRational(void *);
+  DLL_PUBLIC Index getRationalNom(void *);
+  DLL_PUBLIC Index getRationalDenom(void *);
+  DLL_PUBLIC void setRationalNom(void *, Index);
+  DLL_PUBLIC void setRationalDenom(void *, Index);
+  DLL_PUBLIC void printRational(void *);
+  DLL_PUBLIC void simplifyRational(void *);
+  
+  // LineShape::ModelParameters
+  DLL_PUBLIC void printLineShapeModelParameters(void *);
+  
+  // LineShape::SingleSpeciesModel
+  DLL_PUBLIC void * createLineShapeSingleSpeciesModel();
+  DLL_PUBLIC void deleteLineShapeSingleSpeciesModel(void *);
+  DLL_PUBLIC void printLineShapeSingleSpeciesModel(void *);
+  DLL_PUBLIC void * getLineShapeSingleSpeciesModelG0(void *);
+  DLL_PUBLIC void * getLineShapeSingleSpeciesModelD0(void *);
+  DLL_PUBLIC void * getLineShapeSingleSpeciesModelG2(void *);
+  DLL_PUBLIC void * getLineShapeSingleSpeciesModelD2(void *);
+  DLL_PUBLIC void * getLineShapeSingleSpeciesModelFVC(void *);
+  DLL_PUBLIC void * getLineShapeSingleSpeciesModelETA(void *);
+  DLL_PUBLIC void * getLineShapeSingleSpeciesModelY(void *);
+  DLL_PUBLIC void * getLineShapeSingleSpeciesModelG(void *);
+  DLL_PUBLIC void * getLineShapeSingleSpeciesModelDV(void *);
+  DLL_PUBLIC void setLineShapeSingleSpeciesModelG0(void *, void *);
+  DLL_PUBLIC void setLineShapeSingleSpeciesModelD0(void *, void *);
+  DLL_PUBLIC void setLineShapeSingleSpeciesModelG2(void *, void *);
+  DLL_PUBLIC void setLineShapeSingleSpeciesModelD2(void *, void *);
+  DLL_PUBLIC void setLineShapeSingleSpeciesModelFVC(void *, void *);
+  DLL_PUBLIC void setLineShapeSingleSpeciesModelETA(void *, void *);
+  DLL_PUBLIC void setLineShapeSingleSpeciesModelY(void *, void *);
+  DLL_PUBLIC void setLineShapeSingleSpeciesModelG(void *, void *);
+  DLL_PUBLIC void setLineShapeSingleSpeciesModelDV(void *, void *);
+  
+  // LineShape::Model
+  DLL_PUBLIC void * createLineShapeModel();
+  DLL_PUBLIC void deleteLineShapeModel(void *);
+  DLL_PUBLIC void printLineShapeModel(void *);
+  DLL_PUBLIC void resizeLineShapeModel(Index, void *);
+  DLL_PUBLIC Index sizeLineShapeModel(void *);
+  DLL_PUBLIC void * getLineShapeModelSingleSpeciesModel(Index, void *);
+  
+  // Absorption::SingleLine
+  DLL_PUBLIC void * createAbsorptionSingleLine();
+  DLL_PUBLIC void deleteAbsorptionSingleLine(void *);
+  DLL_PUBLIC void printAbsorptionSingleLine(void *);
+  DLL_PUBLIC Numeric getAbsorptionSingleLineF0(void *);
+  DLL_PUBLIC Numeric getAbsorptionSingleLineI0(void *);
+  DLL_PUBLIC Numeric getAbsorptionSingleLineE0(void *);
+  DLL_PUBLIC Numeric getAbsorptionSingleLineGL(void *);
+  DLL_PUBLIC Numeric getAbsorptionSingleLineGU(void *);
+  DLL_PUBLIC Numeric getAbsorptionSingleLineA(void *);
+  DLL_PUBLIC void setAbsorptionSingleLineF0(void *, Numeric);
+  DLL_PUBLIC void setAbsorptionSingleLineI0(void *, Numeric);
+  DLL_PUBLIC void setAbsorptionSingleLineE0(void *, Numeric);
+  DLL_PUBLIC void setAbsorptionSingleLineGL(void *, Numeric);
+  DLL_PUBLIC void setAbsorptionSingleLineGU(void *, Numeric);
+  DLL_PUBLIC void setAbsorptionSingleLineA(void *, Numeric);
+  DLL_PUBLIC void * getAbsorptionSingleLineZeemanModel(void *);
+  DLL_PUBLIC void * getAbsorptionSingleLineLineShapeModel(void *);
+  DLL_PUBLIC Index sizeAbsorptionSingleLineLowerQuantas(void *);
+  DLL_PUBLIC Index sizeAbsorptionSingleLineUpperQuantas(void *);
+  DLL_PUBLIC void resizeAbsorptionSingleLineLowerQuantas(Index, void *);
+  DLL_PUBLIC void resizeAbsorptionSingleLineUpperQuantas(Index, void *);
+  DLL_PUBLIC void * getAbsorptionSingleLineLowerQuanta(Index, void *);
+  DLL_PUBLIC void * getAbsorptionSingleLineUpperQuanta(Index, void *);
+  
+  // QuantumNumbers
+  DLL_PUBLIC void * createQuantumNumbers();
+  DLL_PUBLIC void deleteQuantumNumbers(void *);
+  DLL_PUBLIC void printQuantumNumbers(void *);
+  DLL_PUBLIC void * getQuantumNumbersNumber(Index, void *);
+  
+  // QuantumIdentifier
+  DLL_PUBLIC void * createQuantumIdentifier();
+  DLL_PUBLIC void deleteQuantumIdentifier(void *);
+  DLL_PUBLIC void printQuantumIdentifier(void *);
+  DLL_PUBLIC Index setQuantumIdentifierType(void *, char *);
+  DLL_PUBLIC Index getQuantumIdentifierSpecies(void *);
+  DLL_PUBLIC void setQuantumIdentifierSpecies(void *, Index);
+  DLL_PUBLIC Index getQuantumIdentifierIsotopologue(void *);
+  DLL_PUBLIC void setQuantumIdentifierIsotopologue(void *, Index);
+  DLL_PUBLIC void * getQuantumIdentifierLevelQuantumNumbers(void *);
+  DLL_PUBLIC void * getQuantumIdentifierLowerQuantumNumbers(void *);
+  DLL_PUBLIC void * getQuantumIdentifierUpperQuantumNumbers(void *);
+  
+  // SpeciesTag
+  DLL_PUBLIC void * createSpeciesTag();
+  DLL_PUBLIC void deleteSpeciesTag(void *);
+  DLL_PUBLIC void printSpeciesTag(void *);
+  DLL_PUBLIC void setSpeciesTag(void *, char *);
+  DLL_PUBLIC Index getSpeciesTagSpecies(void *);
+  DLL_PUBLIC Index getSpeciesTagIsotopologue(void *);
+  DLL_PUBLIC Numeric getSpeciesTagLowerFrequency(void *);
+  DLL_PUBLIC Numeric getSpeciesTagUpperFrequency(void *);
+  DLL_PUBLIC Index getSpeciesTagType(void *);
+  DLL_PUBLIC Index getSpeciesTagCIASecond(void *);
+  DLL_PUBLIC Index getSpeciesTagCIADataset(void *);
+  
+  // Absorption::Lines
+  DLL_PUBLIC void * createAbsorptionLines();
+  DLL_PUBLIC void deleteAbsorptionLines(void *);
+  DLL_PUBLIC void printAbsorptionLines(void *);
+  DLL_PUBLIC void printmetaAbsorptionLines(void *);
+  DLL_PUBLIC bool getAbsorptionLinesSelfBroadening(void *);
+  DLL_PUBLIC void setAbsorptionLinesSelfBroadening(void *, bool);
+  DLL_PUBLIC bool getAbsorptionLinesBathBroadening(void *);
+  DLL_PUBLIC void setAbsorptionLinesBathBroadening(void *, bool);
+  DLL_PUBLIC Index getAbsorptionLinesCutoffType(void *);
+  DLL_PUBLIC void setAbsorptionLinesCutoffType(void *, Index);
+  DLL_PUBLIC Index getAbsorptionLinesMirroringType(void *);
+  DLL_PUBLIC Index getAbsorptionLinesPopulationType(void *);
+  DLL_PUBLIC Index getAbsorptionLinesNormalizationType(void *);
+  DLL_PUBLIC Index getAbsorptionLinesLineShapeType(void *);
+  DLL_PUBLIC Numeric getAbsorptionLinesT0(void *);
+  DLL_PUBLIC Numeric getAbsorptionLinesCutoffFrequency(void *);
+  DLL_PUBLIC Numeric getAbsorptionLinesLinemixingLimit(void *);
+  DLL_PUBLIC void * getAbsorptionLinesQuantumIdentifier(void *);
+  DLL_PUBLIC Index getAbsorptionLinesLocalQuantumNumber(Index, void *);
+  DLL_PUBLIC Index getAbsorptionLinesLocalQuantumNumberCount(void *);
+  DLL_PUBLIC void * getAbsorptionLinesSpeciesTag(Index, void *);
+  DLL_PUBLIC Index getAbsorptionLinesSpeciesTagCount(void *);
+  DLL_PUBLIC void * getAbsorptionLinesSingleLine(Index, void *);
+  DLL_PUBLIC Index getAbsorptionLinesSingleLineCount(void *);
+  
+  // generic
+  DLL_PUBLIC Index validSpecies(Index);
+  DLL_PUBLIC Index validIsotopologue(Index, Index);
+  DLL_PUBLIC Index getQuantumNumbersMaxNumber();
+  DLL_PUBLIC Index string2quantumnumbersindex(char *);
+}
+
+#if REMOVE_DLL_PUBLIC
+#undef DLL_PUBLIC
+#endif
+#undef REMOVE_DLL_PUBLIC
+
+#endif // _ARTS_ARTS_API_CLASS_H_
+

--- a/src/arts_api_classes.h
+++ b/src/arts_api_classes.h
@@ -151,6 +151,13 @@ extern "C" {
   DLL_PUBLIC Index getSpeciesTagType(void *);
   DLL_PUBLIC Index getSpeciesTagCIASecond(void *);
   DLL_PUBLIC Index getSpeciesTagCIADataset(void *);
+  DLL_PUBLIC void setSpeciesTagSpecies(void *, Index);
+  DLL_PUBLIC void setSpeciesTagIsotopologue(void *, Index);
+  DLL_PUBLIC void setSpeciesTagLowerFrequency(void *, Numeric);
+  DLL_PUBLIC void setSpeciesTagUpperFrequency(void *, Numeric);
+  DLL_PUBLIC void setSpeciesTagType(void *, Index);
+  DLL_PUBLIC void setSpeciesTagCIASecond(void *, Index);
+  DLL_PUBLIC void setSpeciesTagCIADataset(void *, Index);
   
   // Absorption::Lines
   DLL_PUBLIC void * createAbsorptionLines();
@@ -163,14 +170,19 @@ extern "C" {
   DLL_PUBLIC void setAbsorptionLinesBathBroadening(void *, bool);
   DLL_PUBLIC Index getAbsorptionLinesCutoffType(void *);
   DLL_PUBLIC Index setAbsorptionLinesCutoffType(void *, char *);
+  DLL_PUBLIC void setAbsorptionLinesCutoffTypeByIndex(void *, Index);
   DLL_PUBLIC Index getAbsorptionLinesMirroringType(void *);
   DLL_PUBLIC Index setAbsorptionLinesMirroringType(void *, char *);
+  DLL_PUBLIC void setAbsorptionLinesMirroringTypeByIndex(void *, Index);
   DLL_PUBLIC Index getAbsorptionLinesPopulationType(void *);
   DLL_PUBLIC Index setAbsorptionLinesPopulationType(void *, char *);
+  DLL_PUBLIC void setAbsorptionLinesPopulationTypeByIndex(void *, Index);
   DLL_PUBLIC Index getAbsorptionLinesNormalizationType(void *);
   DLL_PUBLIC Index setAbsorptionLinesNormalizationType(void *, char *);
+  DLL_PUBLIC void setAbsorptionLinesNormalizationTypeByIndex(void *, Index);
   DLL_PUBLIC Index getAbsorptionLinesLineShapeType(void *);
   DLL_PUBLIC Index setAbsorptionLinesLineShapeType(void *, char *);
+  DLL_PUBLIC void setAbsorptionLinesLineShapeTypeByIndex(void *, Index);
   DLL_PUBLIC Numeric getAbsorptionLinesT0(void *);
   DLL_PUBLIC void setAbsorptionLinesT0(void *, Numeric);
   DLL_PUBLIC Numeric getAbsorptionLinesCutoffFrequency(void *);
@@ -185,6 +197,7 @@ extern "C" {
   DLL_PUBLIC void resizeAbsorptionLinesSpeciesTag(Index, void *);
   DLL_PUBLIC void * getAbsorptionLinesSpeciesTag(Index, void *);
   DLL_PUBLIC Index getAbsorptionLinesSpeciesTagCount(void *);
+  DLL_PUBLIC Index isAbsorptionLinesOK(void *);
   
   DLL_PUBLIC void resizeAbsorptionLinesSingleLine(Index, void *);
   DLL_PUBLIC void * getAbsorptionLinesSingleLine(Index, void *);

--- a/src/lineshapemodel.h
+++ b/src/lineshapemodel.h
@@ -86,9 +86,6 @@ enum class TemperatureModel : Index {
   // ALWAYS ADD NEW AT THE END
 };
 
-// Always store the maximum value
-constexpr Index TemperatureModelMax = Index(TemperatureModel::DPL);
-
 /** Turns selected TemperatureModel type into a string
  * 
  * This function takes the input TemperatureModel

--- a/src/lineshapemodel.h
+++ b/src/lineshapemodel.h
@@ -86,6 +86,9 @@ enum class TemperatureModel : Index {
   // ALWAYS ADD NEW AT THE END
 };
 
+// Always store the maximum value
+constexpr Index TemperatureModelMax = Index(TemperatureModel::DPL);
+
 /** Turns selected TemperatureModel type into a string
  * 
  * This function takes the input TemperatureModel
@@ -773,7 +776,7 @@ inline std::istream& operator>>(std::istream& is, SingleSpeciesModel& ssm) {
 }
 
 /** Type of line shape to compute */
-enum class Type {
+enum class Type : Index {
   DP,    // Doppler
   LP,    // Lorentz
   VP,    // Voigt
@@ -1629,3 +1632,4 @@ void vector2modelpb(LineShape::Type& mtype,
 };  // namespace LineShape
 
 #endif  // lineshapemodel_h
+

--- a/src/quantum.cc
+++ b/src/quantum.cc
@@ -238,8 +238,6 @@ void QuantumIdentifier::SetEnergyLevel(const QuantumNumbers& q) {
   mqm[ENERGY_LEVEL_INDEX] = q;
 }
 
-void QuantumIdentifier::SetAll() { mqtype = QuantumIdentifier::ALL; }
-
 void QuantumIdentifier::SetFromString(String str) {
   // Global species lookup data:
   using global_data::species_data;

--- a/src/quantum.h
+++ b/src/quantum.h
@@ -390,7 +390,7 @@ typedef Array<QuantumNumbers> ArrayOfQuantumNumbers;
 class QuantumIdentifier {
  public:
   /** Ways to identify quantum numbers */
-  typedef enum { TRANSITION, ENERGY_LEVEL, ALL, NONE } QType;
+  typedef enum : Index { TRANSITION, ENERGY_LEVEL, ALL, NONE } QType;
 
   /** Initialize with no matches */
   constexpr QuantumIdentifier() noexcept
@@ -500,7 +500,10 @@ class QuantumIdentifier {
   void SetEnergyLevel(const QuantumNumbers& q);
 
   /** Set to All identifier */
-  void SetAll();
+  void SetAll() { mqtype = QuantumIdentifier::ALL; };
+  
+  /** Set to NONE identifier */
+  void SetNone() { mqtype = QuantumIdentifier::NONE; };
 
   /** Set key to transition type */
   void SetTransition() { mqtype = QuantumIdentifier::TRANSITION; };

--- a/src/rational.cc
+++ b/src/rational.cc
@@ -99,3 +99,12 @@ Rational::Rational(const String& s)
     *this = RATIONAL_UNDEFINED;
   }
 }
+
+
+void Rational::simplify_in_place()
+{
+  Rational a = reduce_by_gcd(*this);
+  mnom = a.Nom();
+  mdenom = a.Denom();
+  fixSign();
+}

--- a/src/rational.h
+++ b/src/rational.h
@@ -67,6 +67,18 @@ class Rational {
     }
   }
   
+  /** Initialization call
+   * 
+   * Sets the rational from the string. Formats accepted are
+   * 
+   * Numeric:  1.234567890
+   * Fraction: 12345/67890
+   * Index:    1234567890
+   * 
+   * Note that overflow is possible and we do not care to capture it
+   * 
+   * @param[in] s String of the value
+   */
   Rational(const String& s);
 
   /** Nominator */

--- a/src/rational.h
+++ b/src/rational.h
@@ -86,6 +86,15 @@ class Rational {
 
   /** Denominator */
   constexpr Index Denom() const { return mdenom; }
+  
+  /** Nominator */
+  constexpr Index& Nom() { return mnom; }
+  
+  /** Denominator */
+  constexpr Index& Denom() { return mdenom; }
+  
+  /** Simplify by reducing the values locally */
+  void simplify_in_place();
 
   /** Is the object not defined
    * 
@@ -300,7 +309,7 @@ class Rational {
 constexpr Rational reduce_by_gcd(Rational a) {
   const Index div = gcd(a.Nom(), a.Denom());
   if (div)
-    return Rational(a.Nom() / div, a.Denom());
+    return Rational(a.Nom() / div, a.Denom() / div);
   else
     return a;
 }
@@ -683,3 +692,4 @@ constexpr bool even(Rational r) {
 }
 
 #endif  // rational_h
+


### PR DESCRIPTION
Since we are soon able to rely on python being there and working, I took some time to put together a class representation of the ARTS classes to be accessed via python.  A lot of static_cast(s) later and it seems to work.  I am not entirerly sure how to get this to run with the new python-interface (it does not build for me when I download the file) but it works with the equivalent typhon interface.  I attach a file for testing.  Ideally, there's a way to send the pointers to ARTS variables somehow but I have yet to figure that out how...  

The attached file shows the python interface that can access and manipulate all of these classes.  I for now just implemented everything required for AbsorptionLines, since it had no python interface anyways...

[testing.zip](https://github.com/atmtools/arts/files/4339040/testing.zip)
