### PR TITLE
Use relative include path

### DIFF
--- a/controlfiles/artscomponents/wfuns/TestWfuns.arts
+++ b/controlfiles/artscomponents/wfuns/TestWfuns.arts
@@ -30,7 +30,7 @@ AtmosphereSet1D
 
 jacobianOff
 
-INCLUDE "instruments/odinsmr/odinsmr_501.arts"
+INCLUDE "../../instruments/odinsmr/odinsmr_501.arts"
 
 # Agenda for scalar gas absorption calculation
 Copy(abs_xsec_agenda, abs_xsec_agenda__noCIA)


### PR DESCRIPTION
Without the relative path, the converted Python version of the controlfile
fails to find the linefile.SM_AC2ab.xml input file.