### PR TITLE
Test implementation of weighted RT emission

### DIFF
--- a/src/transmissionmatrix.cc
+++ b/src/transmissionmatrix.cc
@@ -1511,6 +1511,13 @@ void update_radiation_vector(RadiationVector& I,
       }
       I.leftMul(T);
     } break;
+    
+    case RadiativeTransferSolver::WeightedEmission: {
+      I.rem_weighted(J1, J2, T);
+      /* ADD DERIVATIVES */
+      I.leftMul(T);
+      I.add_weighted(J1, J2, T);
+    } break;
   }
 }
 


### PR DESCRIPTION
@erikssonpatrick This is the code I talked about.  It is just tested to run and not for the physics being good.  Some test code to make this work is required to figure out if it is even remotely good.

Change this in m_rte.cc to test the new code "RadiativeTransferSolver::Emission"  → "RadiativeTransferSolver::WeightedEmission".  It does not pass the tests, but it does pass several tests that do use the iyEmissionStandard code when you do the this change.