### PR TITLE
Temporary solution to over-shoot

### DIFF
--- a/controlfiles/artscomponents/wfuns/TestTjacStokes4.arts
+++ b/controlfiles/artscomponents/wfuns/TestTjacStokes4.arts
@@ -16,8 +16,6 @@ INCLUDE "general/continua.arts"
 INCLUDE "general/agendas.arts"
 INCLUDE "general/planet_earth.arts"
 
-StringSet( rt_integration_option, "second order" )
-
 
 # Agenda for scalar gas absorption calculation
 Copy(abs_xsec_agenda, abs_xsec_agenda__noCIA)
@@ -152,8 +150,6 @@ yCalc
 #
 VectorCreate( yref )
 ReadXML( yref, "yREF4.xml" )
-Print(y)
-Print(yref)
 Compare( y, yref, 1e-4,
          "Calculated *y* does not agree with saved reference values." )
 

--- a/controlfiles/artscomponents/wfuns/TestTjacStokes4.arts
+++ b/controlfiles/artscomponents/wfuns/TestTjacStokes4.arts
@@ -16,6 +16,8 @@ INCLUDE "general/continua.arts"
 INCLUDE "general/agendas.arts"
 INCLUDE "general/planet_earth.arts"
 
+StringSet( rt_integration_option, "second order" )
+
 
 # Agenda for scalar gas absorption calculation
 Copy(abs_xsec_agenda, abs_xsec_agenda__noCIA)
@@ -150,6 +152,8 @@ yCalc
 #
 VectorCreate( yref )
 ReadXML( yref, "yREF4.xml" )
+Print(y)
+Print(yref)
 Compare( y, yref, 1e-4,
          "Calculated *y* does not agree with saved reference values." )
 

--- a/src/transmissionmatrix.cc
+++ b/src/transmissionmatrix.cc
@@ -1514,10 +1514,11 @@ void update_radiation_vector(RadiationVector& I,
     } break;
     
     case RadiativeTransferSolver::LinearWeightedEmission: {
-//       for (size_t i = 0; i < dI1.size(); i++) {
-//         dI1[i].addWeightedDerivEmission(PiT, dT1[i], T, I, dJ1[i]);
-//         dI2[i].addWeightedDerivEmission(PiT, dT2[i], T, I, dJ2[i]);
-//       }
+      for (size_t i = 0; i < dI1.size(); i++) {
+        // FIXME: Switch false/true ?????
+        dI1[i].addWeightedDerivEmission(PiT, dT1[i], T, I, J1, J2, dJ1[i], true);
+        dI2[i].addWeightedDerivEmission(PiT, dT2[i], T, I, J1, J2, dJ2[i], false);
+      }
       I.leftMul(T);
       I.add_weighted(T, J1, J2);  
       

--- a/src/transmissionmatrix.cc
+++ b/src/transmissionmatrix.cc
@@ -1514,6 +1514,8 @@ void update_radiation_vector(RadiationVector& I,
     } break;
     
     case RadiativeTransferSolver::LinearWeightedEmission: {
+      if (dI1.size()) throw std::runtime_error("Cannot support derivatives with current integration method\n");
+      
       for (size_t i = 0; i < dI1.size(); i++) {
         // FIXME: Switch false/true ?????
         dI1[i].addWeightedDerivEmission(PiT, dT1[i], T, I, J1, J2, dJ1[i], true);

--- a/src/transmissionmatrix.h
+++ b/src/transmissionmatrix.h
@@ -399,24 +399,25 @@ class TransmissionMatrix {
     if (T(0, 0) < 0.99) {
       const auto od = OptDepth<N>(i);
       const auto doddx = dx.OptDepth<N>(i);
-      const Eigen::Matrix<Numeric, N, 1> second = od.inverse() * (I - (I + od) * T) * far + od.inverse() * (od - I + T) * close;
+      const Eigen::Matrix<Numeric, N, 1> second = od.inverse() * ((I - (I + od) * T) * far + (od - I + T) * close);
       if (first[0] > second[0]) {
-        if (isfar)
+        if (isfar) {
           return od.inverse() * ((I - (I + od) * T) * d
                               - (I + od) * dTdx * far
                               + (doddx + T) * close
-                              - doddx * first);
+                              - doddx * second);
+        }
         else
           return od.inverse() * (
           - (I + od) * dTdx * far
           + (od - I + T) * d
           + (doddx + T) * close
-          - doddx * first);
+          - doddx * second);
       } else {
         return 0.5 * ((I - T) * d - dTdx * (far + close));
       }
     } else {
-      return first;
+      return 0.5 * ((I - T) * d - dTdx * (far + close));
     }
   }
 };


### PR DESCRIPTION
This is code trying to solve a problem of the second order integration routine having much larger source terms than expected.  It now falls back to first order if the first order term is smaller than the second order term.  This is partly in line with the ref I am using here but seems to have some other issues.