### PR TITLE
Remove test conversion from all target

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -49,7 +49,6 @@ add_custom_target(pyarts
   COMMENT "Building ARTS python package.")
 set(CONTROLFILE_DIR ${CMAKE_SOURCE_DIR}/controlfiles)
 add_custom_target(python_tests
-  ALL
   COMMAND PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR} ${PYTHON_EXECUTABLE} bin/arts_convert.py ${CONTROLFILE_DIR} -o controlfiles
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS pyarts


### PR DESCRIPTION
No need to do the controlfile to Python conversion on every invocation of make (all).