### PR TITLE
Added CPP API documentation

### DIFF
--- a/doc/uguide/CMakeLists.txt
+++ b/doc/uguide/CMakeLists.txt
@@ -49,7 +49,8 @@ if (PDFLATEX_COMPILER AND BIBTEX_COMPILER AND MAKEINDEX_COMPILER)
                       "${CMAKE_CURRENT_SOURCE_DIR}/gridded_fields.tex"
                       "${CMAKE_CURRENT_SOURCE_DIR}/interpolation.tex"
                       "${CMAKE_CURRENT_SOURCE_DIR}/integration.tex"
-                      "${CMAKE_CURRENT_SOURCE_DIR}/lin_alg.tex")
+                      "${CMAKE_CURRENT_SOURCE_DIR}/lin_alg.tex"
+                      "${CMAKE_CURRENT_SOURCE_DIR}/cpp_api.tex")
   file (GLOB FIGFILES "${CMAKE_CURRENT_SOURCE_DIR}/Figs/*/*.pdf")
   ARTS_ADD_TEX_DOC ("arts_developer" "${TEXFILES}" "${FIGFILES}")
   

--- a/doc/uguide/arts_developer.tex
+++ b/doc/uguide/arts_developer.tex
@@ -149,6 +149,7 @@ $^c$ Institute of Environmental Physics, University of Bremen, P.O. Box 33044,
 \include{interpolation}
 \include{integration}
 \include{lin_alg}
+\include{cpp_api}
 
 
 

--- a/doc/uguide/cpp_api.tex
+++ b/doc/uguide/cpp_api.tex
@@ -25,23 +25,16 @@ as an automatically generated ARTS namespace to your project.
 
 To link the public interface, you need to \verb|add_subdirectory(arts)|
 anywhere in your CMake project, where the \verb|arts| directory should contain
-a current version of ARTS.  You also need to manually link OpenMP again.
+a current version of ARTS.
 
 An example (in your projects \verb|CMakeLists.txt|):
 \begin{verbatim}
-###########################################################
-# OpenMP Library
-include (FindOpenMP)
-if (NOT ${OPENMP_FOUND})
-  message(FATAL_ERROR "No OPEN MP found, ARTS requires it")
-endif()
-
-# ARTS Library
-add_library (arts_interface STATIC interface.cpp)
+######################################################
+# ARTS Custom Executable
+add_executable(arts_interface STATIC interface.cpp)
 target_link_libraries(arts_interface PUBLIC
-                      public_arts_interface
-                      OpenMP::OpenMP_CXX)
-###########################################################
+                      public_arts_interface)
+######################################################
 \end{verbatim}
 
 At this point, your \verb|interface.cpp| must have
@@ -105,9 +98,10 @@ The purpose of these types is to pass input to the functions of
 Method and AgendaMethod.  The main way to generate
 instances of these variables is by their corresponding \verb|*Create|
 function or by simply accessing them via their common Workspace
-space name.  The only constructor that is recommended to use is the
+names.  The only constructor that is recommended to use is the
 construction from the corresponding Group, as this can simplify
-the access to several methods.
+the access to several methods.  The other two constructors risk
+accessing out-of-bound memory, or to deference a null-pointer.
 
 It is highly recommended to not discard created variables, as they
 will still occupy memory in the Workspace until the end of the program
@@ -122,9 +116,8 @@ Examples:
   Var::Index y = Var::stokes_dim(ws);
   
   // Create a new index on the workspace
-  Var::Index z{Var::IndexCreate(ws,
-                                            Group::Index{1},
-                                            "new_index_name")};
+  Var::Index z{Var::IndexCreate(ws, Group::Index{1},
+                                "new_index_name")};
 \end{verbatim}
 Note that \verb|x| will not work as an input to AgendaMethod functions
 but it will work as an input to Method functions.  It does not append
@@ -182,7 +175,7 @@ automatic variables is long.
 \subsection{AgendaMethod, AgendaDefine, and AgendaExecute}
 %--------------------------------------------------------------------------
 \label{sec:cpp_api:usage:agenda}
-The Agenda namespaces deals with setting and defining Workspace Agendas.
+The Agenda namespaces deal with setting and defining Workspace Agendas.
 It is only possible to set Workspace Agendas that have been defined as part
 of the Workspace at compilation time.  The AgendaMethod namespace contains
 the same functions as the Method namespace but returns an Internal::MRecord.
@@ -190,9 +183,9 @@ The user of this interface is expected to never manually construct an MRecord.
 Instead, this type is meant to only be used when Agendas are defined in the
 AgendaDefine namespace.  The AgendaDefine namespace defines a variadic 
 function per Agenda in the common Workspace and expects a list of MRecord
-to set this Agenda's methods.  Finally, AgendaExecute exist to execute a single
+to set this Agenda's methods.  Finally, AgendaExecute exists to execute a single
 Agenda.  Normally, this is not preferred since Agendas should generally just
-be used inside methods, but the option still exist.
+be used inside methods, but the option still exists.
 
 Examples:
 \begin{verbatim}

