### PR TITLE
Add llvm key manually

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -83,6 +83,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           if [ "${{ matrix.compiler }}" = "clang" ] && [ "${{ matrix.version }}" = "10" ]; then
+             sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 15CF4D18AF4F7421
              sudo add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main"
           fi
 


### PR DESCRIPTION
Automatic import of the LLVM GPG key regularly fails on build servers. Trying to workaround the issue by manually importing the key.