### PR TITLE
Add missing no-docserver guard

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -808,7 +808,7 @@ int main(int argc, char** argv) {
 
   // Now we are set to deal with the more interesting command line
   // switches.
-
+#ifdef ENABLE_DOCSERVER
   if (parameters.check_docs) {
     // Check built-in docs and then exit
     const auto broken_links = Docserver::list_broken_description_links();
@@ -821,6 +821,7 @@ int main(int argc, char** argv) {
               << " found." << std::endl;
     arts_exit(nbroken ? EXIT_FAILURE : EXIT_SUCCESS);
   }
+#endif
 
   // React to option `methods'. If given the argument `all', it
   // should simply prints a list of all methods. If given the name of

--- a/src/parameters.cc
+++ b/src/parameters.cc
@@ -116,7 +116,9 @@ bool get_parameters(int argc, char **argv) {
   */
   struct option longopts[] = {
       {"basename", required_argument, NULL, 'b'},
+#ifdef ENABLE_DOCSERVER
       {"check-docs", no_argument, NULL, 'C'},
+#endif
       {"describe", required_argument, NULL, 'd'},
       {"groups", no_argument, NULL, 'g'},
       {"help", no_argument, NULL, 'h'},
@@ -217,8 +219,11 @@ bool get_parameters(int argc, char **argv) {
       "                    it simply prints a list of all variables.\n"
       "                    If it is given the name of a method, it\n"
       "                    prints all variables needed by this method.\n"
+#ifdef ENABLE_DOCSERVER
       "\nDEVELOPER ONLY:\n\n"
-      "-C, --check-docs    Check for broken links in built-in docs.\n";
+      "-C, --check-docs    Check for broken links in built-in docs.\n"
+#endif
+      ;
 
   // Set the short options automatically from the last columns of
   // longopts.


### PR DESCRIPTION
I tried to get rid of the GhostScript error mess so that I can read true compile errors instead of nonsense errors but disabling docserver did not help...

Found this bug though!