--- a/doc/uguide/cpp_api.tex
+++ b/doc/uguide/cpp_api.tex
@@ -1,0 +1,223 @@
+\chapter{Include ARTS in third-party C++}
+%--------------------------------------------------------------------------
+\label{sec:cpp_api}
+
+\starthistory
+  2020-10-06 & Created and written by Richard Larsson.\\
+\stophistory
+
+%
+% Introduction
+%
+
+It is possible to include ARTS in another C++ program using
+the \verb|public_arts_interface| and linking to \verb|autoarts.h|.
+This will pull in the ARTS public API defined in \verb|agendas.cc|,
+\verb|groups.cc|, \verb|methods.cc|, \verb|workspace.cc| as well
+as an automatically generated ARTS namespace to your project.
+
+\FIXME{a private Module that imports only the ARTS namespace
+       should be added as soon as soon as C++20 becomes norm}
+
+\section{Linking the public interface}
+%--------------------------------------------------------------------------
+\label{sec:cpp_api:public_linking}
+
+To link the public interface, you need to \verb|add_subdirectory(arts)|
+anywhere in your CMake project, where the \verb|arts| directory should contain
+a current version of ARTS.  You also need to manually link OpenMP again.
+
+An example (in your projects \verb|CMakeLists.txt|):
+\begin{verbatim}
+###########################################################
+# OpenMP Library
+include (FindOpenMP)
+if (NOT ${OPENMP_FOUND})
+  message(FATAL_ERROR "No OPEN MP found, ARTS requires it")
+endif()
+
+# ARTS Library
+add_library (arts_interface STATIC interface.cpp)
+target_link_libraries(arts_interface PUBLIC
+                      public_arts_interface
+                      OpenMP::OpenMP_CXX)
+###########################################################
+\end{verbatim}
+
+At this point, your \verb|interface.cpp| must have
+\verb|#include <autoarts.h>| as one of its headers
+and you are good to go.
+
+\section{Using the C++ namespace interface}
+%--------------------------------------------------------------------------
+\label{sec:cpp_api:usage}
+
+The ARTS namespace contains all the interfaces you will need to perform
+all operations supported by ARTS.  The namespace defines only a single
+top level function call, the  \verb|init(...)| function and a single
+top-level type, the ARTS Workspace.  The function is used to generate the ARTS Workspace
+upon which all your function calls are made.  The ARTS namespace has several 
+sub-namespaces for various purposes.  These are in short:
+\begin{itemize}
+ \item[Group] Defines the ARTS public type-system.
+ \item[Internal] Defines the ARTS internal type-system.
+ \item[Var] Defines the ARTS interface type-system,
+                  create variables for the ARTS interface, and
+                  access automatic variables that are defined in the ARTS Workspace
+                  from the start.
+ \item[Method] Defines the ARTS methods.  The ARTS methods can only be called
+                     using their generic inputs and outputs.
+ \item[AgendaMethod] Defines the ARTS methods that can be used by agendas.
+                           They return an internal type and are best used directly,
+                           with no manual modification.
+ \item[AgendaDefine] Defines methods to set the different ARTS agendas.
+                           The agendas are checked and ready to be used after these
+                           methods are called.
+ \item[AgendaExecute] Executes an agenda.
+\end{itemize}
+
+If you are using the public interface, you need not be concerned with the types in the sub-namespaces Group and Internal.
+\FIXME{Otherwise, these define the basic types you need to use ARTS easily.}
+These sub-namespaces are used the same as any other C++ type-system.  The other
+namespaces are domain specific.
+
+An interface will generally start with a call to the initialize function.
+This could look like:
+\begin{verbatim}
+  auto ws = init();
+\end{verbatim}
+After this the order and set of commands that are placed is up to the user.
+For sake of ease, \verb|ws| will be used below to indicate a defined 
+Workspace.  Also, the access to each sub-namespace will be written as if
+operating in the ARTS namespace itself.
+
+\subsection{Var}
+%--------------------------------------------------------------------------
+\label{sec:cpp_api:usage:variable}
+The Var namespace, short for Variable namespace, have three purposes
+\begin{enumerate}
+ \item Type the Method and Agenda interface
+ \item Access common Workspace variables
+ \item Create new variables on the Workspace
+\end{enumerate}
+The types that are defined correspond to the types in Group.
+The purpose of these types is to pass input to the functions of
+Method and AgendaMethod.  The main way to generate
+instances of these variables is by their corresponding \verb|*Create|
+function or by simply accessing them via their common Workspace
+space name.  The only constructor that is recommended to use is the
+construction from the corresponding Group, as this can simplify
+the access to several methods.
+
+It is highly recommended to not discard created variables, as they
+will still occupy memory in the Workspace until the end of the program
+and they become impossible to access once discarded.
+
+Examples:
+\begin{verbatim}
+  // Define an index that is not in the workspace
+  Var::Index x{Group::Index(1)};
+  
+  // Access an index that is in the workspace
+  Var::Index y = Var::stokes_dim(ws);
+  
+  // Create a new index on the workspace
+  Var::Index z{Var::IndexCreate(ws,
+                                            Group::Index{1},
+                                            "new_index_name")};
+\end{verbatim}
+Note that \verb|x| will not work as an input to AgendaMethod functions
+but it will work as an input to Method functions.  It does not append
+to the Workspace.  The other two will work both as inputs to
+AgendaMethod and to Method functions.
+
+\subsection{Method}
+%--------------------------------------------------------------------------
+\label{sec:cpp_api:usage:method}
+The Method namespace contains all but the Agenda manipulating methods
+defined in \verb|methods.cc|.  These can all be called using the generic
+input and outputs.  The inputs and outputs are not guaranteed to be the
+same as in the ARTS methods however, because C++ requires inputs with 
+default values be placed last in the calling order.  Note that all 
+standard inputs and outputs taken from the Workspace must be set on the
+Workspace itself and cannot be passed as inputs.  This creates a few
+idiosyncrasies compared to how ARTS is used in python or in a normal
+controlfile.  
+
+Examples:
+\begin{verbatim}
+  // Call yCalc (no GIN/GOUT)
+  Method::yCalc(ws);
+  
+  // Call Touch on the wind field (Pure GOUT)
+  Method::Touch(ws, Var::wind_u_field(ws));
+  Method::Touch(ws, Var::wind_v_field(ws));
+  Method::Touch(ws, Var::wind_w_field(ws));
+  
+  // Set p_grid by VectorNLogSpace
+  Var::nelem(ws) = 51;
+  Method::VectorNLogSpace(ws, Var::p_grid(ws), 1e+05, 1e-4);
+  
+  // Save x, y, z from the Var example
+  Var::output_file_format(ws) = Group::String{"ascii"};
+  Method::WriteXML(ws, x);
+  Method::WriteXML(ws, y, Group::String{"extra.xml"});
+  Method::WriteXML(ws, z);
+\end{verbatim}
+All methods requires a Workspace (\verb|ws|) to work.
+The first case of the examples calls a function with neither generic input nor generic output --- it cannot take anything other than the Workspace.
+The second triplet case of the examples calls Touch on all wind-field variables.  They will have been default-initialized after this process.
+The third example shows the idiosyncrasies to other methods of using ARTS.  The Workspace variable \verb|nelem| has been used instead of a generic
+input index to define \verb|VectorNLogSpace| --- thus \verb|nelem| must be set manually by the user of the interface.
+The last examples uses the fact that many of \verb|WriteXML|'s inputs are default defined.  Since the default value of filename is empty and since
+the interface then infers it has the variable name input, the first call to \verb|WriteXML| will generate a file called \verb|arts.in.xml|, the second
+call will generate a file called \verb|extra.xml|, and the last call will generate a file called \verb|arts.new_index_name.xml|.  The first part of
+the name can be changed by calling \verb|init()| with the corresponding arguments.
+
+As a last note.  Several inputs above automatically generates inputs from standard C++ types, such as \verb|VectorNLogSpace|
+generating two \verb|Var::Numeric| from two doubles.  This is a convenient way to use the methods but the user should
+be aware that these methods will end up deleting variables in the end, so some care has to be taken when the scope of such
+automatic variables is long.
+
+\subsection{AgendaMethod, AgendaDefine, and AgendaExecute}
+%--------------------------------------------------------------------------
+\label{sec:cpp_api:usage:agenda}
+The Agenda namespaces deals with setting and defining Workspace Agendas.
+It is only possible to set Workspace Agendas that have been defined as part
+of the Workspace at compilation time.  The AgendaMethod namespace contains
+the same functions as the Method namespace but returns an Internal::MRecord.
+The user of this interface is expected to never manually construct an MRecord.
+Instead, this type is meant to only be used when Agendas are defined in the
+AgendaDefine namespace.  The AgendaDefine namespace defines a variadic 
+function per Agenda in the common Workspace and expects a list of MRecord
+to set this Agenda's methods.  Finally, AgendaExecute exist to execute a single
+Agenda.  Normally, this is not preferred since Agendas should generally just
+be used inside methods, but the option still exist.
+
+Examples:
+\begin{verbatim}
+  // Define the basic iy_main_agenda emission agenda
+  AgendaDefine::iy_main_agenda(ws,
+    AgendaMethod::ppathCalc(ws),
+    AgendaMethod::iyEmissionStandard(ws));
+  
+  // Define an empty geo positioning agenda
+  AgendaDefine::geo_pos_agenda(ws,
+    AgendaMethod::Ignore(ws, Var::ppath(ws)),
+    AgendaMethod::VectorSet(ws, Var::geo_pos(ws),
+      Var::VectorCreate(ws, {}, "Default")));
+\end{verbatim}
+The first example simply sets its agenda by using two functions that
+complete the inputs/outputs expected of the agenda.  The second example
+does not need or want to use \verb|Var::ppath(ws)| so it ignores it.  It also
+has the need of a default empty \verb|Var::Vector|.  This variable
+has to first be created onto the Workspace before it can be used as an 
+input.  Had a pure vector been used instead of the create-function,
+a runtime error would occur.  The create function is only invoked once,
+since the internal workings of the Agenda just need to have defined
+the variable.
+
+Lastly, each AgendaMethod function that has a default generic input will
+create a static const Workspace variable of this type upon first call to
+the method.  This means that calling such a method will incur a memory cost
+that lasts until the end of the program.

