### PR TITLE
Fix bug in abs_lines_per_speciesCreateFromLines

### DIFF
--- a/src/m_abs.cc
+++ b/src/m_abs.cc
@@ -95,7 +95,12 @@ void abs_lines_per_speciesCreateFromLines(  // WS Output:
     const Verbosity&) {
   // Size is set but inner size will now change from the original definition of species tags...
   abs_lines_per_species.resize(tgs.nelem());
-  
+
+  // The inner arrays need to be emptied, because they may contain lines
+  // from a previous calculation
+  for (auto &tg : abs_lines_per_species)
+    tg.resize(0);
+
   // Take copies because we have to support frequency ranges, so might have to delete
   for (AbsorptionLines lines: abs_lines) {
     


### PR DESCRIPTION
The contents of the WSV was not emptied. When the WSM was called
multiple times in the same controlfiles, this led to duplicate lines
being present in abs_lines_per_species.

The bug was only showing in Release mode, because output-only variables are
zeroed before use in Debug mode.

This fixes all failing lineshape tests in Release mode.