### PR TITLE
Remove option to disable C-API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,10 +176,8 @@ endif ()
 
 ########### C API ##########
 
-if (NOT NO_C_API)
-  set (C_API true)
-  add_definitions(-fPIC)
-endif ()
+set (C_API true)
+add_definitions(-fPIC)
 
 ########### Check C header files ##########
 check_include_file (stdlib.h    HAVE_STDLIB_H)
@@ -480,12 +478,6 @@ if (OEM_SUPPORT)
   message (STATUS "OEM enabled")
 else()
   message (STATUS "OEM disabled")
-endif()
-
-if (C_API)
-  message (STATUS "C API enabled (use -DNO_C_API=1 to disable)")
-else()
-  message (STATUS "C API disabled")
 endif()
 
 add_subdirectory (src)

--- a/README.md
+++ b/README.md
@@ -255,13 +255,6 @@ cmake -DENABLE_NETCDF=1 ..
 Disabling features
 ------------------
 
-By default, a library to use the ARTS workspace interface in typhon is built.
-You can disable building the C API:
-
-```
-cmake -DNO_C_API=1 ..
-```
-
 Disable assertions:
 ```
 cmake -DNO_ASSERT=1 ..


### PR DESCRIPTION
We can't live without it anymore. Disabling it breaks the build.