### PR TITLE
Add check that each new class in ARTS can be used by pyarts.classes

### DIFF
--- a/controlfiles-python/CMakeLists.txt
+++ b/controlfiles-python/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 ###########################
 ### Python Test Example ###
+arts_test_run_pyfile(fast classes/TestIfClassExists.py)
 arts_test_run_pyfile(fast example/TestExample.py)
 arts_test_run_pyfile(fast classes/TestEnergyLevelMap.py)
 arts_test_run_pyfile(fast classes/TestBasicTypes.py)
@@ -20,6 +21,7 @@ arts_test_run_pyfile(fast classes/TestTessemNN.py)
 arts_test_run_pyfile(fast classes/TestTime.py)
 arts_test_run_pyfile(fast classes/TestTimer.py)
 arts_test_run_pyfile(fast classes/TestXsecRecord.py)
+
 arts_test_run_pyfile(fast raw/calib.py)
 arts_test_run_pyfile(fast raw/corr.py)
 

--- a/controlfiles-python/classes/TestIfClassExists.py
+++ b/controlfiles-python/classes/TestIfClassExists.py
@@ -1,0 +1,39 @@
+import pyarts
+
+
+list_of_groups = pyarts.classes.list_of_workspace_variables()
+for group in list_of_groups:
+    try:
+        if group in ["Index", "Numeric", "String"]:
+            eval("pyarts.classes.{}(1)".format(group.val))
+        else:
+            eval("pyarts.classes.{}()".format(group.val))
+    except:
+        raise ImportError("Cannot use {} in pyarts.classes".format(group))
+
+
+"""
+Note to developer encountering this error.  All workspace classes in ARTS
+should be available in pyarts.  You have probably added a new group.  Unless
+your group is special and have different initialization in different build
+modes (as indicated by the list of special groups above) you need to be able
+to evaluate "pyarts.classes.YOURGROUP()" to show that the new group works in
+pyarts.
+
+The easiest way to add your new group is to look at one of the python/classes/*
+examples and copy it (python class + C-API).  Furthermore, in 
+python/classes/__init__.py, your new class should be imported.  Any subclass
+you want can be supported in this manner as well.  All classes added this way
+should preferably have a TestYOURGROUP.py file in controlfiles-python/classes/,
+Subclasses can be tested here as well.
+
+In C++, you will also need to create the C-interface.  There are plenty of
+helper macros available in arts_api_classes.h/cc to facilitate this addition,
+but depending on your class you might have to do more to make some of the
+internals work.  Be careful, since setting a python class with "void *"
+pointers might mean that it is a true reference, we can only actually delete
+the C-data when we know it is not such a reference.  Functions that return
+"void *" pointers must thus manually manage memory, which is a great annoyance.
+
+Anyways... With hope, and take care!
+"""

--- a/python/pyarts/classes/__init__.py
+++ b/python/pyarts/classes/__init__.py
@@ -79,3 +79,11 @@ def from_workspace(x):
 
 lib.get_variable_data_pointer.restype = c.c_void_p
 lib.get_variable_data_pointer.argtypes = [c.c_void_p, c.c_long]
+
+def list_of_workspace_variables():
+    x = ArrayOfString(c.c_void_p(lib.get_list_of_all_workspace_classes()))
+    x.__delete__ = True
+    return x
+
+lib.get_list_of_all_workspace_classes.restype = c.c_void_p
+lib.get_list_of_all_workspace_classes.argtypes = []

--- a/src/arts_api_classes.cc
+++ b/src/arts_api_classes.cc
@@ -1267,10 +1267,9 @@ VoidStructGetterCAPI(HitranRelaxationMatrixData, W0pp)
 VoidStructGetterCAPI(HitranRelaxationMatrixData, B0pp)
 
 
-
 // generic
 Index string2filetypeindex(char * data) { try { return Index(string2filetype(data)); } catch (std::runtime_error& e) { return -1; } }
-
+void * get_list_of_all_workspace_classes() { return new ArrayOfString{global_data::wsv_group_names}; }
 
 #undef BasicInterfaceCAPI
 #undef GetterSetterCAPI

--- a/src/arts_api_classes.h
+++ b/src/arts_api_classes.h
@@ -890,6 +890,7 @@ extern "C" {
     
     // generic
     DLL_PUBLIC Index string2filetypeindex(char *);
+    DLL_PUBLIC void * get_list_of_all_workspace_classes();
 }
 
 


### PR DESCRIPTION
This is a very small addition.  The TestIfClassExists.py file simply wants to initialize the ARTS class.  If it fails it throws a warning so that test-pyarts-only will fail.  I get the classes directly from global_data::wsv_group_names, so it will warn for future updates that might add more classes to ARTS workspace.