### PR TITLE
Improve error message for missing Python packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,17 +55,7 @@ set(Python_ADDITIONAL_VERSIONS 3)
 find_package (PythonInterp REQUIRED)
 
 include (CheckPythonModule)
-set(REQUIRED_MODULES
-  docutils
-  lark
-  matplotlib
-  netCDF4
-  numpy
-  pytest
-  scipy
-  setuptools
-  )
-check_python_modules("${REQUIRED_MODULES}")
+check_python_modules()
 
 if (ENABLE_FORTRAN)
   enable_language (Fortran)

--- a/cmake/modules/CheckPythonModule.cmake
+++ b/cmake/modules/CheckPythonModule.cmake
@@ -5,7 +5,7 @@
 macro (CHECK_PYTHON_MODULES)
   set(REQUIRED_MODULES
     docutils
-    lark
+    lark.parse_tree_builder
     matplotlib
     netCDF4
     numpy

--- a/cmake/modules/CheckPythonModule.cmake
+++ b/cmake/modules/CheckPythonModule.cmake
@@ -2,8 +2,34 @@
 #
 # Copyright (c) 2020, Oliver Lemke, <oliver.lemke@uni-hamburg.de>
 
-macro (CHECK_PYTHON_MODULES MODULES)
-  foreach(MODULENAME ${MODULES})
+macro (CHECK_PYTHON_MODULES)
+  set(REQUIRED_MODULES
+    docutils
+    lark
+    matplotlib
+    netCDF4
+    numpy
+    pytest
+    scipy
+    setuptools)
+
+  set(PYPI_NAMES
+    docutils
+    lark-parser
+    matplotlib
+    netCDF4
+    numpy
+    pytest
+    scipy
+    setuptools)
+
+  list(LENGTH REQUIRED_MODULES len1)
+  math(EXPR len2 "${len1} - 1")
+
+  set(PYPIERROR 0)
+  foreach(i RANGE ${len2})
+    list(GET REQUIRED_MODULES ${i} MODULENAME)
+    list(GET PYPI_NAMES ${i} PYPINAME)
     execute_process(
       COMMAND "${PYTHON_EXECUTABLE}" "-c" "import ${MODULENAME}"
       RESULT_VARIABLE MODULE_FOUND
@@ -11,11 +37,13 @@ macro (CHECK_PYTHON_MODULES MODULES)
       OUTPUT_STRIP_TRAILING_WHITESPACE
       )
     if(NOT MODULE_FOUND EQUAL 0)
-      message(FATAL_ERROR
-        "Required Python module ${MODULENAME} not found. Please install it.\n"
-        "ARTS requires: ${MODULES}\n"
-        "Note that the lark module is provided by the lark-parser package.")
+      string(REPLACE ";" " " PYPILIST "${PYPI_NAMES}")
+      message(STATUS "ERROR: Required Python package not found: ${PYPINAME}\n")
+      set(PYPIERROR 1)
     endif()
   endforeach()
 
+  if(PYPIERROR)
+    message(FATAL_ERROR "Please install the missing Python package(s)")
+  endif()
 endmacro()


### PR DESCRIPTION
Error message for missing packages now looks like this:
```
cmake .. 
-- The C compiler identification is GNU 9.2.1
-- The CXX compiler identification is GNU 9.2.1
[SNIP]
-- Found PythonInterp: /home/olemke/anaconda3/bin/python3 (found version "3.7.6") 
-- ERROR: Required Python package not found: docutils

-- ERROR: Required Python package not found: lark-parser

-- ERROR: Required Python package not found: matplotlib

-- ERROR: Required Python package not found: numpy

CMake Error at cmake/modules/CheckPythonModule.cmake:47 (message):
  Please install the missing Python package(s)
Call Stack (most recent call first):
  CMakeLists.txt:58 (check_python_modules)


-- Configuring incomplete, errors occurred!
See also "/home/olemke/Hacking/uhh/arts/build/CMakeFiles/CMakeOutput.log".
