### PR TITLE
Peak of lorentz function was off by 1 index

### DIFF
--- a/src/hitran_xsec.cc
+++ b/src/hitran_xsec.cc
@@ -282,7 +282,7 @@ void XsecRecord::Extract(VectorView result,
       for (Index i = 0; i < data_f_extent; i++) {
         f_lorentz[i] =
             lorentz_pdf(data_f_grid[i_data_fstart + i],
-                        data_f_grid[i_data_fstart + data_f_extent / 2],
+                        data_f_grid[i_data_fstart + data_f_extent / 2 - 1],
                         fwhm / 2.);
         lsum += f_lorentz[i];
       }


### PR DESCRIPTION
The slight shift in the broadened spectrum led to high RMSE errors when compared to a reference spectrum.