--- a/doc/uguide/cpp_api.tex
+++ b/doc/uguide/cpp_api.tex
@@ -31,7 +31,7 @@ An example (in your projects \verb|CMakeLists.txt|):
 \begin{verbatim}
 ######################################################
 # ARTS Custom Executable
-add_executable(arts_interface STATIC interface.cpp)
+add_executable(arts_interface interface.cpp)
 target_link_libraries(arts_interface PUBLIC
                       public_arts_interface)
 ######################################################

--- a/src/make_autoarts_h.cc
+++ b/src/make_autoarts_h.cc
@@ -392,9 +392,9 @@ int main() {
             << "#include <m_ignore.h>" << '\n'
             << '\n'
             << '\n';
-  
+
   std::cout << "extern String out_basename;\n\n";
-  
+
   std::cout << "namespace ARTS { using Workspace=Workspace; }\n\n";
   std::cout << "namespace ARTS::Group {\n";
   for (auto& x : artsname.group) {
@@ -402,11 +402,11 @@ int main() {
     std::cout << "using " << x.first << '=' << x.first << ';' << '\n';
   }
   std::cout << "}  // ARTS::Group \n\n";
-  
+
   std::cout << "namespace ARTS::Var {\n";
   for (auto& x : artsname.group) {
     if (x.first == "Any") continue;
-    
+
     std::cout << "class " << x.first << ' ' << '{' << '\n';
     std::cout << "  using type = Group::" << x.first << ";\n";
     std::cout << "  std::size_t p;\n";
@@ -415,9 +415,14 @@ int main() {
     std::cout << "  " << x.first
               << "() noexcept : p(std::numeric_limits<std::size_t>::max()), "
                  "v(nullptr) {}\n";
-    std::cout << "  " << x.first << "(std::size_t i, void * x) noexcept : p(i), " "v(static_cast<type *>(x)) {}\n";
-    std::cout << "  ~" << x.first << "() noexcept {if (islast() and not isnull()) delete v;}\n";
-    std::cout << "  " << x.first << "(const type& val) noexcept : p(std::numeric_limits<std::size_t>::max()), v(new type(val)) {}\n";
+    std::cout << "  " << x.first
+              << "(std::size_t i, void * x) noexcept : p(i), "
+                 "v(static_cast<type *>(x)) {}\n";
+    std::cout << "  ~" << x.first
+              << "() noexcept {if (islast() and not isnull()) delete v;}\n";
+    std::cout
+        << "  " << x.first
+        << "(const type& val) noexcept : p(std::numeric_limits<std::size_t>::max()), v(new type(val)) {}\n";
     std::cout << "  type& value() noexcept {return *v;}\n";
     std::cout << "  const type& value() const noexcept {return *v;}\n";
     std::cout
@@ -425,8 +430,10 @@ int main() {
         << "& operator=(const type& t) noexcept {value() = t; return *this;}\n";
     std::cout << "  std::size_t pos() const noexcept {return p;}\n";
     std::cout << "  bool isnull() const noexcept {return v == nullptr;}\n";
-    std::cout << "  bool islast() const noexcept {return p == std::numeric_limits<std::size_t>::max();}\n";
-    std::cout << "  const Group::String& name() const noexcept {return Workspace::wsv_data[p].Name();}\n";
+    std::cout
+        << "  bool islast() const noexcept {return p == std::numeric_limits<std::size_t>::max();}\n";
+    std::cout
+        << "  const Group::String& name() const noexcept {return Workspace::wsv_data[p].Name();}\n";
     std::cout << '}' << ';' << '\n' << '\n';
   }
   for (auto& x : artsname.varname_group) {
@@ -445,7 +452,7 @@ int main() {
   }
   for (auto& x : artsname.group) {
     if (x.first == "Any") continue;
-    
+
     std::cout << "/*! Creates in, and returns from, Workspace a/an " << x.first
               << '\n'
               << '\n';
@@ -461,12 +468,13 @@ int main() {
                  "position in the workspace\n";
     std::cout << "*/\n";
     std::cout << "[[nodiscard]] inline\n";
-    std::cout << x.first << ' ' << x.first
-              << "Create(\n            Workspace& ws,\n            const Group::"
-              << x.first
-              << "& inval,\n            const Group::String& name,\n            const Group::"
-                 "String& "
-                 "desc=\"nodescription\") {\n";
+    std::cout
+        << x.first << ' ' << x.first
+        << "Create(\n            Workspace& ws,\n            const Group::"
+        << x.first
+        << "& inval,\n            const Group::String& name,\n            const Group::"
+           "String& "
+           "desc=\"nodescription\") {\n";
     std::cout << "  const std::size_t ind = "
                  "std::size_t(ws.add_wsv_inplace({name.c_str(), desc.c_str(), "
               << x.second << "}));\n";
@@ -483,7 +491,8 @@ int main() {
     if (x.agenda_method) continue;
 
     // Also skip create methods since these must be called via Var
-    if (std::any_of(artsname.group.cbegin(), artsname.group.cend(),
+    if (std::any_of(artsname.group.cbegin(),
+                    artsname.group.cend(),
                     [metname = x.name](auto& y) {
                       return (y.first + String("Create")) == metname;
                     }))
@@ -520,8 +529,7 @@ int main() {
     for (std::size_t i = 0; i < x.gin.group.size(); i++) {
       if (not x.gin.hasdefs[i]) {
         std::cout << ',' << "\n      "
-                  << "const Var::" << x.gin.group[i] << ' '
-                  << x.gin.name[i];
+                  << "const Var::" << x.gin.group[i] << ' ' << x.gin.name[i];
       }
     }
 
@@ -530,25 +538,28 @@ int main() {
       if (x.gin.hasdefs[i]) {
         if (x.gin.defs[i] == "{}") {
           std::cout << ',' << "\n      "
-          << "const Var::" << x.gin.group[i] << ' ' << x.gin.name[i]
-          << '=' << "Group::" << x.gin.group[i] << x.gin.defs[i];
+                    << "const Var::" << x.gin.group[i] << ' ' << x.gin.name[i]
+                    << '=' << "Group::" << x.gin.group[i] << x.gin.defs[i];
         } else {
           std::cout << ',' << "\n      "
                     << "const Var::" << x.gin.group[i] << ' ' << x.gin.name[i]
-                    << '=' << "Group::" << x.gin.group[i] << '{' << x.gin.defs[i] << '}';
+                    << '=' << "Group::" << x.gin.group[i] << '{'
+                    << x.gin.defs[i] << '}';
         }
       }
     }
 
     // End of function definition and open function block
     std::cout << ')' << ' ' << '{' << '\n';
-    
+
     // Output variables have to be on the Workspace
     if (x.gout.group.size()) std::cout << ' ';
     for (std::size_t i = 0; i < x.gout.group.size(); i++) {
-      std::cout << " if (" << x.gout.name[i] << ".islast()) {\n    throw std::runtime_error(\"" 
+      std::cout << " if (" << x.gout.name[i]
+                << ".islast()) {\n    throw std::runtime_error(\""
                 << x.gout.name[i] << " needs to be a defined Workspace"
-                << x.gout.group[i] << " since it is output of "<<x.name<<"\");\n  }";
+                << x.gout.group[i] << " since it is output of " << x.name
+                << "\");\n  }";
     }
     if (x.gout.group.size()) std::cout << '\n' << '\n';
 
@@ -559,7 +570,8 @@ int main() {
     bool has_any = false;
     if (x.pass_workspace or x.agenda_method or
         std::any_of(
-            x.gin.group.cbegin(), x.gin.group.cend(),
+            x.gin.group.cbegin(),
+            x.gin.group.cend(),
             [](auto& g) { return g == "Agenda" or g == "ArrayOfAgenda"; }) or
         std::any_of(x.in.varname.cbegin(), x.in.varname.cend(), [&](auto& g) {
           return artsname.varname_group.at(g).varname_group == "Agenda" or
@@ -596,7 +608,8 @@ int main() {
     // Then come all the inputs that are not also outputs
     for (std::size_t i = 0; i < x.in.varname.size(); i++) {
       if (std::any_of(
-              x.out.varname.cbegin(), x.out.varname.cend(),
+              x.out.varname.cbegin(),
+              x.out.varname.cend(),
               [in = x.in.varname[i]](const auto& out) { return in == out; }))
         continue;
       if (has_any) std::cout << ',' << ' ';
@@ -617,14 +630,16 @@ int main() {
       for (std::size_t i = 0; i < x.gin.name.size(); i++) {
         if (has_any) std::cout << ',' << ' ';
         has_any = true;
-        std::cout << x.gin.name[i] << ".islast() ? Group::String{\"" << x.gin.name[i] << "\"} : " << x.gin.name[i] << ".name()";
+        std::cout << x.gin.name[i] << ".islast() ? Group::String{\""
+                  << x.gin.name[i] << "\"} : " << x.gin.name[i] << ".name()";
       }
     }
 
     // Check verbosity
     const bool has_verbosity =
-        std::any_of(x.in.varname.cbegin(), x.in.varname.cend(),
-                    [](auto& name) { return name == "verbosity"; });
+        std::any_of(x.in.varname.cbegin(), x.in.varname.cend(), [](auto& name) {
+          return name == "verbosity";
+        });
 
     // Add verbosity of it does not exist
     if (not has_verbosity) {
@@ -645,7 +660,8 @@ int main() {
     if (x.agenda_method) continue;
 
     // Also skip create methods since these must be called via Var
-    if (std::any_of(artsname.group.cbegin(), artsname.group.cend(),
+    if (std::any_of(artsname.group.cbegin(),
+                    artsname.group.cend(),
                     [metname = x.name](auto& y) {
                       return (y.first + String("Create")) == metname;
                     }))
@@ -678,16 +694,16 @@ int main() {
     // Check if we have the first input
     for (std::size_t i = 0; i < x.gout.group.size(); i++) {
       std::cout << ',' << '\n';
-      std::cout << "                     Var::"
-                << x.gout.group[i] << ' ' << x.gout.name[i];
+      std::cout << "                     Var::" << x.gout.group[i] << ' '
+                << x.gout.name[i];
     }
 
     // Second put all GIN variables that have no default argument
     for (std::size_t i = 0; i < x.gin.group.size(); i++) {
       if (not x.gin.hasdefs[i]) {
         std::cout << ',' << "\n";
-        std::cout << "               const Var::"
-                  << x.gin.group[i] << ' ' << x.gin.name[i];
+        std::cout << "               const Var::" << x.gin.group[i] << ' '
+                  << x.gin.name[i];
       }
     }
 
@@ -695,31 +711,38 @@ int main() {
     for (std::size_t i = 0; i < x.gin.group.size(); i++) {
       if (x.gin.hasdefs[i]) {
         std::cout << ',' << "\n";
-        std::cout << "               const Var::"
-                  << x.gin.group[i] << '&' << ' ' << x.gin.name[i] << '='
-                  << "{}";
+        std::cout << "               const Var::" << x.gin.group[i] << '&'
+                  << ' ' << x.gin.name[i] << '=' << "{}";
       }
     }
 
     // End of function definition and open function block
     std::cout << ')' << ' ' << '{' << '\n';
-    
+
     // Output variables have to be on the Workspace
     if (x.gout.group.size() or x.gin.group.size()) std::cout << ' ';
     for (std::size_t i = 0; i < x.gout.group.size(); i++) {
-      std::cout << " if (" << x.gout.name[i] << ".islast()) {\n    throw std::runtime_error(\"" 
-      << x.gout.name[i] << " needs to be a defined Workspace"
-      << x.gout.group[i] << " since it is output of "<<x.name<<"\");\n  }";
+      std::cout << " if (" << x.gout.name[i]
+                << ".islast()) {\n    throw std::runtime_error(\""
+                << x.gout.name[i] << " needs to be a defined Workspace"
+                << x.gout.group[i] << " since it is output of " << x.name
+                << "\");\n  }";
     }
     for (std::size_t i = 0; i < x.gin.group.size(); i++) {
       if (x.gin.hasdefs[i])
-        std::cout << " if (not " << x.gin.name[i] << ".isnull() and " << x.gin.name[i] << ".islast()) {\n    throw std::runtime_error(\"" 
-        << x.gin.name[i] << " needs to be a defined Workspace"
-        << x.gin.group[i] << " (or left default) since it is agenda input to "<<x.name<<"\");\n  }";
+        std::cout << " if (not " << x.gin.name[i] << ".isnull() and "
+                  << x.gin.name[i]
+                  << ".islast()) {\n    throw std::runtime_error(\""
+                  << x.gin.name[i] << " needs to be a defined Workspace"
+                  << x.gin.group[i]
+                  << " (or left default) since it is agenda input to " << x.name
+                  << "\");\n  }";
       else
-        std::cout << " if (" << x.gin.name[i] << ".islast()) {\n    throw std::runtime_error(\"" 
-        << x.gin.name[i] << " needs to be a defined Workspace"
-        << x.gin.group[i] << " since it is agenda input to "<<x.name<<"\");\n  }";
+        std::cout << " if (" << x.gin.name[i]
+                  << ".islast()) {\n    throw std::runtime_error(\""
+                  << x.gin.name[i] << " needs to be a defined Workspace"
+                  << x.gin.group[i] << " since it is agenda input to " << x.name
+                  << "\");\n  }";
     }
     if (x.gout.group.size() or x.gin.group.size()) std::cout << '\n' << '\n';
 
@@ -737,7 +760,7 @@ int main() {
 
     // Call the ARTS auto_md.h function
     std::cout << "  return MRecord(" << x.pos << ',' << ' '
-    << "\n    Group::ArrayOfIndex(" << '{';
+              << "\n    Group::ArrayOfIndex(" << '{';
 
     // First are all the outputs
     for (std::size_t i = 0; i < x.out.varpos.size(); i++) {
@@ -748,7 +771,8 @@ int main() {
     for (std::size_t i = 0; i < x.gout.name.size(); i++) {
       std::cout << "Group::Index(" << x.gout.name[i] << ".pos())" << ',' << ' ';
     }
-    std::cout << '}' << ')' << ',' << ' ' << "\n    Group::ArrayOfIndex(" << '{';
+    std::cout << '}' << ')' << ',' << ' ' << "\n    Group::ArrayOfIndex("
+              << '{';
 
     // Then come all the inputs that are not also outputs
     for (std::size_t i = 0; i < x.in.varpos.size(); i++) {
@@ -785,10 +809,12 @@ int main() {
               << "inline void " << x.first << "(Workspace& ws) {\n  " << x.first
               << "Execute(ws";
     for (auto& name : x.second.outs) {
-      std::cout << ',' << "\n            " << ' ' << "Var::" << name << "(ws).value()";
+      std::cout << ',' << "\n            " << ' ' << "Var::" << name
+                << "(ws).value()";
     }
     for (auto& name : x.second.ins) {
-      if (not std::any_of(x.second.outs.cbegin(), x.second.outs.cend(),
+      if (not std::any_of(x.second.outs.cbegin(),
+                          x.second.outs.cend(),
                           [name](auto& outname) { return name == outname; }))
         std::cout << ',' << "\n            " << ' ' << "Var::" << name
                   << "(ws).value()";
@@ -815,15 +841,16 @@ int main() {
               << "inline\nvoid " << x.first
               << "(Workspace& ws, Records ... records) {\n"
               << "  ARTS::Var::" << x.first << "(ws).value().resize(0);\n"
-              << "  ARTS::Var::" << x.first << "(ws).value().set_name(\"" << x.first
-              << "\");\n"
-              << "  Append(ARTS::Var::" << x.first << "(ws).value(), records...);"
+              << "  ARTS::Var::" << x.first << "(ws).value().set_name(\""
+              << x.first << "\");\n"
+              << "  Append(ARTS::Var::" << x.first
+              << "(ws).value(), records...);"
               << "\n"
               << "  Var::" << x.first
               << "(ws).value().check(ws, Var::verbosity(ws).value());\n}\n\n";
   }
   std::cout << "}  // ARTS::AgendaDefine \n\n";
-  
+
   // Make the main "startup"
   std::cout << "namespace ARTS {\n";
   std::cout << "/*! Create a Workspace and set its main verbosity\n\n"
@@ -833,35 +860,35 @@ int main() {
             << "  @param[in] basename Default basename for output variables\n"
             << "  @return Workspace a full ARTS Workspace\n"
             << "*/\n";
-  std::cout <<
-    "inline Workspace init(std::size_t screen=0, std::size_t file=0, std::size_t agenda=0, const Group::String& basename=\"arts\") {\n"
-    "  define_wsv_group_names();\n"
-    "  Workspace::define_wsv_data();\n"
-    "  Workspace::define_wsv_map();\n"
-    "  define_md_data_raw();\n"
-    "  expand_md_data_raw_to_md_data();\n"
-    "  define_md_map();\n"
-    "  define_agenda_data();\n"
-    "  define_agenda_map();\n"
-    "  define_species_data();\n"
-    "  define_species_map();\n"
-    "  global_data::workspace_memory_handler.initialize();\n"
-    "\n"
-    "  Workspace ws;\n"
-    "  ws.initialize();\n"
-    "  Var::verbosity(ws).value().set_screen_verbosity(screen);\n"
-    "  Var::verbosity(ws).value().set_agenda_verbosity(agenda);\n"
-    "  Var::verbosity(ws).value().set_file_verbosity(file);\n"
-    "  Var::verbosity(ws).value().set_main_agenda(1);\n"
-    "\n"
-    "  out_basename = basename;\n"
-    "\n"
-    "  #ifndef NDEBUG\n"
-    "  ws.context = \"\";\n"
-  "  #endif\n"
-  "\n"
-  "  return ws;\n"
-  "}\n";
+  std::cout
+      << "inline Workspace init(std::size_t screen=0, std::size_t file=0, std::size_t agenda=0, const Group::String& basename=\"arts\") {\n"
+         "  define_wsv_group_names();\n"
+         "  Workspace::define_wsv_data();\n"
+         "  Workspace::define_wsv_map();\n"
+         "  define_md_data_raw();\n"
+         "  expand_md_data_raw_to_md_data();\n"
+         "  define_md_map();\n"
+         "  define_agenda_data();\n"
+         "  define_agenda_map();\n"
+         "  define_species_data();\n"
+         "  define_species_map();\n"
+         "  global_data::workspace_memory_handler.initialize();\n"
+         "\n"
+         "  Workspace ws;\n"
+         "  ws.initialize();\n"
+         "  Var::verbosity(ws).value().set_screen_verbosity(screen);\n"
+         "  Var::verbosity(ws).value().set_agenda_verbosity(agenda);\n"
+         "  Var::verbosity(ws).value().set_file_verbosity(file);\n"
+         "  Var::verbosity(ws).value().set_main_agenda(1);\n"
+         "\n"
+         "  out_basename = basename;\n"
+         "\n"
+         "  #ifndef NDEBUG\n"
+         "  ws.context = \"\";\n"
+         "  #endif\n"
+         "\n"
+         "  return ws;\n"
+         "}\n";
   std::cout << "}  // namespace::ARTS\n\n";
 
   std::cout << "#endif  // autoarts_h\n\n";

--- a/src/make_autoarts_h.cc
+++ b/src/make_autoarts_h.cc
@@ -824,6 +824,12 @@ int main() {
   
   // Make the main "startup"
   std::cout << "namespace ARTS {\n";
+  std::cout << "/*! Create a Workspace and set its main verbosity\n\n"
+            << "  @param[in] screen Screen verbosity\n"
+            << "  @param[in] file File verbosity\n"
+            << "  @param[in] agenda Agenda verbosity\n"
+            << "  @return Workspace a full ARTS Workspace\n"
+            << "*/\n";
   std::cout <<
     "inline Workspace init(std::size_t screen=0, std::size_t file=0, std::size_t agenda=0) {\n"
     "  define_wsv_group_names();\n"
@@ -849,7 +855,7 @@ int main() {
     "  ws.context = \"\";\n"
   "  #endif\n"
   "\n"
-  "  return ws;"
+  "  return ws;\n"
   "}\n";
   std::cout << "}  // namespace::ARTS\n\n";
 

--- a/src/make_autoarts_h.cc
+++ b/src/make_autoarts_h.cc
@@ -858,10 +858,13 @@ int main() {
             << "  @param[in] file File verbosity\n"
             << "  @param[in] agenda Agenda verbosity\n"
             << "  @param[in] basename Default basename for output variables\n"
+            << "  @param[in] numthreads OpenMP thread count (defaults to max if invalid count)\n"
             << "  @return Workspace a full ARTS Workspace\n"
             << "*/\n";
   std::cout
-      << "inline Workspace init(std::size_t screen=0, std::size_t file=0, std::size_t agenda=0, const Group::String& basename=\"arts\") {\n"
+      << "inline Workspace init(std::size_t screen=0, std::size_t file=0, std::size_t agenda=0, const Group::String& basename=\"arts\", int numthreads=0) {\n"
+         "  omp_set_num_threads(numthreads < 1 ? arts_omp_get_max_threads() : numthreads > arts_omp_get_max_threads() ? arts_omp_get_max_threads() : numthreads);\n"
+         "\n"
          "  define_wsv_group_names();\n"
          "  Workspace::define_wsv_data();\n"
          "  Workspace::define_wsv_map();\n"

--- a/src/make_autoarts_h.cc
+++ b/src/make_autoarts_h.cc
@@ -393,6 +393,8 @@ int main() {
             << '\n'
             << '\n';
   
+  std::cout << "extern String out_basename;\n\n";
+  
   std::cout << "namespace ARTS { using Workspace=Workspace; }\n\n";
   std::cout << "namespace ARTS::Group {\n";
   for (auto& x : artsname.group) {
@@ -405,21 +407,21 @@ int main() {
   for (auto& x : artsname.group) {
     if (x.first == "Any") continue;
     
-    std::cout << "class Workspace" << x.first << ' ' << '{' << '\n';
+    std::cout << "class " << x.first << ' ' << '{' << '\n';
     std::cout << "  using type = Group::" << x.first << ";\n";
     std::cout << "  std::size_t p;\n";
     std::cout << "  type* v;\n";
     std::cout << "public:\n";
-    std::cout << "  Workspace" << x.first
+    std::cout << "  " << x.first
               << "() noexcept : p(std::numeric_limits<std::size_t>::max()), "
                  "v(nullptr) {}\n";
-    std::cout << "  Workspace" << x.first << "(std::size_t i, void * x) noexcept : p(i), " "v(static_cast<type *>(x)) {}\n";
-    std::cout << "  ~Workspace" << x.first << "() noexcept {if (islast() and not isnull()) delete v;}\n";
-    std::cout << "  Workspace" << x.first << "(const type& val) noexcept : p(std::numeric_limits<std::size_t>::max()), v(new type(val)) {}\n";
+    std::cout << "  " << x.first << "(std::size_t i, void * x) noexcept : p(i), " "v(static_cast<type *>(x)) {}\n";
+    std::cout << "  ~" << x.first << "() noexcept {if (islast() and not isnull()) delete v;}\n";
+    std::cout << "  " << x.first << "(const type& val) noexcept : p(std::numeric_limits<std::size_t>::max()), v(new type(val)) {}\n";
     std::cout << "  type& value() noexcept {return *v;}\n";
     std::cout << "  const type& value() const noexcept {return *v;}\n";
     std::cout
-        << "  Workspace" << x.first
+        << "  " << x.first
         << "& operator=(const type& t) noexcept {value() = t; return *this;}\n";
     std::cout << "  std::size_t pos() const noexcept {return p;}\n";
     std::cout << "  bool isnull() const noexcept {return v == nullptr;}\n";
@@ -433,7 +435,7 @@ int main() {
     std::cout << "@return A class with a pointer to this variable and its "
                  "position in the workspace\n*/\n";
     std::cout << "[[nodiscard]] inline ";
-    std::cout << "Workspace" << x.second.varname_group << ' ' << x.first
+    std::cout << x.second.varname_group << ' ' << x.first
               << "(Workspace& ws) "
                  "noexcept { "
                  "return {"
@@ -459,7 +461,7 @@ int main() {
                  "position in the workspace\n";
     std::cout << "*/\n";
     std::cout << "[[nodiscard]] inline\n";
-    std::cout << "Workspace" << x.first << ' ' << x.first
+    std::cout << x.first << ' ' << x.first
               << "Create(\n            Workspace& ws,\n            const Group::"
               << x.first
               << "& inval,\n            const Group::String& name,\n            const Group::"
@@ -468,7 +470,7 @@ int main() {
     std::cout << "  const std::size_t ind = "
                  "std::size_t(ws.add_wsv_inplace({name.c_str(), desc.c_str(), "
               << x.second << "}));\n";
-    std::cout << "  Workspace" << x.first << ' ' << "val{ind, ws[ind]};\n";
+    std::cout << "  " << x.first << ' ' << "val{ind, ws[ind]};\n";
     std::cout << "  return val = inval;\n"
               << "}\n\n";
   }
@@ -510,7 +512,7 @@ int main() {
 
     // First put all GOUT variables
     for (std::size_t i = 0; i < x.gout.group.size(); i++) {
-      std::cout << ',' << "\n            Var::Workspace" << x.gout.group[i] << ' '
+      std::cout << ',' << "\n            Var::" << x.gout.group[i] << ' '
                 << x.gout.name[i];
     }
 
@@ -518,7 +520,7 @@ int main() {
     for (std::size_t i = 0; i < x.gin.group.size(); i++) {
       if (not x.gin.hasdefs[i]) {
         std::cout << ',' << "\n      "
-                  << "const Var::Workspace" << x.gin.group[i] << ' '
+                  << "const Var::" << x.gin.group[i] << ' '
                   << x.gin.name[i];
       }
     }
@@ -528,11 +530,11 @@ int main() {
       if (x.gin.hasdefs[i]) {
         if (x.gin.defs[i] == "{}") {
           std::cout << ',' << "\n      "
-          << "const Var::Workspace" << x.gin.group[i] << ' ' << x.gin.name[i]
+          << "const Var::" << x.gin.group[i] << ' ' << x.gin.name[i]
           << '=' << "Group::" << x.gin.group[i] << x.gin.defs[i];
         } else {
           std::cout << ',' << "\n      "
-                    << "const Var::Workspace" << x.gin.group[i] << ' ' << x.gin.name[i]
+                    << "const Var::" << x.gin.group[i] << ' ' << x.gin.name[i]
                     << '=' << "Group::" << x.gin.group[i] << '{' << x.gin.defs[i] << '}';
         }
       }
@@ -676,7 +678,7 @@ int main() {
     // Check if we have the first input
     for (std::size_t i = 0; i < x.gout.group.size(); i++) {
       std::cout << ',' << '\n';
-      std::cout << "                     Var::Workspace"
+      std::cout << "                     Var::"
                 << x.gout.group[i] << ' ' << x.gout.name[i];
     }
 
@@ -684,7 +686,7 @@ int main() {
     for (std::size_t i = 0; i < x.gin.group.size(); i++) {
       if (not x.gin.hasdefs[i]) {
         std::cout << ',' << "\n";
-        std::cout << "               const Var::Workspace"
+        std::cout << "               const Var::"
                   << x.gin.group[i] << ' ' << x.gin.name[i];
       }
     }
@@ -693,7 +695,7 @@ int main() {
     for (std::size_t i = 0; i < x.gin.group.size(); i++) {
       if (x.gin.hasdefs[i]) {
         std::cout << ',' << "\n";
-        std::cout << "               const Var::Workspace"
+        std::cout << "               const Var::"
                   << x.gin.group[i] << '&' << ' ' << x.gin.name[i] << '='
                   << "{}";
       }
@@ -828,10 +830,11 @@ int main() {
             << "  @param[in] screen Screen verbosity\n"
             << "  @param[in] file File verbosity\n"
             << "  @param[in] agenda Agenda verbosity\n"
+            << "  @param[in] basename Default basename for output variables\n"
             << "  @return Workspace a full ARTS Workspace\n"
             << "*/\n";
   std::cout <<
-    "inline Workspace init(std::size_t screen=0, std::size_t file=0, std::size_t agenda=0) {\n"
+    "inline Workspace init(std::size_t screen=0, std::size_t file=0, std::size_t agenda=0, const Group::String& basename=\"arts\") {\n"
     "  define_wsv_group_names();\n"
     "  Workspace::define_wsv_data();\n"
     "  Workspace::define_wsv_map();\n"
@@ -850,6 +853,8 @@ int main() {
     "  Var::verbosity(ws).value().set_agenda_verbosity(agenda);\n"
     "  Var::verbosity(ws).value().set_file_verbosity(file);\n"
     "  Var::verbosity(ws).value().set_main_agenda(1);\n"
+    "\n"
+    "  out_basename = basename;\n"
     "\n"
     "  #ifndef NDEBUG\n"
     "  ws.context = \"\";\n"


### PR DESCRIPTION
You were a bit too quick with the merge Oliver, I thought I would have time to add some documentation before the merge.

This adds documentation, renames some types, and allow setting some more global states.

I would like someone to comment on if the documentation makes sense.

I am unsure about the rename and would be willing to revert it.  Before ARTS::Var::WorkspaceIndex was a thing.  To be more consistent, it is now called ARTS::Var::Index.  The latter does not interfere with the global Index, and everything inside the Var namespace knows it has to use a Var::Index.  Everywhere else, it is anyways necessary to use Var::Index, so this does not interfere either with Var::Index.  It thus made more sense to me to have as common a tongue as we can have here.  The hope is anyways that when modules are a thing that there will be no access to the global Index, so then the namespaces having their own similarly named types makes a lot more sense than to have the longer WorkspaceIndex abomination of a name.  Of course, this all applies to all Groups.