### PR TITLE
Automatic ARTS interface generation to use ARTS in another C++ program

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -569,5 +569,5 @@ add_custom_target(make_autoarts_h_target SOURCES ${ARTS_BINARY_DIR}/src/autoarts
 # Generate autoarts.h for the ARTS interface
 add_executable(test_cpp_api test_cpp_api.cc)
 target_link_libraries(test_cpp_api public_arts_interface)
-add_test(NAME "arts.cpp_api.fast.silly_groundbased_water_test" COMMAND test_cpp_api > /dev/null)
+add_test(NAME "arts.cpp_api.fast.silly_groundbased_water_test" COMMAND test_cpp_api)
 ########################################################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -564,3 +564,10 @@ add_custom_command(OUTPUT autoarts.h
                    DEPENDS make_autoarts_h)
 add_custom_target(make_autoarts_h_target SOURCES ${ARTS_BINARY_DIR}/src/autoarts.h)
 ########################################################################################
+
+########################################################################################
+# Generate autoarts.h for the ARTS interface
+add_executable(test_cpp_api test_cpp_api.cc)
+target_link_libraries(test_cpp_api public_arts_interface)
+add_test(NAME "arts.test_cpp_api" COMMAND test_cpp_api > /dev/null)
+########################################################################################

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -538,28 +538,29 @@ arts_test_cmdline("workspacevariables" -w all)
 arts_test_cmdline("check-docs" -C)
 
 ########### ARTS Interface ###############
-                                                   
+
 ########################################################################################
 # ARTS Library for including in C++ (must link to autoarts.h to get file)
-add_library (public_arts_interface STATIC autoarts.h)
-target_link_libraries(public_arts_interface PUBLIC ${ALL_ARTS_LIBRARIES})
-target_include_directories(public_arts_interface PUBLIC ${ARTS_BINARY_DIR}
-                                                        ${ARTS_BINARY_DIR}/src/
-                                                        ${ARTS_SOURCE_DIR}/src/
-                                                        ${ARTS_SOURCE_DIR}/3rdparty/
-                                                        ${ARTS_SOURCE_DIR}/3rdparty/invlib/src)
+add_library (public_arts_interface INTERFACE)
+target_link_libraries(public_arts_interface INTERFACE ${ALL_ARTS_LIBRARIES})
+target_include_directories(public_arts_interface INTERFACE ${ARTS_BINARY_DIR}
+                                                           ${ARTS_BINARY_DIR}/src/
+                                                           ${ARTS_SOURCE_DIR}/src/
+                                                           ${ARTS_SOURCE_DIR}/3rdparty/
+                                                           ${ARTS_SOURCE_DIR}/3rdparty/invlib/src)
+add_dependencies(public_arts_interface make_autoarts_h_target)
 ########################################################################################
 
 ########################################################################################
 # Generate the internal structure for the ARTS C++ interface
-add_executable(genautoarts_h genautoarts.cc)
-target_link_libraries(genautoarts_h PUBLIC ${ALL_ARTS_LIBRARIES})
+add_executable(make_autoarts_h make_autoarts_h.cc)
+target_link_libraries(make_autoarts_h PUBLIC ${ALL_ARTS_LIBRARIES})
 ########################################################################################
 
 ########################################################################################
 # Generate autoarts.h for the ARTS interface
 add_custom_command(OUTPUT autoarts.h
-                   COMMAND genautoarts_h > ${ARTS_BINARY_DIR}/src/autoarts.h
-                   DEPENDS genautoarts_h)
+                   COMMAND make_autoarts_h > ${ARTS_BINARY_DIR}/src/autoarts.h
+                   DEPENDS make_autoarts_h)
+add_custom_target(make_autoarts_h_target SOURCES ${ARTS_BINARY_DIR}/src/autoarts.h)
 ########################################################################################
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -537,3 +537,29 @@ arts_test_cmdline("version" -v)
 arts_test_cmdline("workspacevariables" -w all)
 arts_test_cmdline("check-docs" -C)
 
