### PR TITLE
Interpolation fo cloudbox field

### DIFF
--- a/controlfiles/artscomponents/heatingrates/TestSpectralRadianceField.arts
+++ b/controlfiles/artscomponents/heatingrates/TestSpectralRadianceField.arts
@@ -128,7 +128,7 @@ scat_data_checkedCalc
 # Run DISORT and use a third method
 #
 DisortCalc( nstreams = 8 )
-Copy( iy_cloudbox_agenda, iy_cloudbox_agenda__QuadInterpField1D )
+Copy( iy_cloudbox_agenda, iy_cloudbox_agenda__QuarticInterpField )
 spectral_radiance_fieldExpandCloudboxField
 #WriteXML( "binary", spectral_radiance_field, "f3.xml" )
 Compare( ref_field, spectral_radiance_field, 2e-18 )

--- a/controlfiles/artscomponents/scatsolvercomp/TestScatSolvers.arts
+++ b/controlfiles/artscomponents/scatsolvercomp/TestScatSolvers.arts
@@ -27,7 +27,7 @@ Copy( ppath_agenda, ppath_agenda__FollowSensorLosPath )
 Copy( iy_main_agenda, iy_main_agenda__Emission )
 Copy( iy_space_agenda, iy_space_agenda__CosmicBackground )
 Copy( iy_surface_agenda, iy_surface_agenda__UseSurfaceRtprop )
-Copy( iy_cloudbox_agenda,  iy_cloudbox_agenda__QuadInterpField1D )
+Copy( iy_cloudbox_agenda,  iy_cloudbox_agenda__QuarticInterpField )
 
 # Absorption species
 abs_speciesSet( species=[ "N2-SelfContStandardType",

--- a/controlfiles/artscomponents/scatsolvercomp/TestScatSolvers_fast.arts
+++ b/controlfiles/artscomponents/scatsolvercomp/TestScatSolvers_fast.arts
@@ -28,7 +28,7 @@ Copy( ppath_agenda, ppath_agenda__FollowSensorLosPath )
 Copy( iy_main_agenda, iy_main_agenda__Emission )
 Copy( iy_space_agenda, iy_space_agenda__CosmicBackground )
 Copy( iy_surface_agenda, iy_surface_agenda__UseSurfaceRtprop )
-Copy( iy_cloudbox_agenda,  iy_cloudbox_agenda__QuadInterpField1D )
+Copy( iy_cloudbox_agenda,  iy_cloudbox_agenda__QuarticInterpField )
 
 # Absorption species
 abs_speciesSet( species=[ "N2-SelfContStandardType",

--- a/controlfiles/general/agendas.arts
+++ b/controlfiles/general/agendas.arts
@@ -157,10 +157,10 @@ AgendaSet( iy_cloudbox_agenda__LinInterpField ){
 }
 
 ###
-# quadratic interpolation of the intensity field of the cloud box
+# quartic interpolation of the intensity field of the cloud box
 #
-AgendaCreate( iy_cloudbox_agenda__QuadInterpField1D )
-AgendaSet( iy_cloudbox_agenda__QuadInterpField1D ){
+AgendaCreate( iy_cloudbox_agenda__QuarticInterpField )
+AgendaSet( iy_cloudbox_agenda__QuarticInterpField ){
   iyInterpCloudboxField( za_interp_order = 4 )
 }
 

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -8082,7 +8082,7 @@ void define_md_data_raw() {
           "za_extpolfac",
           "aa_interp_order"),
       GIN_TYPE("Index", "Index", "Index", "Numeric", "Index"),
-      GIN_DEFAULT("1", "0", "0", "0.5", "1"),
+      GIN_DEFAULT("1", "1", "0", "0.5", "1"),
       GIN_DESC("Zenith angle interpolation order.",
                "Flag whether to restric zenith angle interpolation to one"
                " hemisphere.",

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -8084,8 +8084,8 @@ void define_md_data_raw() {
       GIN_TYPE("Index", "Index", "Index", "Numeric", "Index"),
       GIN_DEFAULT("1", "1", "0", "0.5", "1"),
       GIN_DESC("Zenith angle interpolation order.",
-               "Flag whether to restric zenith angle interpolation to one"
-               " hemisphere.",
+               "Flag whether to restric zenith angle interpolation to one "
+               "hemisphere.",
                "Flag whether to do zenith angle interpolation in cosine space.",
                "Maximum allowed extrapolation range in zenith angle.",
                "Azimuth angle interpolation order.")));


### PR DESCRIPTION
This fixes some old mistakes from a commit in Oct 2019. Most importantly changing back the default for za_restrict fixes that results now are consistent with ones from the SVN time. Anyhow, za_restrict=1 is clearly the better option for default.