### PR TITLE
Secordint

### DIFF
--- a/src/m_fos.cc
+++ b/src/m_fos.cc
@@ -1909,6 +1909,15 @@ void iyHybrid2(Workspace& ws,
                             tot_tra[ip],
                             dlyr_tra_above[ip + 1],
                             dlyr_tra_below[ip + 1],
+                            PropagationMatrix(),
+                            PropagationMatrix(),
+                            ArrayOfPropagationMatrix(),
+                            ArrayOfPropagationMatrix(),
+                            Numeric(),
+                            Vector(),
+                            Vector(),
+                            0,
+                            0,
                             RadiativeTransferSolver::Emission);
   }
 

--- a/src/m_transmitter.cc
+++ b/src/m_transmitter.cc
@@ -1000,6 +1000,15 @@ void iyTransmissionStandard(Workspace& ws,
                             tot_tra[ip],
                             dlyr_tra_above[ip + 1],
                             dlyr_tra_below[ip + 1],
+                            PropagationMatrix(),
+                            PropagationMatrix(),
+                            ArrayOfPropagationMatrix(),
+                            ArrayOfPropagationMatrix(),
+                            Numeric(),
+                            Vector(),
+                            Vector(),
+                            0,
+                            0,
                             RadiativeTransferSolver::Transmission);
   }
 

--- a/src/propagationmatrix.h
+++ b/src/propagationmatrix.h
@@ -37,6 +37,166 @@
 #include "complex.h"
 #include "matpackIV.h"
 