+########### ARTS Interface ###############
+                                                   
+########################################################################################
+# ARTS Library for including in C++ (must link to autoarts.h to get file)
+add_library (public_arts_interface STATIC autoarts.h)
+target_link_libraries(public_arts_interface PUBLIC ${ALL_ARTS_LIBRARIES})
+target_include_directories(public_arts_interface PUBLIC ${ARTS_BINARY_DIR}
+                                                        ${ARTS_BINARY_DIR}/src/
+                                                        ${ARTS_SOURCE_DIR}/src/
+                                                        ${ARTS_SOURCE_DIR}/3rdparty/
+                                                        ${ARTS_SOURCE_DIR}/3rdparty/invlib/src)
+########################################################################################
+
+########################################################################################
+# Generate the internal structure for the ARTS C++ interface
+add_executable(genautoarts_h genautoarts.cc)
+target_link_libraries(genautoarts_h PUBLIC ${ALL_ARTS_LIBRARIES})
+########################################################################################
+
+########################################################################################
+# Generate autoarts.h for the ARTS interface
+add_custom_command(OUTPUT autoarts.h
+                   COMMAND genautoarts_h > ${ARTS_BINARY_DIR}/src/autoarts.h
+                   DEPENDS genautoarts_h)
+########################################################################################
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -569,5 +569,5 @@ add_custom_target(make_autoarts_h_target SOURCES ${ARTS_BINARY_DIR}/src/autoarts
 # Generate autoarts.h for the ARTS interface
 add_executable(test_cpp_api test_cpp_api.cc)
 target_link_libraries(test_cpp_api public_arts_interface)
-add_test(NAME "arts.test_cpp_api" COMMAND test_cpp_api > /dev/null)
+add_test(NAME "arts.cpp_api.fast.silly_groundbased_water_test" COMMAND test_cpp_api > /dev/null)
 ########################################################################################

--- a/src/genautoarts.cc
+++ b/src/genautoarts.cc
@@ -1,0 +1,859 @@
+#include <auto_md.h>
+#include <global_data.h>
+
+#include <algorithm>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+struct Group {
+  std::string varname_group;
+  std::string varname_desc;
+  std::size_t artspos;
+};
+
+struct Method {
+  struct Gin {
+    std::vector<std::string> desc;
+    std::vector<std::string> group;
+    std::vector<std::string> name;
+    std::vector<std::string> defs;
+    std::vector<bool> hasdefs;
+  };
+
+  struct Gout {
+    std::vector<std::string> desc;
+    std::vector<std::string> group;
+    std::vector<std::string> name;
+  };
+
+  struct In {
+    std::vector<std::string> varname;
+    std::vector<std::size_t> varpos;
+  };
+
+  struct Out {
+    std::vector<std::string> varname;
+    std::vector<std::size_t> varpos;
+  };
+
+  std::string name;
+  std::size_t pos;
+  std::string desc;
+  std::vector<std::string> authors;
+  bool set_method;
+  bool agenda_method;
+  bool supergeneric;
+  bool uses_templates;
+  bool pass_workspace;
+  bool pass_wsv_names;
+  In in;
+  Gin gin;
+  Out out;
+  Gout gout;
+  std::vector<std::size_t> inoutvarpos;
+};
+
+struct AgendaData {
+  std::size_t pos;
+  std::string desc;
+  std::vector<std::string> ins;
+  std::vector<std::string> outs;
+};
+
+std::map<std::string, Group> groups() {
+  std::map<std::string, std::size_t> group;
+  for (auto& x : global_data::WsvGroupMap) group[x.first] = x.second;
+  std::map<std::string, std::size_t> name;
+  for (auto& x : Workspace::wsv_data) name[x.Name()] = x.Group();
+  std::map<std::string, std::string> desc;
+  for (auto& x : Workspace::wsv_data) desc[x.Name()] = x.Description();
+  std::map<std::string, std::size_t> pos;
+  for (auto& x : Workspace::WsvMap) pos[x.first] = x.second;
+
+  std::map<std::string, Group> out;
+  for (auto& x : name) {
+    for (auto& y : group) {
+      if (y.second == x.second) {
+        out[x.first] = {y.first, desc[x.first], pos[x.first]};
+        break;
+      }
+    }
+  }
+  return out;
+}
+
+std::pair<std::vector<std::string>, std::vector<bool>> fixed_defaults(
+    const std::vector<std::string>& vargroups,
+    const std::vector<std::string>& vardefaults) {
+  std::vector<std::string> defaults(vargroups.size());
+  std::vector<bool> hasdefaults(vargroups.size());
+  for (size_t i = 0; i < vargroups.size(); i++) {
+    if (vardefaults[i] == NODEF)
+      hasdefaults[i] = false;
+    else
+      hasdefaults[i] = true;
+
+    if (vargroups[i] == "String") {
+      defaults[i] = std::string("\"") + vardefaults[i] + std::string("\"");
+    } else if (vargroups[i] == "Numeric") {
+      if ("NaN" == vardefaults[i] or "nan" == vardefaults[i]) {
+        defaults[i] = "std::numeric_limits<Numeric>::quiet_NaN()";
+      } else if ("Inf" == vardefaults[i] or "inf" == vardefaults[i]) {
+        defaults[i] = "std::numeric_limits<Numeric>::infinity()";
+      } else if ("-Inf" == vardefaults[i] or "-inf" == vardefaults[i]) {
+        defaults[i] = "-std::numeric_limits<Numeric>::infinity()";
+      } else {
+        defaults[i] = vardefaults[i];
+      }
+    } else if (vardefaults[i] == "[]") {
+      defaults[i] = "{}";
+    } else {
+      defaults[i] = vardefaults[i];
+    }
+
+    if (defaults[i] == "") defaults[i] = "{}";
+
+    for (auto& x : defaults[i]) {
+      if (x == '[')
+        x = '{';
+      else if (x == ']')
+        x = '}';
+    }
+  }
+
+  return {defaults, hasdefaults};
+}
+
+std::vector<Method> methods() {
+  std::map<std::string, std::size_t> vargroup;
+  for (auto& x : global_data::WsvGroupMap) vargroup[x.first] = x.second;
+  std::map<std::string, std::size_t> varpos;
+  for (auto& x : Workspace::WsvMap) varpos[x.first] = x.second;
+  std::map<std::string, std::size_t> methodpos;
+  for (auto& x : global_data::MdMap) methodpos[x.first] = x.second;
+
+  std::vector<std::string> metname;
+  for (auto& x : global_data::md_data) metname.push_back(x.Name());
+  std::vector<std::string> actual_groups;
+  for (auto& x : global_data::md_data)
+    actual_groups.push_back(x.ActualGroups());
+  std::vector<std::vector<std::size_t>> gin_group;
+  for (auto& x : global_data::md_data)
+    gin_group.push_back({x.GInType().cbegin(), x.GInType().cend()});
+  std::vector<std::vector<std::string>> gin_names;
+  for (auto& x : global_data::md_data)
+    gin_names.push_back({x.GIn().cbegin(), x.GIn().cend()});
+  std::vector<std::vector<std::string>> gin_defaults;
+  for (auto& x : global_data::md_data)
+    gin_defaults.push_back({x.GInDefault().cbegin(), x.GInDefault().cend()});
+  std::vector<std::vector<std::string>> gin_desc;
+  for (auto& x : global_data::md_data)
+    gin_desc.push_back(
+        {x.GInDescription().cbegin(), x.GInDescription().cend()});
+  std::vector<std::vector<std::size_t>> gout_group;
+  for (auto& x : global_data::md_data)
+    gout_group.push_back({x.GOutType().cbegin(), x.GOutType().cend()});
+  std::vector<std::vector<std::string>> gout_names;
+  for (auto& x : global_data::md_data)
+    gout_names.push_back({x.GOut().cbegin(), x.GOut().cend()});
+  std::vector<std::vector<std::string>> gout_desc;
+  for (auto& x : global_data::md_data)
+    gout_desc.push_back(
+        {x.GOutDescription().cbegin(), x.GOutDescription().cend()});
+  std::vector<std::vector<std::size_t>> in_wspace;
+  for (auto& x : global_data::md_data)
+    in_wspace.push_back({x.In().cbegin(), x.In().cend()});
+  std::vector<std::vector<std::size_t>> out_wspace;
+  for (auto& x : global_data::md_data)
+    out_wspace.push_back({x.Out().cbegin(), x.Out().cend()});
+  std::vector<std::string> desc;
+  for (auto& x : global_data::md_data) desc.push_back(x.Description());
+  std::vector<std::vector<std::string>> authors;
+  for (auto& x : global_data::md_data)
+    authors.push_back({x.Authors().cbegin(), x.Authors().cend()});
+
+  std::vector<bool> set_method;
+  for (auto& x : global_data::md_data) set_method.push_back(x.SetMethod());
+  std::vector<bool> agenda_method;
+  for (auto& x : global_data::md_data)
+    agenda_method.push_back(x.AgendaMethod());
+  std::vector<bool> supergeneric;
+  for (auto& x : global_data::md_data) supergeneric.push_back(x.Supergeneric());
+  std::vector<bool> uses_templates;
+  for (auto& x : global_data::md_data)
+    uses_templates.push_back(x.UsesTemplates());
+  std::vector<bool> pass_workspace;
+  for (auto& x : global_data::md_data)
+    pass_workspace.push_back(x.PassWorkspace());
+  std::vector<bool> pass_wsv_names;
+  for (auto& x : global_data::md_data)
+    pass_wsv_names.push_back(x.PassWsvNames());
+
+  std::vector<std::vector<std::size_t>> inoutvarpos;
+  for (auto& x : global_data::md_data)
+    inoutvarpos.push_back({x.InOut().cbegin(), x.InOut().cend()});
+  std::vector<std::vector<std::size_t>> invarpos;
+  for (auto& x : global_data::md_data)
+    invarpos.push_back({x.In().cbegin(), x.In().cend()});
+  std::vector<std::vector<std::size_t>> outvarpos;
+  for (auto& x : global_data::md_data)
+    outvarpos.push_back({x.Out().cbegin(), x.Out().cend()});
+
+  std::vector<Method> retval;
+  for (std::size_t i = 0; i < desc.size(); i++) {
+    Method m;
+    m.name = metname[i];
+    if (supergeneric[i])
+      m.pos = methodpos[metname[i] + String("_sg_") + actual_groups[i]];
+    else
+      m.pos = methodpos[metname[i]];
+    m.desc = desc[i];
+    m.authors = authors[i];
+
+    Method::Gin gin;
+    gin.desc = gin_desc[i];
+    for (auto g : gin_group[i]) {
+      bool found = false;
+      for (auto& y : vargroup) {
+        if (y.second == g) {
+          gin.group.push_back(y.first);
+          found = true;
+          break;
+        }
+      }
+      if (not found) {
+        std::cerr << "Cannot find group\n";
+        std::terminate();
+      }
+    }
+    gin.name = gin_names[i];
+    auto fixgin = fixed_defaults(gin.group, gin_defaults[i]);
+    gin.defs = fixgin.first;
+    gin.hasdefs = fixgin.second;
+    m.gin = gin;
+
+    Method::Gout gout;
+    gout.desc = gout_desc[i];
+    for (auto g : gout_group[i]) {
+      bool found = false;
+      for (auto& y : vargroup) {
+        if (y.second == g) {
+          gout.group.push_back(y.first);
+          found = true;
+          break;
+        }
+      }
+      if (not found) {
+        std::cerr << "Cannot find group\n";
+        std::terminate();
+      }
+    }
+    gout.name = gout_names[i];
+    m.gout = gout;
+
+    Method::In in;
+    for (auto v : in_wspace[i]) {
+      bool found = false;
+      for (auto& y : varpos) {
+        if (v == y.second) {
+          in.varname.push_back(y.first);
+          found = true;
+          break;
+        }
+      }
+      if (not found) {
+        std::cerr << "Cannot find variable\n";
+        std::terminate();
+      }
+    }
+    in.varpos = invarpos[i];
+    m.in = in;
+
+    Method::Out out;
+    for (auto v : out_wspace[i]) {
+      bool found = false;
+      for (auto& y : varpos) {
+        if (v == y.second) {
+          out.varname.push_back(y.first);
+          found = true;
+          break;
+        }
+      }
+      if (not found) {
+        std::cerr << "Cannot find variable\n";
+        std::terminate();
+      }
+    }
+    out.varpos = outvarpos[i];
+    m.out = out;
+
+    m.set_method = set_method[i];
+    m.agenda_method = agenda_method[i];
+    m.supergeneric = supergeneric[i];
+    m.uses_templates = uses_templates[i];
+    m.pass_workspace = pass_workspace[i];
+    m.pass_wsv_names = pass_wsv_names[i];
+    m.inoutvarpos = inoutvarpos[i];
+    retval.push_back(m);
+  }
+
+  return retval;
+}
+
+std::map<std::string, AgendaData> agendas() {
+  auto g = groups();
+
+  std::map<std::string, AgendaData> out;
+  for (auto& x : global_data::agenda_data) {
+    out[x.Name()].pos = global_data::AgendaMap.at(x.Name());
+    out[x.Name()].desc = x.Description();
+
+    for (std::size_t i : x.In()) {
+      bool found = false;
+      for (auto& y : g) {
+        if (y.second.artspos == i) {
+          out[x.Name()].ins.push_back(y.first);
+          found = true;
+          break;
+        }
+      }
+      if (not found) {
+        std::cerr << "Cannot find the variable\n";
+        std::terminate();
+      }
+    }
+
+    for (std::size_t i : x.Out()) {
+      bool found = false;
+      for (auto& y : g) {
+        if (y.second.artspos == i) {
+          out[x.Name()].outs.push_back(y.first);
+          found = true;
+          break;
+        }
+      }
+      if (not found) {
+        std::cerr << "Cannot find the variable\n";
+        std::terminate();
+      }
+    }
+  }
+  return out;
+}
+
+struct NameMaps {
+  std::map<std::string, AgendaData> agendaname_agenda;
+  std::vector<Method> methodname_method;
+  std::map<std::string, Group> varname_group;
+  std::map<std::string, std::size_t> group;
+
+  NameMaps() {
+    for (auto& x : global_data::WsvGroupMap) group[x.first] = x.second;
+    varname_group = groups();
+    methodname_method = methods();
+    agendaname_agenda = agendas();
+  }
+};
+
+int main() {
+  define_wsv_group_names();
+  Workspace::define_wsv_data();
+  Workspace::define_wsv_map();
+  define_md_data_raw();
+  expand_md_data_raw_to_md_data();
+  define_md_map();
+  define_agenda_data();
+  define_agenda_map();
+  define_species_data();
+  define_species_map();
+
+  const auto artsname = NameMaps();
+
+  std::cout << "#ifndef autoarts_h\n"
+            << "#define autoarts_h\n"
+            << '\n'
+            << "#include <auto_md.h>" << '\n'
+            << "#include <arts.h>" << '\n'
+            << "#include <global_data.h>" << '\n'
+            << "#include <m_basic_types.h>" << '\n'
+            << "#include <m_general.h>" << '\n'
+            << "#include <m_append.h>" << '\n'
+            << "#include <m_conversion.h>" << '\n'
+            << "#include <m_copy.h>" << '\n'
+            << "#include <m_gridded_fields.h>" << '\n'
+            << "#include <m_xml.h>" << '\n'
+            << "#include <m_select.h>" << '\n'
+            << "#include <m_reduce.h>" << '\n'
+            << "#include <m_nc.h>" << '\n'
+            << "#include <m_delete.h>" << '\n'
+            << "#include <m_extract.h>" << '\n'
+            << "#include <m_ignore.h>" << '\n'
+            << '\n'
+            << '\n';
+            
+  std::cout << "namespace ARTS::Var {\n";
+  for (auto& x : artsname.varname_group) {
+    std::cout << "/*! " << x.second.varname_desc << '\n';
+    std::cout << "@param[in,out] Workspace ws - An ARTS workspace\n@return "
+                 "Reference to this workspace variable\n"
+                 "*/\n";
+    std::cout << "[[nodiscard]] inline ";
+    std::cout << x.second.varname_group << '&' << ' ' << x.first
+              << "(Workspace& ws) "
+                 "noexcept { "
+                 "return *static_cast<"
+              << x.second.varname_group << " *>(ws[" << x.second.artspos
+              << "]); "
+                 "}\n\n";
+  }
+  std::cout << "}  // ARTS::Var \n\n";
+
+  std::cout << "namespace ARTS::AgendaVar {\n";
+  for (auto& x : artsname.group) {
+    if (x.first == "Any") continue;
+    
+    std::cout << "class Workspace" << x.first << ' ' << '{' << '\n';
+    std::cout << "  using type = " << x.first << ";\n";
+    std::cout << "  std::size_t p;\n";
+    std::cout << "  type* v;\n";
+    std::cout << "public:\n";
+    std::cout << "  Workspace" << x.first
+              << "() noexcept : p(std::numeric_limits<std::size_t>::max()), "
+                 "v(nullptr) {}\n";
+    std::cout << "  Workspace" << x.first
+              << "(std::size_t i, void * x) noexcept : p(i), "
+                 "v(static_cast<type *>(x)) {}\n";
+    std::cout << "  type& value() noexcept {return *v;}\n";
+    std::cout << "  const type& value() const noexcept {return *v;}\n";
+    std::cout
+        << "  Workspace" << x.first
+        << "& operator=(const type& t) noexcept {value() = t; return *this;}\n";
+    std::cout << "  std::size_t pos() const noexcept {return p;}\n";
+    std::cout << "  bool isnull() const noexcept {return v == nullptr;}\n";
+    std::cout << '}' << ';' << '\n' << '\n';
+  }
+  for (auto& x : artsname.varname_group) {
+    std::cout << "/*! " << x.second.varname_desc << '\n';
+    std::cout << "@param[in,out] Workspace ws - An ARTS workspace\n";
+    std::cout << "@return A class with a pointer to this variable and its "
+                 "position in the workspace\n*/\n";
+    std::cout << "[[nodiscard]] inline ";
+    std::cout << "Workspace" << x.second.varname_group << ' ' << x.first
+              << "(Workspace& ws) "
+                 "noexcept { "
+                 "return {"
+              << x.second.artspos << ", ws[" << x.second.artspos
+              << "]}; "
+                 "}\n\n";
+  }
+  for (auto& x : artsname.group) {
+    if (x.first == "Any") continue;
+    
+    std::cout << "/*! Creates in, and returns from, Workspace a/an " << x.first
+              << '\n'
+              << '\n';
+    std::cout << "@param[in,out] Workspace ws - An ARTS workspace\n";
+    std::cout << "@param[in] " << x.first
+              << " inval - The default value the variable will have in "
+                 "the workspace\n";
+    std::cout << "@param[in] String name - The name the variable will have in "
+                 "the workspace\n";
+    std::cout << "@param[in] String desc - The description the variable will "
+                 "have in the workspace (default: \"nodescription\")\n";
+    std::cout << "@return A class with a pointer to this variable and its new "
+                 "position in the workspace\n";
+    std::cout << "*/\n";
+    std::cout << "[[nodiscard]] inline\n";
+    std::cout << "Workspace" << x.first << ' ' << x.first
+              << "Create(\n            Workspace& ws,\n            const "
+              << x.first
+              << "& inval,\n            const String& name,\n            const "
+                 "String& "
+                 "desc=\"nodescription\") {\n";
+    std::cout << "  const std::size_t ind = "
+                 "std::size_t(ws.add_wsv_inplace({name.c_str(), desc.c_str(), "
+              << x.second << "}));\n";
+    std::cout << "  Workspace" << x.first << ' ' << "val{ind, ws[ind]};\n";
+    std::cout << "  return val = inval;\n"
+              << "}\n\n";
+  }
+  std::cout << "}  // ARTS::AgendaVar \n\n";
+
+  std::cout << "namespace ARTS::Method {\n";
+
+  for (auto& x : artsname.methodname_method) {
+    // Skip methods using verbosity and Agenda methods (for now)
+    if (x.agenda_method) continue;
+
+    // Also skip create methods since these must be called via AgendaVar
+    if (std::any_of(artsname.group.cbegin(), artsname.group.cend(),
+                    [metname = x.name](auto& y) {
+                      return (y.first + String("Create")) == metname;
+                    }))
+      continue;
+
+    // Describe the method
+    std::cout << "/*! " << x.desc << '\n';
+    for (auto a : x.authors) std::cout << "@author " << a << '\n';
+    std::cout << "\n"
+                 "@param[in,out] Workspace ws - An ARTS workspace\n";
+    for (std::size_t i = 0; i < x.gout.name.size(); i++)
+      std::cout << "@param[out] " << x.gout.name[i] << " - " << x.gout.desc[i]
+                << "\n";
+    for (std::size_t i = 0; i < x.gin.name.size(); i++) {
+      std::cout << "@param[in] " << x.gin.name[i] << " - " << x.gin.desc[i];
+      if (x.gin.hasdefs[i]) std::cout << " (default: " << x.gin.defs[i] << ")";
+      std::cout << '\n';
+    }
+    std::cout << "\nUse the ARTS documentation to read more on how the "
+                 "workspace is manipulated\n";
+    std::cout << "This interface function has been automatically generated\n";
+    std::cout << "*/" << '\n';
+
+    // Make the function
+    std::cout << "inline void " << x.name << "(\n            Workspace& ws";
+
+    // First put all GOUT variables
+    if (x.pass_wsv_names) {
+      for (std::size_t i = 0; i < x.gout.group.size(); i++) {
+        std::cout << ',' << "\n            "
+                  << "std::pair<" << x.gout.group[i] << ", String>" << '&'
+                  << ' ' << x.gout.name[i];
+      }
+    } else {
+      for (std::size_t i = 0; i < x.gout.group.size(); i++) {
+        std::cout << ',' << "\n            " << x.gout.group[i] << '&' << ' '
+                  << x.gout.name[i];
+      }
+    }
+
+    // Second put all GIN variables that have no default argument
+    if (x.pass_wsv_names) {
+      for (std::size_t i = 0; i < x.gin.group.size(); i++) {
+        if (not x.gin.hasdefs[i]) {
+          std::cout << ',' << "\n            "
+                    << "const std::pair<" << x.gin.group[i] << ", String>"
+                    << '&' << ' ' << x.gin.name[i];
+        }
+      }
+    } else {
+      for (std::size_t i = 0; i < x.gin.group.size(); i++) {
+        if (not x.gin.hasdefs[i]) {
+          std::cout << ',' << "\n            "
+                    << "const " << x.gin.group[i] << '&' << ' '
+                    << x.gin.name[i];
+        }
+      }
+    }
+
+    // Lastly put all GIN variables that have a default argument
+    if (x.pass_wsv_names) {
+      for (std::size_t i = 0; i < x.gin.group.size(); i++) {
+        if (x.gin.hasdefs[i]) {
+          std::cout << ',' << "\n            "
+                    << "const std::pair<" << x.gin.group[i] << ", String>"
+                    << '&' << ' ' << x.gin.name[i] << '=' << '{'
+                    << x.gin.defs[i] << ", \"" << x.gin.name[i] << "\"}";
+        }
+      }
+    } else {
+      for (std::size_t i = 0; i < x.gin.group.size(); i++) {
+        if (x.gin.hasdefs[i]) {
+          std::cout << ',' << "\n            "
+                    << "const " << x.gin.group[i] << '&' << ' ' << x.gin.name[i]
+                    << '=' << x.gin.defs[i];
+        }
+      }
+    }
+
+    // End of function definition and open function block
+    std::cout << ')' << ' ' << '{' << '\n' << ' ' << ' ';
+
+    // Call the ARTS auto_md.h function
+    std::cout << x.name << '(';
+
+    // We need the workspace if we input an Agenda or simply pass the workspace
+    bool has_any = false;
+    if (x.pass_workspace or x.agenda_method or
+        std::any_of(
+            x.gin.group.cbegin(), x.gin.group.cend(),
+            [](auto& g) { return g == "Agenda" or g == "ArrayOfAgenda"; }) or
+        std::any_of(x.in.varname.cbegin(), x.in.varname.cend(), [&](auto& g) {
+          return artsname.varname_group.at(g).varname_group == "Agenda" or
+                 artsname.varname_group.at(g).varname_group == "ArrayOfAgenda";
+        })) {
+      std::cout << "ws";
+      has_any = true;
+    }
+
+    // First are all the outputs
+    for (std::size_t i = 0; i < x.out.varname.size(); i++) {
+      if (has_any) std::cout << ',' << ' ';
+      has_any = true;
+      std::cout << "Var::" << x.out.varname[i] << "(ws)";
+    }
+
+    // Second comes all the generic outputs
+    for (std::size_t i = 0; i < x.gout.name.size(); i++) {
+      if (has_any) std::cout << ',' << ' ';
+      has_any = true;
+      std::cout << x.gout.name[i];
+      if (x.pass_wsv_names) std::cout << ".first";
+    }
+
+    // And their filenames if relevant
+    if (x.pass_wsv_names) {
+      for (std::size_t i = 0; i < x.gout.name.size(); i++) {
+        if (has_any) std::cout << ',' << ' ';
+        has_any = true;
+        std::cout << x.gout.name[i] << ".second";
+      }
+    }
+
+    // Then come all the inputs that are not also outputs
+    for (std::size_t i = 0; i < x.in.varname.size(); i++) {
+      if (std::any_of(
+              x.out.varname.cbegin(), x.out.varname.cend(),
+              [in = x.in.varname[i]](const auto& out) { return in == out; }))
+        continue;
+      if (has_any) std::cout << ',' << ' ';
+      has_any = true;
+      std::cout << "Var::" << x.in.varname[i] << "(ws)";
+    }
+
+    // Lastly are all the generic inputs, which cannot also be outputs
+    for (std::size_t i = 0; i < x.gin.name.size(); i++) {
+      if (has_any) std::cout << ',' << ' ';
+      has_any = true;
+      std::cout << x.gin.name[i];
+      if (x.pass_wsv_names) std::cout << ".first";
+    }
+
+    // And their filenames if relevant
+    if (x.pass_wsv_names) {
+      for (std::size_t i = 0; i < x.gin.name.size(); i++) {
+        if (has_any) std::cout << ',' << ' ';
+        has_any = true;
+        std::cout << x.gin.name[i] << ".second";
+      }
+    }
+
+    // Check verbosity
+    const bool has_verbosity =
+        std::any_of(x.in.varname.cbegin(), x.in.varname.cend(),
+                    [](auto& name) { return name == "verbosity"; });
+
+    // Add verbosity of it does not exist
+    if (not has_verbosity) {
+      if (has_any) std::cout << ',' << ' ';
+      has_any = true;
+      std::cout << "Var::verbosity(ws)";
+    }
+
+    // Close the function call and the function itself
+    std::cout << ')' << ';' << '\n' << '}' << '\n' << '\n' << '\n';
+  }
+  std::cout << "}  // ARTS::Method \n\n";
+
+  std::cout << "namespace ARTS::AgendaMethod  {\n";
+
+  for (auto& x : artsname.methodname_method) {
+    // Skip methods using verbosity and Agenda methods (for now)
+    if (x.agenda_method) continue;
+
+    // Also skip create methods since these must be called via AgendaVar
+    if (std::any_of(artsname.group.cbegin(), artsname.group.cend(),
+                    [metname = x.name](auto& y) {
+                      return (y.first + String("Create")) == metname;
+                    }))
+      continue;
+
+    // Describe the method
+    std::cout << "/*! " << x.desc << '\n';
+    for (auto a : x.authors) std::cout << "@author " << a << '\n';
+    std::cout << "\n"
+                 "@param[in,out] Workspace ws - An ARTS workspace\n";
+    for (std::size_t i = 0; i < x.gout.name.size(); i++)
+      std::cout << "@param[out] " << x.gout.name[i] << " - " << x.gout.desc[i]
+                << "\n";
+    for (std::size_t i = 0; i < x.gin.name.size(); i++) {
+      std::cout << "@param[in] " << x.gin.name[i] << " - " << x.gin.desc[i];
+      if (x.gin.hasdefs[i]) std::cout << " (default: " << x.gin.defs[i] << ")";
+      std::cout << '\n';
+    }
+    std::cout << "\nUse the ARTS documentation to read more on how the "
+                 "workspace is manipulated\n";
+    std::cout << "This interface function has been automatically generated\n";
+    std::cout << "\n"
+              << "@return MRecord to call this method\n";
+    std::cout << "*/" << '\n';
+
+    // Make the function
+    std::cout << "[[nodiscard]] inline\nMRecord " << x.name
+              << "(\n            [[maybe_unused]] Workspace& ws";
+
+    // Check if we have the first input
+    for (std::size_t i = 0; i < x.gout.group.size(); i++) {
+      std::cout << ',' << '\n';
+      std::cout << "                             AgendaVar::Workspace"
+                << x.gout.group[i] << ' ' << x.gout.name[i];
+    }
+
+    // Second put all GIN variables that have no default argument
+    for (std::size_t i = 0; i < x.gin.group.size(); i++) {
+      if (not x.gin.hasdefs[i]) {
+        std::cout << ',' << "\n";
+        std::cout << "                       const AgendaVar::Workspace"
+                  << x.gin.group[i] << ' ' << x.gin.name[i];
+      }
+    }
+
+    // Lastly put all GIN variables that have a default argument
+    for (std::size_t i = 0; i < x.gin.group.size(); i++) {
+      if (x.gin.hasdefs[i]) {
+        std::cout << ',' << "\n";
+        std::cout << "                       const AgendaVar::Workspace"
+                  << x.gin.group[i] << '&' << ' ' << x.gin.name[i] << '='
+                  << "{}";
+      }
+    }
+
+    // End of function definition and open function block
+    std::cout << ')' << ' ' << '{' << '\n';
+
+    for (std::size_t i = 0; i < x.gin.group.size(); i++) {
+      if (x.gin.hasdefs[i]) {
+        std::cout
+            << "  static const auto " << x.gin.name[i]
+            << "_default = AgendaVar::" << x.gin.group[i] << "Create(ws, "
+            << x.gin.defs[i] << ",\n    \"" << x.name << '_' << x.gin.name[i]
+            << "_autodefault"
+            << "\",\n    \"auto generated variable with default from method "
+               "definition\");\n";
+      }
+    }
+
+    // Call the ARTS auto_md.h function
+    std::cout << "  return MRecord(" << x.pos << ',' << ' '
+              << "\n    ArrayOfIndex(" << '{';
+
+    // First are all the outputs
+    for (std::size_t i = 0; i < x.out.varpos.size(); i++) {
+      std::cout << x.out.varpos[i] << ',' << ' ';
+    }
+
+    // Second comes all the generic outputs
+    for (std::size_t i = 0; i < x.gout.name.size(); i++) {
+      std::cout << "Index(" << x.gout.name[i] << ".pos())" << ',' << ' ';
+    }
+    std::cout << '}' << ')' << ',' << ' ' << "\n    ArrayOfIndex(" << '{';
+
+    // Then come all the inputs that are not also outputs
+    for (std::size_t i = 0; i < x.in.varpos.size(); i++) {
+      std::cout << x.in.varpos[i] << ',' << ' ';
+    }
+
+    // Lastly are all the generic inputs, which cannot also be outputs
+    for (std::size_t i = 0; i < x.gin.name.size(); i++) {
+      if (x.gin.hasdefs[i])
+        std::cout << x.gin.name[i] << ".isnull() ? Index(" << x.gin.name[i]
+                  << "_default.pos()) : ";
+      std::cout << "Index(" << x.gin.name[i] << ".pos())" << ',' << ' ';
+    }
+
+    std::cout << '}' << ')' << ',' << ' ';
+
+    if (x.set_method)
+      std::cout << "\n    TokVal{" << x.gin.name[0] << ".value()}";
+    else
+      std::cout << "\n    TokVal{}";
+
+    std::cout << ", Agenda{}";
+
+    // Close the function call and the function itself
+    std::cout << ')' << ';' << '\n' << '}' << '\n' << '\n' << '\n';
+  }
+  std::cout << "}  // ARTS::AgendaMethod \n\n";
+
+  std::cout << "namespace ARTS::AgendaExecute { \n\n";
+  for (auto& x : artsname.agendaname_agenda) {
+    std::cout << "/*! " << x.second.desc << '\n'
+              << "@param[in,out] Workspace ws - An ARTS workspace\n"
+              << "*/\n"
+              << "inline void " << x.first << "(Workspace& ws) {\n  " << x.first
+              << "Execute(ws";
+    for (auto& name : x.second.outs) {
+      std::cout << ',' << "\n            " << ' ' << "Var::" << name << "(ws)";
+    }
+    for (auto& name : x.second.ins) {
+      if (not std::any_of(x.second.outs.cbegin(), x.second.outs.cend(),
+                          [name](auto& outname) { return name == outname; }))
+        std::cout << ',' << "\n            " << ' ' << "Var::" << name
+                  << "(ws)";
+    }
+    std::cout << ",\n             Var::" << x.first << "(ws));\n}\n\n";
+  }
+  std::cout << "}  // ARTS::AgendaExecute \n\n";
+
+  std::cout << "namespace ARTS::AgendaDefine { \n";
+  std::cout << "/*! Append Records to an agenda */\n";
+  std::cout << "template <typename ... Records>\nvoid Append(Agenda& ag, "
+               "Records ... records) {\n"
+            << "  for (auto& x: { MRecord(records)... })\n    "
+               "ag.push_back(x);\n}\n\n";
+  for (auto& x : artsname.agendaname_agenda) {
+    if (artsname.varname_group.at(x.first).varname_group == "ArrayOfAgenda")
+      continue;
+    std::cout << "/*! " << x.second.desc << '\n'
+              << "@param[in,out] Workspace ws - An ARTS workspace\n"
+              << "@param[in] MRecords records - Any number of ARTS methods "
+                 "from ARTS::AgendaMethod\n"
+              << "*/\n"
+              << "template <typename ... Records> "
+              << "inline\nvoid " << x.first
+              << "(Workspace& ws, Records ... records) {\n"
+              << "  ARTS::Var::" << x.first << "(ws).resize(0);\n"
+              << "  ARTS::Var::" << x.first << "(ws).set_name(\"" << x.first
+              << "\");\n"
+              << "  Append(ARTS::Var::" << x.first << "(ws), records...);"
+              << "\n"
+              << "  Var::" << x.first
+              << "(ws).check(ws, Var::verbosity(ws));\n}\n\n";
+  }
+  std::cout << "}  // ARTS::AgendaDefine \n\n";
+  
+  // Make the main "startup"
+  std::cout << "namespace ARTS {\n";
+  std::cout <<
+    "inline Workspace init(std::size_t screen=0, std::size_t file=0, std::size_t agenda=0) {\n"
+    "  define_wsv_group_names();\n"
+    "  Workspace::define_wsv_data();\n"
+    "  Workspace::define_wsv_map();\n"
+    "  define_md_data_raw();\n"
+    "  expand_md_data_raw_to_md_data();\n"
+    "  define_md_map();\n"
+    "  define_agenda_data();\n"
+    "  define_agenda_map();\n"
+    "  define_species_data();\n"
+    "  define_species_map();\n"
+    "  global_data::workspace_memory_handler.initialize();\n"
+    "\n"
+    "  Workspace ws;\n"
+    "  ws.initialize();\n"
+    "  Var::verbosity(ws).set_screen_verbosity(screen);\n"
+    "  Var::verbosity(ws).set_agenda_verbosity(agenda);\n"
+    "  Var::verbosity(ws).set_file_verbosity(file);\n"
+    "  Var::verbosity(ws).set_main_agenda(1);\n"
+    "\n"
+    "  #ifndef NDEBUG\n"
+    "  ws.context = "";\n"
+  "  #endif\n"
+  "\n"
+  "  return ws;"
+  "}\n";
+  std::cout << "}  // namespace::ARTS\n\n";
+
+  std::cout << "#endif  // autoarts_h\n\n";
+}

