### PR TITLE
Add error if NetCDF library is missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,9 @@ find_package (LAPACK REQUIRED)
 ########## NetCDF support #########
 if (ENABLE_NETCDF)
   include (FindNetCDF)
+  if (NOT NETCDF_FOUND)
+      message(FATAL_ERROR "NetCDF library not found")
+  endif()
 endif (ENABLE_NETCDF)
 
 ########## FFTW support #########


### PR DESCRIPTION
Throw a CMake error if the NetCDF support was explicitly enabled, but the
library is not available.