### PR TITLE
Prefer OpenBLAS

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -112,7 +112,7 @@ jobs:
             sudo apt-get install -y texlive
           fi
 
-          sudo apt-get install -y python3-minimal python3-pip python3-setuptools zlib1g-dev libblas-dev liblapack-dev libfftw3-dev
+          sudo apt-get install -y python3-minimal python3-pip python3-setuptools zlib1g-dev libopenblas-dev libfftw3-dev
           sudo pip3 install docutils lark-parser matplotlib netCDF4 numpy pytest scipy
 
       - name: Setup (macOS)

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ Build Prerequisites:
 - gcc/g++ >=8 (or llvm/clang >=8) older versions might work, but are untested
 - cmake (>=3.1.0)
 - zlib
-- blas
-- lapack
+- openblas
 - netcdf (optional)
 - Python3 (>=3.6)
   - required modules:

--- a/cmake/modules/FindLAPACK.cmake
+++ b/cmake/modules/FindLAPACK.cmake
@@ -370,5 +370,10 @@ else()
  endif()
 endif()
 
+if(NOT APPLE AND NOT LAPACK_LIBRARIES MATCHES "libopenblas")
+  message(WARNING "Non-OpenBLAS LAPACK library detected. "
+          "We recommend to use OpenBLAS instead.")
+endif()
+
 cmake_pop_check_state()
 set(CMAKE_FIND_LIBRARY_SUFFIXES ${_lapack_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})


### PR DESCRIPTION
Make OpenBLAS the preferred LAPACK variant for ARTS. Other libraries can still be used, but trigger a warning on Linux.

Fixes #168.