--- a/src/make_autoarts_h.cc
+++ b/src/make_autoarts_h.cc
@@ -509,7 +509,7 @@ int main() {
     // Second put all GIN variables that have no default argument
     for (std::size_t i = 0; i < x.gin.group.size(); i++) {
       if (not x.gin.hasdefs[i]) {
-        std::cout << ',' << "\n            "
+        std::cout << ',' << "\n      "
                   << "const Var::Workspace" << x.gin.group[i] << ' '
                   << x.gin.name[i];
       }
@@ -519,11 +519,11 @@ int main() {
     for (std::size_t i = 0; i < x.gin.group.size(); i++) {
       if (x.gin.hasdefs[i]) {
         if (x.gin.defs[i] == "{}") {
-          std::cout << ',' << "\n            "
+          std::cout << ',' << "\n      "
           << "const Var::Workspace" << x.gin.group[i] << ' ' << x.gin.name[i]
           << '=' << x.gin.group[i] << x.gin.defs[i];
         } else {
-          std::cout << ',' << "\n            "
+          std::cout << ',' << "\n      "
                     << "const Var::Workspace" << x.gin.group[i] << ' ' << x.gin.name[i]
                     << '=' << x.gin.group[i] << '{' << x.gin.defs[i] << '}';
         }
@@ -538,7 +538,7 @@ int main() {
     for (std::size_t i = 0; i < x.gout.group.size(); i++) {
       std::cout << " if (" << x.gout.name[i] << ".islast()) {\n    throw std::runtime_error(\"" 
                 << x.gout.name[i] << " needs to be a defined Workspace"
-                << x.gout.group[i] << " since it is output\");\n}";
+                << x.gout.group[i] << " since it is output of "<<x.name<<"\");\n  }";
     }
     if (x.gout.group.size()) std::cout << '\n' << '\n';
 
@@ -663,12 +663,12 @@ int main() {
 
     // Make the function
     std::cout << "[[nodiscard]] inline\nMRecord " << x.name
-              << "(\n            [[maybe_unused]] Workspace& ws";
+              << "(\n    [[maybe_unused]] Workspace& ws";
 
     // Check if we have the first input
     for (std::size_t i = 0; i < x.gout.group.size(); i++) {
       std::cout << ',' << '\n';
-      std::cout << "                             Var::Workspace"
+      std::cout << "                     Var::Workspace"
                 << x.gout.group[i] << ' ' << x.gout.name[i];
     }
 
@@ -676,7 +676,7 @@ int main() {
     for (std::size_t i = 0; i < x.gin.group.size(); i++) {
       if (not x.gin.hasdefs[i]) {
         std::cout << ',' << "\n";
-        std::cout << "                       const Var::Workspace"
+        std::cout << "               const Var::Workspace"
                   << x.gin.group[i] << ' ' << x.gin.name[i];
       }
     }
@@ -685,7 +685,7 @@ int main() {
     for (std::size_t i = 0; i < x.gin.group.size(); i++) {
       if (x.gin.hasdefs[i]) {
         std::cout << ',' << "\n";
-        std::cout << "                       const Var::Workspace"
+        std::cout << "               const Var::Workspace"
                   << x.gin.group[i] << '&' << ' ' << x.gin.name[i] << '='
                   << "{}";
       }
@@ -693,6 +693,25 @@ int main() {
 
     // End of function definition and open function block
     std::cout << ')' << ' ' << '{' << '\n';
+    
+    // Output variables have to be on the Workspace
+    if (x.gout.group.size() or x.gin.group.size()) std::cout << ' ';
+    for (std::size_t i = 0; i < x.gout.group.size(); i++) {
+      std::cout << " if (" << x.gout.name[i] << ".islast()) {\n    throw std::runtime_error(\"" 
+      << x.gout.name[i] << " needs to be a defined Workspace"
+      << x.gout.group[i] << " since it is output of "<<x.name<<"\");\n  }";
+    }
+    for (std::size_t i = 0; i < x.gin.group.size(); i++) {
+      if (x.gin.hasdefs[i])
+        std::cout << " if (not " << x.gin.name[i] << ".isnull() and " << x.gin.name[i] << ".islast()) {\n    throw std::runtime_error(\"" 
+        << x.gin.name[i] << " needs to be a defined Workspace"
+        << x.gin.group[i] << " (or left default) since it is agenda input to "<<x.name<<"\");\n  }";
+      else
+        std::cout << " if (" << x.gin.name[i] << ".islast()) {\n    throw std::runtime_error(\"" 
+        << x.gin.name[i] << " needs to be a defined Workspace"
+        << x.gin.group[i] << " since it is agenda input to "<<x.name<<"\");\n  }";
+    }
+    if (x.gout.group.size() or x.gin.group.size()) std::cout << '\n' << '\n';
 
     for (std::size_t i = 0; i < x.gin.group.size(); i++) {
       if (x.gin.hasdefs[i]) {

--- a/src/make_autoarts_h.cc
+++ b/src/make_autoarts_h.cc
@@ -196,7 +196,7 @@ std::vector<Method> methods() {
     inoutvarpos.push_back({x.InOut().cbegin(), x.InOut().cend()});
   std::vector<std::vector<std::size_t>> invarpos;
   for (auto& x : global_data::md_data)
-    invarpos.push_back({x.In().cbegin(), x.In().cend()});
+    invarpos.push_back({x.InOnly().cbegin(), x.InOnly().cend()});
   std::vector<std::vector<std::size_t>> outvarpos;
   for (auto& x : global_data::md_data)
     outvarpos.push_back({x.Out().cbegin(), x.Out().cend()});

--- a/src/make_autoarts_h.cc
+++ b/src/make_autoarts_h.cc
@@ -392,13 +392,21 @@ int main() {
             << "#include <m_ignore.h>" << '\n'
             << '\n'
             << '\n';
-
+  
+  std::cout << "namespace ARTS { using Workspace=Workspace; }\n\n";
+  std::cout << "namespace ARTS::Group {\n";
+  for (auto& x : artsname.group) {
+    if (x.first == "Any") continue;
+    std::cout << "using " << x.first << '=' << x.first << ';' << '\n';
+  }
+  std::cout << "}  // ARTS::Group \n\n";
+  
   std::cout << "namespace ARTS::Var {\n";
   for (auto& x : artsname.group) {
     if (x.first == "Any") continue;
     
     std::cout << "class Workspace" << x.first << ' ' << '{' << '\n';
-    std::cout << "  using type = " << x.first << ";\n";
+    std::cout << "  using type = Group::" << x.first << ";\n";
     std::cout << "  std::size_t p;\n";
     std::cout << "  type* v;\n";
     std::cout << "public:\n";
@@ -416,7 +424,7 @@ int main() {
     std::cout << "  std::size_t pos() const noexcept {return p;}\n";
     std::cout << "  bool isnull() const noexcept {return v == nullptr;}\n";
     std::cout << "  bool islast() const noexcept {return p == std::numeric_limits<std::size_t>::max();}\n";
-    std::cout << "  const String& name() const noexcept {return Workspace::wsv_data[p].Name();}\n";
+    std::cout << "  const Group::String& name() const noexcept {return Workspace::wsv_data[p].Name();}\n";
     std::cout << '}' << ';' << '\n' << '\n';
   }
   for (auto& x : artsname.varname_group) {
@@ -452,9 +460,9 @@ int main() {
     std::cout << "*/\n";
     std::cout << "[[nodiscard]] inline\n";
     std::cout << "Workspace" << x.first << ' ' << x.first
-              << "Create(\n            Workspace& ws,\n            const "
+              << "Create(\n            Workspace& ws,\n            const Group::"
               << x.first
-              << "& inval,\n            const String& name,\n            const "
+              << "& inval,\n            const Group::String& name,\n            const Group::"
                  "String& "
                  "desc=\"nodescription\") {\n";
     std::cout << "  const std::size_t ind = "
@@ -521,11 +529,11 @@ int main() {
         if (x.gin.defs[i] == "{}") {
           std::cout << ',' << "\n      "
           << "const Var::Workspace" << x.gin.group[i] << ' ' << x.gin.name[i]
-          << '=' << x.gin.group[i] << x.gin.defs[i];
+          << '=' << "Group::" << x.gin.group[i] << x.gin.defs[i];
         } else {
           std::cout << ',' << "\n      "
                     << "const Var::Workspace" << x.gin.group[i] << ' ' << x.gin.name[i]
-                    << '=' << x.gin.group[i] << '{' << x.gin.defs[i] << '}';
+                    << '=' << "Group::" << x.gin.group[i] << '{' << x.gin.defs[i] << '}';
         }
       }
     }
@@ -607,7 +615,7 @@ int main() {
       for (std::size_t i = 0; i < x.gin.name.size(); i++) {
         if (has_any) std::cout << ',' << ' ';
         has_any = true;
-        std::cout << x.gin.name[i] << ".islast() ? String{\"" << x.gin.name[i] << "\"} : " << x.gin.name[i] << ".name()";
+        std::cout << x.gin.name[i] << ".islast() ? Group::String{\"" << x.gin.name[i] << "\"} : " << x.gin.name[i] << ".name()";
       }
     }
 
@@ -727,7 +735,7 @@ int main() {
 
     // Call the ARTS auto_md.h function
     std::cout << "  return MRecord(" << x.pos << ',' << ' '
-              << "\n    ArrayOfIndex(" << '{';
+    << "\n    Group::ArrayOfIndex(" << '{';
 
     // First are all the outputs
     for (std::size_t i = 0; i < x.out.varpos.size(); i++) {
@@ -736,9 +744,9 @@ int main() {
 
     // Second comes all the generic outputs
     for (std::size_t i = 0; i < x.gout.name.size(); i++) {
-      std::cout << "Index(" << x.gout.name[i] << ".pos())" << ',' << ' ';
+      std::cout << "Group::Index(" << x.gout.name[i] << ".pos())" << ',' << ' ';
     }
-    std::cout << '}' << ')' << ',' << ' ' << "\n    ArrayOfIndex(" << '{';
+    std::cout << '}' << ')' << ',' << ' ' << "\n    Group::ArrayOfIndex(" << '{';
 
     // Then come all the inputs that are not also outputs
     for (std::size_t i = 0; i < x.in.varpos.size(); i++) {
@@ -750,7 +758,7 @@ int main() {
       if (x.gin.hasdefs[i])
         std::cout << x.gin.name[i] << ".isnull() ? Index(" << x.gin.name[i]
                   << "_default.pos()) : ";
-      std::cout << "Index(" << x.gin.name[i] << ".pos())" << ',' << ' ';
+      std::cout << "Group::Index(" << x.gin.name[i] << ".pos())" << ',' << ' ';
     }
 
     std::cout << '}' << ')' << ',' << ' ';

--- a/src/make_autoarts_h.cc
+++ b/src/make_autoarts_h.cc
@@ -849,7 +849,7 @@ int main() {
     "  Var::verbosity(ws).set_main_agenda(1);\n"
     "\n"
     "  #ifndef NDEBUG\n"
-    "  ws.context = "";\n"
+    "  ws.context = \"\";\n"
   "  #endif\n"
   "\n"
   "  return ws;"

--- a/src/make_autoarts_h.cc
+++ b/src/make_autoarts_h.cc
@@ -819,6 +819,7 @@ int main() {
               << "\");\n"
               << "  Append(ARTS::Var::" << x.first << "(ws), records...);"
               << "\n"
+              << "  Var::" << x.first << "(ws).set_main_agenda();\n"
               << "  Var::" << x.first
               << "(ws).check(ws, Var::verbosity(ws));\n}\n\n";
   }

--- a/src/test_cpp_api.cc
+++ b/src/test_cpp_api.cc
@@ -1,0 +1,252 @@
+#include <autoarts.h>
+
+namespace ARTS::Agenda {
+  Workspace& iy_main_agenda_emission(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    iy_main_agenda(ws, ppathCalc(ws), iyEmissionStandard(ws));
+    return ws;
+  }
+  
+  Workspace& iy_main_agenda_transmission(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    using namespace Var;
+    iy_main_agenda(ws, Ignore(ws, iy_unit(ws)), Ignore(ws, iy_id(ws)),
+                   ppathCalc(ws), iyTransmissionStandard(ws));
+    return ws;
+  }
+  
+  Workspace& iy_space_agenda_cosmic_background(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    using namespace Var;
+    iy_space_agenda(ws, Ignore(ws, rtp_pos(ws)), Ignore(ws, rtp_los(ws)),
+                    MatrixCBR(ws, iy(ws), f_grid(ws)));
+    return ws;
+  }
+  
+  Workspace& iy_surface_agenda_use_surface_property(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    iy_surface_agenda(ws, SurfaceDummy(ws), iySurfaceRtpropAgenda(ws));
+    return ws;
+  }
+  
+  Workspace& ppath_agenda_follow_sensor_los(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    using namespace Var;
+    ppath_agenda(ws, Ignore(ws, rte_pos2(ws)), ppathStepByStep(ws));
+    return ws;
+  }
+  
+  Workspace& ppath_agenda_plane_parallel(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    using namespace Var;
+    ppath_agenda(ws, Ignore(ws, ppath_lraytrace(ws)), Ignore(ws, rte_pos2(ws)),
+                 Ignore(ws, t_field(ws)), Ignore(ws, vmr_field(ws)),
+                 Ignore(ws, f_grid(ws)), ppathPlaneParallel(ws));
+    return ws;
+  }
+  
+  Workspace& ppath_step_agenda_geometric_path(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    using namespace Var;
+    ppath_step_agenda(ws, Ignore(ws, ppath_lraytrace(ws)), Ignore(ws, f_grid(ws)),
+                      ppath_stepGeometric(ws));
+    return ws;
+  }
+  
+  Workspace& ppath_step_agenda_refracted_path(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    ppath_step_agenda(ws, ppath_stepRefractionBasic(ws));
+    return ws;
+  }
+  
+  Workspace& propmat_clearsky_agenda_on_the_fly(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    using namespace Var;
+    propmat_clearsky_agenda(ws, Ignore(ws, rtp_mag(ws)), Ignore(ws, rtp_los(ws)),
+                            propmat_clearskyInit(ws),
+                            propmat_clearskyAddOnTheFly(ws));
+    return ws;
+  }
+  
+  Workspace& propmat_clearsky_agenda_on_the_fly_zeeman(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    propmat_clearsky_agenda(ws, propmat_clearskyInit(ws),
+                            propmat_clearskyAddOnTheFly(ws),
+                            propmat_clearskyAddZeeman(ws));
+    return ws;
+  }
+  
+  Workspace& abs_xsec_agenda_standard(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    abs_xsec_agenda(ws, abs_xsec_per_speciesInit(ws),
+                    abs_xsec_per_speciesAddLines(ws),
+                    abs_xsec_per_speciesAddConts(ws));
+    return ws;
+  }
+  
+  Workspace& abs_xsec_agenda_standard_with_cia(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    abs_xsec_agenda(
+      ws, abs_xsec_per_speciesInit(ws), abs_xsec_per_speciesAddLines(ws),
+                    abs_xsec_per_speciesAddConts(ws), abs_xsec_per_speciesAddCIA(ws));
+    return ws;
+  }
+  
+  Workspace& surface_rtprop_agenda_blackbody_from_surface(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    using namespace Var;
+    surface_rtprop_agenda(
+      ws, InterpSurfaceFieldToPosition(ws, surface_skin_t(ws), t_surface(ws)),
+                          surfaceBlackbody(ws));
+    return ws;
+  }
+  
+  Workspace& surface_rtprop_agenda_blackbody_from_atmosphere(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    using namespace Var;
+    surface_rtprop_agenda(
+      ws, InterpAtmFieldToPosition(ws, surface_skin_t(ws), t_field(ws)),
+                          surfaceBlackbody(ws));
+    return ws;
+  }
+  
+  Workspace& geo_pos_agenda_empty(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    using namespace Var;
+    geo_pos_agenda(ws, Ignore(ws, ppath(ws)),
+                   VectorSet(ws, geo_pos(ws), VectorCreate(ws, {}, "Default")));
+    return ws;
+  }
+  
+  Workspace& water_p_eq_agenda_default(Workspace& ws) {
+    using namespace AgendaMethod;
+    using namespace AgendaDefine;
+    water_p_eq_agenda(ws, water_p_eq_fieldMK05(ws));
+    return ws;
+  }
+}  // namespace ARTS::Agenda
+
+namespace ARTS::Continua {
+  Workspace& init(Workspace& ws) { Method::abs_cont_descriptionInit(ws); return ws; }
+  
+  Workspace& addH2OPWR98(Workspace& ws) { Method::abs_cont_descriptionAppend(ws, String{"H2O-PWR98"}, String{"Rosenkranz"}); return ws; }
+  
+  Workspace& addO2PWR98(Workspace& ws) { Method::abs_cont_descriptionAppend(ws, String{"O2-PWR98"}, String{"Rosenkranz"}); return ws; }
+}  // ARTS::Continua
+
+int main() try {
+  using namespace ARTS;
+  
+  auto ws = init(0, 0, 0);
+  
+  ARTS::Agenda::iy_main_agenda_emission(ws);
+  
+  ARTS::Agenda::iy_space_agenda_cosmic_background(ws);
+  
+  ARTS::Agenda::iy_surface_agenda_use_surface_property(ws);
+  
+  ARTS::Agenda::ppath_agenda_follow_sensor_los(ws);
+  
+  ARTS::Agenda::ppath_step_agenda_geometric_path(ws);
+  
+  ARTS::Agenda::propmat_clearsky_agenda_on_the_fly(ws);
+  
+  ARTS::Agenda::abs_xsec_agenda_standard(ws);
+  
+  ARTS::Agenda::surface_rtprop_agenda_blackbody_from_surface(ws);
+  
+  ARTS::Agenda::geo_pos_agenda_empty(ws);
+  
+  ARTS::Agenda::water_p_eq_agenda_default(ws);
+  
+  Method::jacobianOff(ws);
+  Method::nlteOff(ws);
+  Var::iy_unit(ws) = "PlanckBT";
+  Method::Touch(ws, Var::iy_aux_vars(ws));
+  Method::Touch(ws, Var::surface_props_names(ws));
+  
+  ARTS::Continua::init(ws);
+  ARTS::Continua::addH2OPWR98(ws);
+  ARTS::Continua::addO2PWR98(ws);
+  
+  Method::abs_speciesSet(ws, ArrayOfString{"H2O-PWR98", "O2-PWR98"});
+  
+  Method::partition_functionsInitFromBuiltin(ws);
+  Method::isotopologue_ratiosInitFromBuiltin(ws);
+  Var::nelem(ws) = 51;
+  Method::VectorNLogSpace(ws, Var::p_grid(ws), 1e+05, 1e-4);
+  
+  Method::AtmosphereSet1D(ws);
+  Var::lat_true(ws) = Var::lat_grid(ws);
+  Var::lon_true(ws) = Var::lon_grid(ws);
+  Method::Touch(ws, Var::wind_u_field(ws));
+  Method::Touch(ws, Var::wind_v_field(ws));
+  Method::Touch(ws, Var::wind_w_field(ws));
+  Method::Touch(ws, Var::mag_u_field(ws));
+  Method::Touch(ws, Var::mag_v_field(ws));
+  Method::Touch(ws, Var::mag_w_field(ws));
+  Method::Touch(ws, Var::nlte_field(ws));
+  Method::Touch(ws, Var::rte_alonglos_v(ws));
+  Method::Touch(ws, Var::surface_props_data(ws));
+  
+  Var::p_hse(ws) = 1e5;
+  Var::t_field(ws) = Tensor3(51, 1, 1, 250.0);
+  Var::vmr_field(ws) = Tensor4(2, 51, 1, 1, 1e-2);
+  Var::z_field(ws) = Tensor3(51, 1, 1, 0);
+  for (Index i=0; i<51; i++) Var::z_field(ws).value()(i, 0, 0) = 2e3 * Numeric(i);
+  Method::Touch(ws, Var::nlte_field(ws));
+  
+  Method::refellipsoidVenus(ws, String{"Sphere"});
+  Method::z_surfaceConstantAltitude(ws);
+  Var::t_surface(ws) = Matrix(1, 1, 250.0);
+  
+  Method::Touch(ws, Var::abs_lines(ws));
+  Method::abs_lines_per_speciesCreateFromLines(ws);
+  
+  Var::abs_f_interp_order(ws) = 1;
+  Var::stokes_dim(ws) = 1;
+  Var::ppath_lraytrace(ws) = 1e3;
+  Var::ppath_lmax(ws) = 1e3;
+  
+  Var::nelem(ws) = 10001;
+  Method::VectorNLinSpace(ws, Var::f_grid(ws), 22e9 - 500e6, 22e9 + 500e6);
+  
+  Var::sensor_pos(ws) = Matrix(1, 1, 100);
+  Var::sensor_los(ws) = Matrix(1, 1, 75);
+  Method::Touch(ws, Var::transmitter_pos(ws));
+  Method::sensorOff(ws);
+  Method::cloudboxOff(ws);
+  
+  Method::atmgeom_checkedCalc(ws);
+  Method::atmfields_checkedCalc(ws);
+  Method::cloudbox_checkedCalc(ws);
+  Method::sensor_checkedCalc(ws);
+  Method::propmat_clearsky_agenda_checkedCalc(ws);
+  Method::abs_xsec_agenda_checkedCalc(ws);
+  Method::lbl_checkedCalc(ws);
+  
+  Method::yCalc(ws);
+  for (auto& n: Var::y(ws).value()) std::cout << n << ',';
+  std::cout  << '\n';
+  return 0;
+} catch(const std::exception& e) {
+  std::ostringstream os;
+  os << "EXITING WITH ERROR:\n" << e.what() << '\n';
+  std::cerr << os.str();
+  return 1;
+}

--- a/src/workspace_ng.cc
+++ b/src/workspace_ng.cc
@@ -57,6 +57,12 @@ Index Workspace::add_wsv(const WsvRecord &wsv) {
   return wsv_data.nelem() - 1;
 }
 
+Index Workspace::add_wsv_inplace(const WsvRecord &wsv) {
+  const Index pos = add_wsv(wsv);
+  ws.push_back(stack<WsvStruct *>());
+  return pos;
+}
+
 void Workspace::del(Index i) {
   WsvStruct *wsvs = ws[i].top();
 

--- a/src/workspace_ng.h
+++ b/src/workspace_ng.h
@@ -160,6 +160,9 @@ class Workspace {
 
   /** Get the number of workspace variables. */
   Index nelem() { return ws.nelem(); }
+  
+  /** Add a new variable to existing workspace and to the static maps */
+  Index add_wsv_inplace(const WsvRecord &wsv);
 
   /** Retrieve a pointer to the given WSV. */
   void *operator[](Index i);


### PR DESCRIPTION
This is the interface I hinted at before.  If interest exist to keep this in ARTS, I would be happier to have it here than in external code.

### Definiitions

(EDIT:) To use you need:

#### CMakeLists.txt

```cmake
include (FindOpenMP)
if (NOT ${OPENMP_FOUND})
  message(FATAL_ERROR "No OPEN MP found, ARTS requires it")
endif()

########################################################################################
# ARTS Library: For ARTS usage
add_library (arts_interface STATIC RELEVANT_FILES)
target_link_libraries(arts_interface PUBLIC public_arts_interface OpenMP::OpenMP_CXX)
########################################################################################
```

#### autoarts.h (auto-generated)
```cpp
namespace ARTS {
Workspace init(...);  // Initializes the workspace
namespace Var {...}  // Contains direct access to most Workspace variables
namespace AgendaVar {...}  // Contains access to most Workspace variables and can add Workspace variables
namespace Method {...}  // Contains direct access to most Workspace methods
namespace AgendaMethod {...}  // Returns MRecord of the agenda
namespace AgendaExecute {...}  // Directly executes single Agenda
namespace AgendaDefine {...}  // Defines executes single Agenda
}
```

#### PotentialUse.cpp
```cpp
#include <autoarts.h>
int main() {
  auto ws = ARTS::init(1, 1, 1);

  //  Use a method to print something
  ARTS::Method::Print(ws, Index(1));

  // Set a workspace variable and print it
  ARTS::Var::atmosphere_dim(ws) = 3;
  ARTS::Method::Print(ws, String{"Set atmosphere_dim to:"});
  ARTS::Method::Print(ws, ARTS::Var::atmosphere_dim(ws));

  // Create a new workspace variable
  auto test_num = ARTS::AgendaVar::NumericCreate(ws, 3.14, "TestNumber");

  // Define g0_agenda
  ARTS::AgendaDefine::g0_agenda(
      ws, ARTS::AgendaMethod::NumericSet(ws, ARTS::AgendaVar::g0(ws), test_num),
      ARTS::AgendaMethod::Ignore(ws, ARTS::AgendaVar::lat(ws)),
      ARTS::AgendaMethod::Ignore(ws, ARTS::AgendaVar::lon(ws)),
      ARTS::AgendaMethod::Print(
          ws, ARTS::AgendaVar::StringCreate(ws, "Print inside of Agenda",
                                            "TestString")),
      ARTS::AgendaMethod::Print(ws, test_num));

  // Execute g0_agenda
  ARTS::AgendaExecute::g0_agenda(ws);

  // Print the g0 that has now been set
  ARTS::Method::Print(ws, String{"Print outsjde of Agenda"});
  ARTS::Method::Print(ws, ARTS::Var::g0(ws));
}
```

#### Notes
The entire default namespace of ARTS is present at base.  So things like String and Numeric and Index are defined.  Also, all Workspace methods can be called directly via auto_md.h, but that sort of defeats the purpose of keeping track of Workspace, which is what ARTS does best.  It is up to the user to not have name collisions with ARTS main, but I keep things in namespaces because otherwise it gets silly.

I do not know why the inclusion of OpenMP::OpenMP_CXX is required.  I thought we already linked against it in ARTS but for some reason this linking is not persistent when reaching the interface file...

I require a change in Workspace.  It must be possible to simply push back against the vector of stacks that it is controlling.

It is not too difficult to have things like general_agendas.cc define functions like the Agendas more naturally, like this for the standard emission Agenda (note how it is now the same syntax pretty much as the python interface and normal controlfiles)
```cpp
Workspace& iy_main_agenda_emission(Workspace& ws) {
  using namespace AgendaMethod;
  using namespace AgendaDefine;
  iy_main_agenda(ws,
                 ppathCalc(ws),
                 iyEmissionStandard(ws));
  return ws;
}
```
I did not want to make this the default because I am not sure if we enforce different names between agendas and methods and workspace variables, and I don't want this to become a future issue.

Finally, the autoarts.h file is enormous because it generates all the default documentation in doxygen format for all methods (and, significantly, also for their valid templates).  I think it is worth it to have this documentation in autoarts.h because it makes the editting and writing of new cpp files much easier when a documentation parser is available inline.