### PR TITLE
Fix potential bug in iyActiveSingleScat2.

### DIFF
--- a/src/m_cloudradar.cc
+++ b/src/m_cloudradar.cc
@@ -1131,7 +1131,7 @@ void iyActiveSingleScat2(Workspace& ws,
       cumulative_backscatter_derivative(Pe, ppvar_dpnd_dx);
 
   lvl_rad[0] = iy0;
-  RadiationVector rad_inc{};
+  RadiationVector rad_inc = RadiationVector(nf, ns);
   rad_inc = iy0;
   set_backscatter_radiation_vector(lvl_rad,
                                    dlvl_rad,

--- a/src/m_cloudradar.cc
+++ b/src/m_cloudradar.cc
@@ -1131,8 +1131,11 @@ void iyActiveSingleScat2(Workspace& ws,
       cumulative_backscatter_derivative(Pe, ppvar_dpnd_dx);
 
   lvl_rad[0] = iy0;
+  RadiationVector rad_inc{};
+  rad_inc = iy0;
   set_backscatter_radiation_vector(lvl_rad,
                                    dlvl_rad,
+                                   rad_inc,
                                    lyr_tra,
                                    tot_tra_forward,
                                    tot_tra_reflect,
@@ -1141,6 +1144,7 @@ void iyActiveSingleScat2(Workspace& ws,
                                    dlyr_tra_below,
                                    dreflect_matrix,
                                    BackscatterSolver::CommutativeTransmission);
+
 
   // Size iy and set to zero
   iy.resize(nf * np, ns);  // iv*np + ip is the desired output order...

--- a/src/transmissionmatrix.cc
+++ b/src/transmissionmatrix.cc
@@ -1538,6 +1538,7 @@ ArrayOfTransmissionMatrix cumulative_transmission(
 void set_backscatter_radiation_vector(
     ArrayOfRadiationVector& I,
     ArrayOfArrayOfArrayOfRadiationVector& dI,
+    const RadiationVector &I_incoming,
     const ArrayOfTransmissionMatrix& T,
     const ArrayOfTransmissionMatrix& PiTf,
     const ArrayOfTransmissionMatrix& PiTr,
@@ -1552,10 +1553,10 @@ void set_backscatter_radiation_vector(
   const Index nq = np ? dI[0][0].nelem() : 0;
   
   // For all transmission, the I-vector is the same
-  for (Index ip = 1; ip < np; ip++)
-    I[ip].setBackscatterTransmission(I[0], PiTr[ip], PiTf[ip], Z[ip]);
+  for (Index ip = 0; ip < np; ip++)
+    I[ip].setBackscatterTransmission(I_incoming, PiTr[ip], PiTf[ip], Z[ip]);
   
-  for (Index ip = 1; ip < np; ip++) {
+  for (Index ip = 0; ip < np; ip++) {
     for (Index iq = 0; iq < nq; iq++) {
       dI[ip][ip][iq].setBackscatterTransmissionDerivative(
         I[0], PiTr[ip], PiTf[ip], dZ[ip][iq]);
@@ -1568,7 +1569,7 @@ void set_backscatter_radiation_vector(
       switch(ns) { 
         case 1: {
           BackscatterSolverCommutativeTransmissionStokesDimOne:
-          for (Index ip = 1; ip < np; ip++) {
+          for (Index ip = 0; ip < np; ip++) {
             for (Index j = ip; j < np; j++) {
               for (Index iq = 0; iq < nq; iq++) {
                 for (Index iv = 0; iv < nv; iv++) {
@@ -1588,7 +1589,7 @@ void set_backscatter_radiation_vector(
           }
         } break;
         case 2: {
-          for (Index ip = 1; ip < np; ip++) {
+          for (Index ip = 0; ip < np; ip++) {
             for (Index j = ip; j < np; j++) {
               for (Index iq = 0; iq < nq; iq++) {
                 for (Index iv = 0; iv < nv; iv++) {
@@ -1608,7 +1609,7 @@ void set_backscatter_radiation_vector(
           }
         } break;
         case 3: {
-          for (Index ip = 1; ip < np; ip++) {
+          for (Index ip = 0; ip < np; ip++) {
             for (Index j = ip; j < np; j++) {
               for (Index iq = 0; iq < nq; iq++) {
                 for (Index iv = 0; iv < nv; iv++) {
@@ -1628,7 +1629,7 @@ void set_backscatter_radiation_vector(
           }
         } break;
         case 4: {
-          for (Index ip = 1; ip < np; ip++) {
+          for (Index ip = 0; ip < np; ip++) {
             for (Index j = ip; j < np; j++) {
               for (Index iq = 0; iq < nq; iq++) {
                 for (Index iv = 0; iv < nv; iv++) {
@@ -1657,7 +1658,7 @@ void set_backscatter_radiation_vector(
           goto BackscatterSolverCommutativeTransmissionStokesDimOne;
         } break;
         case 2: {
-          for (Index ip = 1; ip < np; ip++) {
+          for (Index ip = 0; ip < np; ip++) {
             for (Index j = ip; j < np; j++) {
               for (Index iq = 0; iq < nq; iq++) {
                 for (Index iv = 0; iv < nv; iv++) {

--- a/src/transmissionmatrix.cc
+++ b/src/transmissionmatrix.cc
@@ -1559,7 +1559,7 @@ void set_backscatter_radiation_vector(
   for (Index ip = 0; ip < np; ip++) {
     for (Index iq = 0; iq < nq; iq++) {
       dI[ip][ip][iq].setBackscatterTransmissionDerivative(
-        I[0], PiTr[ip], PiTf[ip], dZ[ip][iq]);
+        I_incoming, PiTr[ip], PiTf[ip], dZ[ip][iq]);
     }
   }
   

--- a/src/transmissionmatrix.h
+++ b/src/transmissionmatrix.h
@@ -973,6 +973,7 @@ ArrayOfTransmissionMatrix cumulative_transmission(
  * 
  * @param[in,out] I Radiation vector of all layers
  * @param[in,out] dI Radiation vector derivative of all layers
+ * @param[in] I_incoming Incoming radiation vector
  * @param[in] T Transmission matrix of all layers
  * @param[in] PiTf Forwards accumulated transmission of all layers
  * @param[in] PiTr Backwards accumulated transmission of all layers
@@ -985,6 +986,7 @@ ArrayOfTransmissionMatrix cumulative_transmission(
 void set_backscatter_radiation_vector(
     ArrayOfRadiationVector& I,
     ArrayOfArrayOfArrayOfRadiationVector& dI,
+    const RadiationVector & I_incoming,
     const ArrayOfTransmissionMatrix& T,
     const ArrayOfTransmissionMatrix& PiTf,
     const ArrayOfTransmissionMatrix& PiTr,


### PR DESCRIPTION
I think that setting lvl_rad[0] = iy0 is incorrect because this is the incoming irradiance, while lvl_rad should hold the backscattered irradiance. This led to the backscatter associated with the first layer always being 1. This PR fixes this, please check if it makes sense.