### PR TITLE
Make ARTS even more linkable

### DIFF
--- a/src/m_append.h
+++ b/src/m_append.h
@@ -82,7 +82,7 @@ void Append(  // WS Generic Output:
 }
 
 /* Implementation for array types to append single element */
-void Append(Workspace& ws,
+inline void Append(Workspace& ws,
             // WS Generic Output:
             ArrayOfAgenda& out,
             const String& out_name,
@@ -99,7 +99,7 @@ void Append(Workspace& ws,
 }
 
 /* Implementation for array types to append single element */
-void Append(Workspace& ws,
+inline void Append(Workspace& ws,
             // WS Generic Output:
             ArrayOfAgenda& out,
             const String& out_name,
@@ -118,7 +118,7 @@ void Append(Workspace& ws,
 }
 
 /* Implementation for Vector */
-void Append(  // WS Generic Output:
+inline void Append(  // WS Generic Output:
     Vector& out,
     const String& /* out_name */,
     // WS Generic Input:
@@ -152,7 +152,7 @@ void Append(  // WS Generic Output:
 }
 
 /* Implementation for Matrix */
-void Append(  // WS Generic Output:
+inline void Append(  // WS Generic Output:
     Matrix& out,
     const String& /* out_name */,
     // WS Generic Input:
@@ -207,7 +207,7 @@ void Append(  // WS Generic Output:
 }
 
 /* Implementation for Matrix/Vector */
-void Append(  // WS Generic Output:
+inline void Append(  // WS Generic Output:
     Matrix& out,
     const String& /* out_name */,
     // WS Generic Input:
@@ -251,7 +251,7 @@ void Append(  // WS Generic Output:
 }
 
 /* Implementation for Vector/Numeric */
-void Append(  // WS Generic Output:
+inline void Append(  // WS Generic Output:
     Vector& out,
     const String& /* out_name */,
     // WS Generic Input:
@@ -274,7 +274,7 @@ void Append(  // WS Generic Output:
 }
 
 /* Implementation for Tensor3/Matrix */
-void Append(  // WS Generic Output:
+inline void Append(  // WS Generic Output:
     Tensor3& out,
     const String& /* out_name */,
     // WS Generic Input:
@@ -305,7 +305,7 @@ void Append(  // WS Generic Output:
 }
 
 /* Implementation for Tensor3 */
-void Append(  // WS Generic Output:
+inline void Append(  // WS Generic Output:
     Tensor3& out,
     const String& /* out_name */,
     // WS Generic Input:
@@ -348,7 +348,7 @@ void Append(  // WS Generic Output:
 }
 
 /* Implementation for Tensor4/Tensor3 */
-void Append(  // WS Generic Output:
+inline void Append(  // WS Generic Output:
     Tensor4& out,
     const String& /* out_name */,
     // WS Generic Input:
@@ -385,7 +385,7 @@ void Append(  // WS Generic Output:
 }
 
 /* Implementation for Tensor4 */
-void Append(  // WS Generic Output:
+inline void Append(  // WS Generic Output:
     Tensor4& out,
     const String& /* out_name */,
     // WS Generic Input:
@@ -435,7 +435,7 @@ void Append(  // WS Generic Output:
 }
 
 /* Implementation for String */
-void Append(  // WS Generic Output:
+inline void Append(  // WS Generic Output:
     String& out,
     const String& /* out_name */,
     // WS Generic Input:

--- a/src/m_basic_types.h
+++ b/src/m_basic_types.h
@@ -72,7 +72,7 @@ TMPL_NGET_GENERIC(nlibraries)
 #undef TMPL_NGET_GENERIC
 
 #define TMPL_NGET_AGENDA(what)                                                 \
-  void what##Get(Workspace& ws _U_, Index&, const Agenda&, const Verbosity&) { \
+inline void what##Get(Workspace& ws _U_, Index&, const Agenda&, const Verbosity&) { \
     ostringstream os;                                                          \
     os << "The variable has no such attribute.\n";                             \
     throw runtime_error(os.str());                                             \
@@ -103,12 +103,12 @@ void IndexSetToLast(Index&, const T&, const Verbosity&) {
 // value of the requested attribute.
 
 #define NGET_GENERIC(what, type)                                 \
-  void what##Get(Index& what, const type& x, const Verbosity&) { \
+inline void what##Get(Index& what, const type& x, const Verbosity&) { \
     what = x.what();                                             \
   }
 
 #define SET_TO_LAST_GENERIC(type)                                  \
-  void IndexSetToLast(Index& i, const type& x, const Verbosity&) { \
+inline void IndexSetToLast(Index& i, const type& x, const Verbosity&) { \
     i = x.nelem() - 1;                                             \
   }
 
@@ -225,14 +225,14 @@ NGET_GENERIC(nlibraries, Tensor7)
 #undef NGET_GENERIC
 #undef SET_TO_LAST_GENERIC
 
-void nelemGet(Workspace& /* ws */,
+inline void nelemGet(Workspace& /* ws */,
               Index& nelem,
               const ArrayOfAgenda& x,
               const Verbosity&) {
   nelem = x.nelem();
 }
 
-void IndexSetToLast(Workspace& /* ws */,
+inline void IndexSetToLast(Workspace& /* ws */,
                     Index& nelem,
                     const ArrayOfAgenda& x,
                     const Verbosity&) {

--- a/src/m_conversion.h
+++ b/src/m_conversion.h
@@ -31,7 +31,7 @@ extern const Numeric SPEED_OF_LIGHT;
 extern const Numeric PI;
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void FrequencyFromWavelength(  // WS Generic Output
+inline void FrequencyFromWavelength(  // WS Generic Output
     Numeric& frequency,
     // WS Generic Input
     const Numeric& wavelength,
@@ -41,7 +41,7 @@ void FrequencyFromWavelength(  // WS Generic Output
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void FrequencyFromWavelength(  // WS Generic Output
+inline void FrequencyFromWavelength(  // WS Generic Output
     Vector& frequency,
     // WS Generic Input
     const Vector& wavelength,
@@ -53,7 +53,7 @@ void FrequencyFromWavelength(  // WS Generic Output
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void FrequencyFromCGSAngularWavenumber(  // WS Generic Output
+inline void FrequencyFromCGSAngularWavenumber(  // WS Generic Output
     Numeric& frequency,
     // WS Generic Input
     const Numeric& angular_wavenumber,
@@ -62,7 +62,7 @@ void FrequencyFromCGSAngularWavenumber(  // WS Generic Output
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void FrequencyFromCGSAngularWavenumber(  // WS Generic Output
+inline void FrequencyFromCGSAngularWavenumber(  // WS Generic Output
     Vector& frequency,
     // WS Generic Input
     const Vector& angular_wavenumber,
@@ -74,7 +74,7 @@ void FrequencyFromCGSAngularWavenumber(  // WS Generic Output
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void FrequencyFromCGSKayserWavenumber(  // WS Generic Output
+inline void FrequencyFromCGSKayserWavenumber(  // WS Generic Output
     Numeric& frequency,
     // WS Generic Input
     const Numeric& kayser_wavenumber,
@@ -83,7 +83,7 @@ void FrequencyFromCGSKayserWavenumber(  // WS Generic Output
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void FrequencyFromCGSKayserWavenumber(  // WS Generic Output
+inline void FrequencyFromCGSKayserWavenumber(  // WS Generic Output
     Vector& frequency,
     // WS Generic Input
     const Vector& kayser_wavenumber,

--- a/src/m_copy.h
+++ b/src/m_copy.h
@@ -47,7 +47,7 @@ void Copy(  // WS Generic Output:
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Copy(Workspace& ws,
+inline void Copy(Workspace& ws,
           // WS Generic Output:
           Agenda& out,
           const String& out_name,
@@ -61,7 +61,7 @@ void Copy(Workspace& ws,
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Copy(Workspace& ws,
+inline void Copy(Workspace& ws,
           // WS Generic Output:
           ArrayOfAgenda& out,
           const String& out_name,

--- a/src/m_extract.h
+++ b/src/m_extract.h
@@ -59,7 +59,7 @@ void Extract(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void ArrayOfIndexExtractFromArrayOfArrayOfIndex(
+inline void ArrayOfIndexExtractFromArrayOfArrayOfIndex(
     // WS Generic Output:
     ArrayOfIndex& aoi,
     // WS Input:
@@ -78,7 +78,7 @@ void ArrayOfIndexExtractFromArrayOfArrayOfIndex(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Extract(
+inline void Extract(
     // WS Generic Output:
     Numeric& n,
     // WS Input:
@@ -96,7 +96,7 @@ void Extract(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Extract(
+inline void Extract(
     // WS Generic Output:
     Matrix& m,
     // WS Input:
@@ -114,7 +114,7 @@ void Extract(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Extract(
+inline void Extract(
     // WS Generic Output:
     Tensor3& t3,
     // WS Input:
@@ -133,7 +133,7 @@ void Extract(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Extract(
+inline void Extract(
     // WS Generic Output:
     Tensor4& t4,
     // WS Input:
@@ -156,7 +156,7 @@ void Extract(
    Implementation largely copied from Patrick's MatrixExtractFromTensor3 method. 
 
    2007-10-26 Oliver Lemke */
-void Extract(
+inline void Extract(
     // WS Generic Output:
     ArrayOfGriddedField3& agf,
     // WS Input:
@@ -180,7 +180,7 @@ void Extract(
    Implementation largely copied from MatrixExtractFromArrayOfMatrix.
 
    2007-11-26 Stefan Buehler */
-void Extract(
+inline void Extract(
     // WS Generic Output:
     GriddedField4& m,
     // WS Input:
@@ -201,7 +201,7 @@ void Extract(
   m = agf4[index];
 }
 
-void Extract(
+inline void Extract(
     // WS Generic Output:
     QuantumIdentifier& qi,
     // WS Input:

--- a/src/m_ignore.h
+++ b/src/m_ignore.h
@@ -36,13 +36,13 @@
 #include "workspace_ng.h"
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Ignore(Workspace&,
+inline void Ignore(Workspace&,
             // WS Generic Input:
             const Agenda&,
             const Verbosity&) {}
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Ignore(Workspace&,
+inline void Ignore(Workspace&,
             // WS Generic Input:
             const ArrayOfAgenda&,
             const Verbosity&) {}
@@ -54,7 +54,7 @@ void Ignore(  // WS Generic Input:
     const Verbosity&) {}
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Touch(Workspace&,
+inline void Touch(Workspace&,
            // WS Generic Output:
            Agenda&,
            const Verbosity&) {}

--- a/src/m_nc.h
+++ b/src/m_nc.h
@@ -158,7 +158,7 @@ void ReadNetCDF(Workspace& ws _U_,
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void WriteNetCDF(Workspace& ws _U_,
+inline void WriteNetCDF(Workspace& ws _U_,
                  // WS Generic Input:
                  const Agenda& v,
                  const String& f,

--- a/src/m_reduce.h
+++ b/src/m_reduce.h
@@ -37,7 +37,7 @@
 
 //////// Helper function /////////
 
-Index num_elem_from_dim_sizes(const ArrayOfIndex& dim_sizes) {
+inline Index num_elem_from_dim_sizes(const ArrayOfIndex& dim_sizes) {
   Index m = 1;
   for (ArrayOfIndex::const_iterator it = dim_sizes.begin();
        it != dim_sizes.end();
@@ -48,7 +48,7 @@ Index num_elem_from_dim_sizes(const ArrayOfIndex& dim_sizes) {
 }
 
 // Need this for each matpack type: Vector
-void select_dims_by_size(ArrayOfIndex& dim_sizes,
+inline void select_dims_by_size(ArrayOfIndex& dim_sizes,
                          const Index min_num_elem,
                          const Vector& type) {
   dim_sizes.resize(0);
@@ -56,7 +56,7 @@ void select_dims_by_size(ArrayOfIndex& dim_sizes,
 }
 
 // Need this for each matpack type: Matrix
-void select_dims_by_size(ArrayOfIndex& dim_sizes,
+inline void select_dims_by_size(ArrayOfIndex& dim_sizes,
                          const Index min_num_elem,
                          const Matrix& type) {
   dim_sizes.resize(0);
@@ -65,7 +65,7 @@ void select_dims_by_size(ArrayOfIndex& dim_sizes,
 }
 
 // Need this for each matpack type: Tensor3
-void select_dims_by_size(ArrayOfIndex& dim_sizes,
+inline void select_dims_by_size(ArrayOfIndex& dim_sizes,
                          const Index min_num_elem,
                          const Tensor3& type) {
   dim_sizes.resize(0);
@@ -75,7 +75,7 @@ void select_dims_by_size(ArrayOfIndex& dim_sizes,
 }
 
 // Need this for each matpack type: Tensor4
-void select_dims_by_size(ArrayOfIndex& dim_sizes,
+inline void select_dims_by_size(ArrayOfIndex& dim_sizes,
                          const Index min_num_elem,
                          const Tensor4& type) {
   dim_sizes.resize(0);
@@ -86,7 +86,7 @@ void select_dims_by_size(ArrayOfIndex& dim_sizes,
 }
 
 // Need this for each matpack type: Tensor5
-void select_dims_by_size(ArrayOfIndex& dim_sizes,
+inline void select_dims_by_size(ArrayOfIndex& dim_sizes,
                          const Index min_num_elem,
                          const Tensor5& type) {
   dim_sizes.resize(0);
@@ -98,7 +98,7 @@ void select_dims_by_size(ArrayOfIndex& dim_sizes,
 }
 
 // Need this for each matpack type: Tensor6
-void select_dims_by_size(ArrayOfIndex& dim_sizes,
+inline void select_dims_by_size(ArrayOfIndex& dim_sizes,
                          const Index min_num_elem,
                          const Tensor6& type) {
   dim_sizes.resize(0);
@@ -111,7 +111,7 @@ void select_dims_by_size(ArrayOfIndex& dim_sizes,
 }
 
 // Need this for each matpack type: Tensor7
-void select_dims_by_size(ArrayOfIndex& dim_sizes,
+inline void select_dims_by_size(ArrayOfIndex& dim_sizes,
                          const Index min_num_elem,
                          const Tensor7& type) {
   dim_sizes.resize(0);
@@ -129,7 +129,7 @@ void select_dims_by_size(ArrayOfIndex& dim_sizes,
 // To Numeric
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Numeric& o,
     // WS Input:
@@ -146,7 +146,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Numeric& o,
     // WS Input:
@@ -163,7 +163,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Numeric& o,
     // WS Input:
@@ -180,7 +180,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Numeric& o,
     // WS Input:
@@ -197,7 +197,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Numeric& o,
     // WS Input:
@@ -215,7 +215,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Numeric& o,
     // WS Input:
@@ -233,7 +233,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Numeric& o,
     // WS Input:
@@ -253,7 +253,7 @@ void Reduce(
 //To Vector
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Vector& o,
     // WS Input:
@@ -279,7 +279,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Vector& o,
     // WS Input:
@@ -305,7 +305,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Vector& o,
     // WS Input:
@@ -331,7 +331,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Vector& o,
     // WS Input:
@@ -357,7 +357,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Vector& o,
     // WS Input:
@@ -383,7 +383,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Vector& o,
     // WS Input:
@@ -411,7 +411,7 @@ void Reduce(
 // To Matrix
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Matrix& o,
     // WS Input:
@@ -437,7 +437,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Matrix& o,
     // WS Input:
@@ -463,7 +463,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Matrix& o,
     // WS Input:
@@ -489,7 +489,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Matrix& o,
     // WS Input:
@@ -515,7 +515,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Matrix& o,
     // WS Input:
@@ -543,7 +543,7 @@ void Reduce(
 // To Tensor 3
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Tensor3& o,
     // WS Input:
@@ -569,7 +569,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Tensor3& o,
     // WS Input:
@@ -595,7 +595,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Tensor3& o,
     // WS Input:
@@ -621,7 +621,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Tensor3& o,
     // WS Input:
@@ -649,7 +649,7 @@ void Reduce(
 // To Tensor4
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Tensor4& o,
     // WS Input:
@@ -675,7 +675,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Tensor4& o,
     // WS Input:
@@ -701,7 +701,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Tensor4& o,
     // WS Input:
@@ -729,7 +729,7 @@ void Reduce(
 // To Tensor5
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Tensor5& o,
     // WS Input:
@@ -756,7 +756,7 @@ void Reduce(
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Tensor5& o,
     // WS Input:
@@ -785,7 +785,7 @@ void Reduce(
 // To Tensor6
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Reduce(
+inline void Reduce(
     // WS Generic Output:
     Tensor6& o,
     // WS Input:

--- a/src/m_select.h
+++ b/src/m_select.h
@@ -74,7 +74,7 @@ void Select(  // WS Generic Output:
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Select(Workspace& /* ws */,
+inline void Select(Workspace& /* ws */,
             // WS Generic Output:
             ArrayOfAgenda& needles,
             // WS Generic Input:
@@ -85,7 +85,7 @@ void Select(Workspace& /* ws */,
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Select(  // WS Generic Output:
+inline void Select(  // WS Generic Output:
     Vector& needles,
     // WS Generic Input:
     const Vector& haystack,
@@ -123,7 +123,7 @@ void Select(  // WS Generic Output:
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Select(  // WS Generic Output:
+inline void Select(  // WS Generic Output:
     Matrix& needles,
     // WS Generic Input:
     const Matrix& haystack,
@@ -161,7 +161,7 @@ void Select(  // WS Generic Output:
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void Select(  // WS Generic Output:
+inline void Select(  // WS Generic Output:
     Sparse& needles,
     // WS Generic Input:
     const Sparse& haystack,


### PR DESCRIPTION
Sprinkling inline in our "m_*.h" files help not generating multiple links to the same function when using ARTS via a C++ API.  (This makes it possible to compile the code without weird compiler flags.)

I think there is very little interest in having ARTS as a linkable library now that the python package exist.  I need it because when you try to add too many features to python, its memory model makes it difficult to debug.  And crashes that occurs after just a few weeks when you want to run the program for months are difficult to work with.  If there is any interest other than my own, I can try to put my C++ linking in ARTS itself.