### PR TITLE
Use modern OpenMP detection in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ endif ()
 if (ENABLE_CXX20)
   cmake_minimum_required (VERSION 3.12)
 else ()
-  cmake_minimum_required (VERSION 3.8)
+  cmake_minimum_required (VERSION 3.9)
 endif ()
 
 set (CMAKE_LEGACY_CYGWIN_WIN32 0)
@@ -320,12 +320,10 @@ if (WERROR)
   ARTS_ADD_COMPILER_FLAG (Werror)
 endif (WERROR)
 
-if (OPENMP_FOUND)
+if (OpenMP_FOUND)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-  set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
-  set (CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
-endif (OPENMP_FOUND)
+endif ()
 
 set (COMPILER "${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} (${CMAKE_CXX_COMPILER})")
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Building ARTS
 Build Prerequisites:
 
 - gcc/g++ >=8 (or llvm/clang >=10) older versions might work, but are untested
-- cmake (>=3.8)
+- cmake (>=3.9)
 - zlib
 - openblas
 - netcdf (optional)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,10 @@ set (ALL_ARTS_LIBRARIES
 file (GLOB HEADERFILES "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 add_custom_target(UtilityHeadersArts SOURCES ${HEADERFILES})
 
+if (OpenMP_CXX_FOUND)
+  list (APPEND ALL_ARTS_LIBRARIES OpenMP::OpenMP_CXX)
+endif ()
+
 if (ENABLE_RT4)
   list (APPEND ALL_ARTS_LIBRARIES rt4)
 endif (ENABLE_RT4)
@@ -417,9 +421,9 @@ find_program( CSHFOUND csh )
 
 if (MATLABDIR AND ATMLABDIR AND CSHFOUND AND OEM_SUPPORT)
 
-  if (OPENMP_FOUND)
+  if (OpenMP_CXX_FOUND)
     add_definitions(-DOMP)
-  endif (OPENMP_FOUND)
+  endif ()
 
   add_executable (test_oem
     timings.cc


### PR DESCRIPTION
Since version 3.9, CMake provides a cleaner detection of OpenMP.