### PR TITLE
Account for brew messing with Python 3.9

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Setup (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew unlink python@3.9
+          brew unlink python@3.9 || true
           brew install cmake python@3.8
           sudo pip3.8 install docutils lark-parser matplotlib netCDF4 numpy pytest scipy
           if [ "${{ matrix.compiler }}" = "gcc" ]; then


### PR DESCRIPTION
Don't fail if Python 3.9 is not installed.

Workaround from yesterday was failing because brew now removed Python 3.9 again. 🤪