### PR TITLE
Increase fetch depth to 10

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
         with:
-          fetch-depth: 1
+          fetch-depth: 10
 
       - name: Setup (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
Build actions can fail on quick successive updates with fetch depth 1.