+inline Eigen::Matrix<double, 1, 1> matrix1(const Numeric& a) noexcept {
+  return Eigen::Matrix<double, 1, 1>(a);
+}
+
+inline Eigen::Matrix2d matrix2(const Numeric& a, const Numeric& b) noexcept {
+  return (Eigen::Matrix2d() << a, b, b, a).finished();
+}
+
+inline Eigen::Matrix3d matrix3(const Numeric& a,
+                               const Numeric& b,
+                               const Numeric& c,
+                               const Numeric& u) noexcept {
+                                 return (Eigen::Matrix3d() << a, b, c, b, a, u, c, -u, a).finished();
+                               }
+
+inline Eigen::Matrix4d matrix4(const Numeric& a,
+                               const Numeric& b,
+                               const Numeric& c,
+                               const Numeric& d,
+                               const Numeric& u,
+                               const Numeric& v,
+                               const Numeric& w) noexcept {
+  return (Eigen::Matrix4d() << a,
+          b,
+          c,
+          d,
+          b,
+          a,
+          u,
+          v,
+          c,
+          -u,
+          a,
+          w,
+          d,
+          -v,
+          -w,
+          a)
+      .finished();
+}
+
+template <int N>
+Eigen::Matrix<double, N, N> matrix_from_vectorview(const ConstVectorView vec) {
+  static_assert (N>0 and N<5, "Bad size N");
+  if constexpr (N == 1) {
+    return matrix1(vec[0]);
+  } else if constexpr (N==2) {
+    return matrix2(vec[0], vec[1]);
+  } else if constexpr (N==3) {
+    return matrix3(vec[0], vec[1], vec[2], vec[3]);
+  } else if constexpr (N==4) {
+    return matrix4(vec[0], vec[1], vec[2], vec[3], vec[4], vec[5], vec[6]);
+  }
+}
+
+inline Eigen::Matrix<double, 1, 1> matrix1(const ConstMatrixView m) noexcept {
+  return Eigen::Matrix<double, 1, 1>(m(0, 0));
+}
+
+inline Eigen::Matrix2d matrix2(const ConstMatrixView m) noexcept {
+  return (Eigen::Matrix2d() << m(0, 0), m(0, 1), m(1, 0), m(1, 1)).finished();
+}
+
+inline Eigen::Matrix3d matrix3(const ConstMatrixView m) noexcept {
+  return (Eigen::Matrix3d() << m(0, 0),
+          m(0, 1),
+          m(0, 2),
+          m(1, 0),
+          m(1, 1),
+          m(1, 2),
+          m(2, 0),
+          m(2, 1),
+          m(2, 2))
+      .finished();
+}
+
+inline Eigen::Matrix4d matrix4(const ConstMatrixView m) noexcept {
+  return (Eigen::Matrix4d() << m(0, 0),
+          m(0, 1),
+          m(0, 2),
+          m(0, 3),
+          m(1, 0),
+          m(1, 1),
+          m(1, 2),
+          m(1, 3),
+          m(2, 0),
+          m(2, 1),
+          m(2, 2),
+          m(2, 3),
+          m(3, 0),
+          m(3, 1),
+          m(3, 2),
+          m(3, 3))
+      .finished();
+}
+
+inline Eigen::Matrix<double, 1, 1> inv1(const Numeric& a) noexcept {
+  return Eigen::Matrix<double, 1, 1>(1 / a);
+}
+
+inline Eigen::Matrix2d inv2(const Numeric& a, const Numeric& b) noexcept {
+  return (Eigen::Matrix2d() << a, -b, -b, a).finished() / (a * a - b * b);
+}
+
+inline Eigen::Matrix3d inv3(const Numeric& a,
+                            const Numeric& b,
+                            const Numeric& c,
+                            const Numeric& u) noexcept {
+  return (Eigen::Matrix3d() << a * a + u * u,
+          -a * b - c * u,
+          -a * c + b * u,
+          -a * b + c * u,
+          a * a - c * c,
+          -a * u + b * c,
+          -a * c - b * u,
+          a * u + b * c,
+          a * a - b * b)
+             .finished() /
+         (a * a * a - a * b * b - a * c * c + a * u * u);
+}
+
+inline Eigen::Matrix4d inv4(const Numeric& a,
+                            const Numeric& b,
+                            const Numeric& c,
+                            const Numeric& d,
+                            const Numeric& u,
+                            const Numeric& v,
+                            const Numeric& w) noexcept {
+  return (Eigen::Matrix4d() << a * a * a + a * u * u + a * v * v + a * w * w,
+          -a * a * b - a * c * u - a * d * v - b * w * w + c * v * w -
+              d * u * w,
+          -a * a * c + a * b * u - a * d * w + b * v * w - c * v * v +
+              d * u * v,
+          -a * a * d + a * b * v + a * c * w - b * u * w + c * u * v -
+              d * u * u,
+          -a * a * b + a * c * u + a * d * v - b * w * w + c * v * w -
+              d * u * w,
+          a * a * a - a * c * c - a * d * d + a * w * w,
+          -a * a * u + a * b * c - a * v * w + b * d * w - c * d * v +
+              d * d * u,
+          -a * a * v + a * b * d + a * u * w - b * c * w + c * c * v -
+              c * d * u,
+          -a * a * c - a * b * u + a * d * w + b * v * w - c * v * v +
+              d * u * v,
+          a * a * u + a * b * c - a * v * w - b * d * w + c * d * v - d * d * u,
+          a * a * a - a * b * b - a * d * d + a * v * v,
+          -a * a * w + a * c * d - a * u * v + b * b * w - b * c * v +
+              b * d * u,
+          -a * a * d - a * b * v - a * c * w - b * u * w + c * u * v -
+              d * u * u,
+          a * a * v + a * b * d + a * u * w + b * c * w - c * c * v + c * d * u,
+          a * a * w + a * c * d - a * u * v - b * b * w + b * c * v - b * d * u,
+          a * a * a - a * b * b - a * c * c + a * u * u)
+             .finished() /
+         (a * a * a * a - a * a * b * b - a * a * c * c - a * a * d * d +
+          a * a * u * u + a * a * v * v + a * a * w * w - b * b * w * w +
+          2 * b * c * v * w - 2 * b * d * u * w - c * c * v * v +
+          2 * c * d * u * v - d * d * u * u);
+}
+
 /** Class to help with hidden temporary variables for operations of type Numeric times Class
  * 
  * This class only exists in public settings and other classes are required to implement its

--- a/src/propmat_field.cc
+++ b/src/propmat_field.cc
@@ -246,5 +246,14 @@ void emission_from_propmat_field(
                             tot_tra[ip],
                             tmtmp,
                             tmtmp,
+                            PropagationMatrix(),
+                            PropagationMatrix(),
+                            ArrayOfPropagationMatrix(),
+                            ArrayOfPropagationMatrix(),
+                            Numeric(),
+                            Vector(),
+                            Vector(),
+                            0,
+                            0,
                             RadiativeTransferSolver::Emission);
 }

--- a/src/transmissionmatrix.cc
+++ b/src/transmissionmatrix.cc
@@ -99,152 +99,6 @@ inline Eigen::Vector4d vector4(const StokesVector& a,
                            dS.K14()[i] + da.K14()[i] * B[i]);
 }
 
-inline Eigen::Matrix<double, 1, 1> matrix1(const Numeric& a) noexcept {
-  return Eigen::Matrix<double, 1, 1>(a);
-}
-
-inline Eigen::Matrix2d matrix2(const Numeric& a, const Numeric& b) noexcept {
-  return (Eigen::Matrix2d() << a, b, b, a).finished();
-}
-
-inline Eigen::Matrix3d matrix3(const Numeric& a,
-                               const Numeric& b,
-                               const Numeric& c,
-                               const Numeric& u) noexcept {
-  return (Eigen::Matrix3d() << a, b, c, b, a, u, c, -u, a).finished();
-}
-
-inline Eigen::Matrix4d matrix4(const Numeric& a,
-                               const Numeric& b,
-                               const Numeric& c,
-                               const Numeric& d,
-                               const Numeric& u,
-                               const Numeric& v,
-                               const Numeric& w) noexcept {
-  return (Eigen::Matrix4d() << a,
-          b,
-          c,
-          d,
-          b,
-          a,
-          u,
-          v,
-          c,
-          -u,
-          a,
-          w,
-          d,
-          -v,
-          -w,
-          a)
-      .finished();
-}
-
-inline Eigen::Matrix<double, 1, 1> matrix1(const ConstMatrixView m) noexcept {
-  return Eigen::Matrix<double, 1, 1>(m(0, 0));
-}
-
-inline Eigen::Matrix2d matrix2(const ConstMatrixView m) noexcept {
-  return (Eigen::Matrix2d() << m(0, 0), m(0, 1), m(1, 0), m(1, 1)).finished();
-}
-
-inline Eigen::Matrix3d matrix3(const ConstMatrixView m) noexcept {
-  return (Eigen::Matrix3d() << m(0, 0),
-          m(0, 1),
-          m(0, 2),
-          m(1, 0),
-          m(1, 1),
-          m(1, 2),
-          m(2, 0),
-          m(2, 1),
-          m(2, 2))
-      .finished();
-}
-
-inline Eigen::Matrix4d matrix4(const ConstMatrixView m) noexcept {
-  return (Eigen::Matrix4d() << m(0, 0),
-          m(0, 1),
-          m(0, 2),
-          m(0, 3),
-          m(1, 0),
-          m(1, 1),
-          m(1, 2),
-          m(1, 3),
-          m(2, 0),
-          m(2, 1),
-          m(2, 2),
-          m(2, 3),
-          m(3, 0),
-          m(3, 1),
-          m(3, 2),
-          m(3, 3))
-      .finished();
-}
-
-inline Eigen::Matrix<double, 1, 1> inv1(const Numeric& a) noexcept {
-  return Eigen::Matrix<double, 1, 1>(1 / a);
-}
-
-inline Eigen::Matrix2d inv2(const Numeric& a, const Numeric& b) noexcept {
-  return (Eigen::Matrix2d() << a, -b, -b, a).finished() / (a * a - b * b);
-}
-
-inline Eigen::Matrix3d inv3(const Numeric& a,
-                            const Numeric& b,
-                            const Numeric& c,
-                            const Numeric& u) noexcept {
-  return (Eigen::Matrix3d() << a * a + u * u,
-          -a * b - c * u,
-          -a * c + b * u,
-          -a * b + c * u,
-          a * a - c * c,
-          -a * u + b * c,
-          -a * c - b * u,
-          a * u + b * c,
-          a * a - b * b)
-             .finished() /
-         (a * a * a - a * b * b - a * c * c + a * u * u);
-}
-
-inline Eigen::Matrix4d inv4(const Numeric& a,
-                            const Numeric& b,
-                            const Numeric& c,
-                            const Numeric& d,
-                            const Numeric& u,
-                            const Numeric& v,
-                            const Numeric& w) noexcept {
-  return (Eigen::Matrix4d() << a * a * a + a * u * u + a * v * v + a * w * w,
-          -a * a * b - a * c * u - a * d * v - b * w * w + c * v * w -
-              d * u * w,
-          -a * a * c + a * b * u - a * d * w + b * v * w - c * v * v +
-              d * u * v,
-          -a * a * d + a * b * v + a * c * w - b * u * w + c * u * v -
-              d * u * u,
-          -a * a * b + a * c * u + a * d * v - b * w * w + c * v * w -
-              d * u * w,
-          a * a * a - a * c * c - a * d * d + a * w * w,
-          -a * a * u + a * b * c - a * v * w + b * d * w - c * d * v +
-              d * d * u,
-          -a * a * v + a * b * d + a * u * w - b * c * w + c * c * v -
-              c * d * u,
-          -a * a * c - a * b * u + a * d * w + b * v * w - c * v * v +
-              d * u * v,
-          a * a * u + a * b * c - a * v * w - b * d * w + c * d * v - d * d * u,
-          a * a * a - a * b * b - a * d * d + a * v * v,
-          -a * a * w + a * c * d - a * u * v + b * b * w - b * c * v +
-              b * d * u,
-          -a * a * d - a * b * v - a * c * w - b * u * w + c * u * v -
-              d * u * u,
-          a * a * v + a * b * d + a * u * w + b * c * w - c * c * v + c * d * u,
-          a * a * w + a * c * d - a * u * v - b * b * w + b * c * v - b * d * u,
-          a * a * a - a * b * b - a * c * c + a * u * u)
-             .finished() /
-         (a * a * a * a - a * a * b * b - a * a * c * c - a * a * d * d +
-          a * a * u * u + a * a * v * v + a * a * w * w - b * b * w * w +
-          2 * b * c * v * w - 2 * b * d * u * w - c * c * v * v +
-          2 * c * d * u * v - d * d * u * u);
-}
-
 inline void transmat1(TransmissionMatrix& T,
                       const PropagationMatrix& K1,
                       const PropagationMatrix& K2,
@@ -1493,6 +1347,15 @@ void update_radiation_vector(RadiationVector& I,
                              const TransmissionMatrix& PiT,
                              const ArrayOfTransmissionMatrix& dT1,
                              const ArrayOfTransmissionMatrix& dT2,
+                             [[maybe_unused]] const PropagationMatrix& K1,
+                             [[maybe_unused]] const PropagationMatrix& K2,
+                             [[maybe_unused]] const ArrayOfPropagationMatrix& dK1,
+                             [[maybe_unused]] const ArrayOfPropagationMatrix& dK2,
+                             [[maybe_unused]] const Numeric r,
+                             [[maybe_unused]] const Vector& dr1,
+                             [[maybe_unused]] const Vector& dr2,
+                             [[maybe_unused]] const Index ia,
+                             [[maybe_unused]] const Index iz,
                              const RadiativeTransferSolver solver) {
   switch (solver) {
     case RadiativeTransferSolver::Emission: {
@@ -1516,13 +1379,8 @@ void update_radiation_vector(RadiationVector& I,
     case RadiativeTransferSolver::LinearWeightedEmission: {
       if (dI1.size()) throw std::runtime_error("Cannot support derivatives with current integration method\n");
       
-      for (size_t i = 0; i < dI1.size(); i++) {
-        // FIXME: Switch false/true ?????
-        dI1[i].addWeightedDerivEmission(PiT, dT1[i], T, I, J1, J2, dJ1[i], true);
-        dI2[i].addWeightedDerivEmission(PiT, dT2[i], T, I, J1, J2, dJ2[i], false);
-      }
       I.leftMul(T);
-      I.add_weighted(T, J1, J2);  
+      I.add_weighted(T, J1, J2, K1.Data()(ia, iz, joker, joker), K2.Data()(ia, iz, joker, joker), r);  
       
     } break;
   }


### PR DESCRIPTION
This makes the code compliant with the source for second order integration (except using first order calculations rather than the delta-s version of Qmax; the source function never defines delta-s so I assume it is the distance but cannot know for sure).  Note that I leave a lot of fixmes around here.  This is not good code but it solves the problem.

The new output is close to the results from before but the second order integration case is activated more often.  This improves the forward results of TestTjacStokes4.arts, for example, because the output using second order integration is closer to the values if the pressure grid is ten times as dense of first order integration.

Note that I don't think this or the previous code should have been merged before we have a proper derivation of the equations and can redesign the entire absorption-to-RT step accordingly.  All of our RT algorithms are turning into spaghetti code at this rate.  For instance, one of the steps in these equations would work rather better if they had alpha and j rather than S and K.  The latter are not necessarily the same according to how we have defined them, so I am unsure whether or not this code can at all work with the iy-transmission code...  we currently throw away j and alpha after computing S.