### PR TITLE
Add Jekyll config file

### DIFF
--- a/python/doc/CMakeLists.txt
+++ b/python/doc/CMakeLists.txt
@@ -18,3 +18,5 @@ file(GLOB_RECURSE RST_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.rst")
 foreach(file ${RST_FILES})
   configure_file(${file} ${file} @ONLY)
 endforeach()
+
+configure_file(build/.nojekyll build/.nojekyll @ONLY)

--- a/python/doc/source/index.rst
+++ b/python/doc/source/index.rst
@@ -2,7 +2,7 @@ pyarts
 ======
 
 **pyarts** is the Python interface for the
-`Atmospheric Radiative Transfer Simulator <www.radiativetransfer.org>`_
+`Atmospheric Radiative Transfer Simulator <https://www.radiativetransfer.org>`_
 (ARTS). It provides
 
 -  an interactive interface to the ARTS engine for running radiative transfer


### PR DESCRIPTION
Prevent Jekyll from hiding directories that start with an _.
Prevents breakage when publishing docs to Github pages.