### PR TITLE
Use C++17 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,10 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}" OR "${ARTS_SOURCE_DIR}"
 )
 endif ()
 
-if (ENABLE_CXX17)
-  cmake_minimum_required (VERSION 3.9.6)
+if (ENABLE_CXX20)
+  cmake_minimum_required (VERSION 3.12)
 else ()
-  cmake_minimum_required (VERSION 3.1.0)
+  cmake_minimum_required (VERSION 3.8)
 endif ()
 
 set (CMAKE_LEGACY_CYGWIN_WIN32 0)
@@ -126,13 +126,13 @@ if (ENABLE_CCACHE)
   endif (CCACHE_FOUND)
 endif ()
 
-########### C++14/17 Support ##########
+########### C++17/20 Support ##########
 
 if (NOT CMAKE_CXX_STANDARD)
-  if (ENABLE_CXX17)
-    set(CMAKE_CXX_STANDARD 17)
+  if (ENABLE_CXX20)
+    set(CMAKE_CXX_STANDARD 20)
   else ()
-    set(CMAKE_CXX_STANDARD 14)
+    set(CMAKE_CXX_STANDARD 17)
   endif ()
 endif()
 
@@ -144,7 +144,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # depend on this newer version of cmake because it was only
 # released in June 2016.
 if (CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 endif ()
 
 ########### Intel compiler specific settings ##########

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Building ARTS
 Build Prerequisites:
 
 - gcc/g++ >=8 (or llvm/clang >=8) older versions might work, but are untested
-- cmake (>=3.1.0)
+- cmake (>=3.8)
 - zlib
 - openblas
 - netcdf (optional)
@@ -373,11 +373,11 @@ open ARTS.xcodeproj
 Experimental features (ONLY USE IF YOU KNOW WHAT YOU'RE DOING)
 --------------------------------------------------------------
 
-Enable C++17 (only for compatibility testing, do not use C++17 features in your
-code):
+Enable C++20 (only for compatibility testing, do not use C++20 features in your
+code, you need CMake >=3.12):
 
 ```
-cmake -DENABLE_CXX17=1 ..
+cmake -DENABLE_CXX20=1 ..
 ```
 
 


### PR DESCRIPTION
Up C++ standard used for compilation from 14 to 17.

Minimum CMake version is now 3.8, required for C++17 support.

Provide cmake option ENABLE_CXX20 for experimental testing.

Closes #212