### PR TITLE
Switch to default python from brew for macos build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -119,9 +119,7 @@ jobs:
       - name: Setup (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew unlink python@3.9 || true
-          brew install cmake python@3.8
-          sudo pip3.8 install docutils lark-parser matplotlib netCDF4 numpy pytest scipy
+          sudo pip3 install docutils lark-parser matplotlib netCDF4 numpy pytest scipy
           if [ "${{ matrix.compiler }}" = "gcc" ]; then
             brew install gcc@${{ matrix.version }}
             echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV


### PR DESCRIPTION
Recent macOS builds were failing with Python 3.8 due to pip3.8 missing in brew. Since Python 3.9 seems to work fine now in brew, we're switching to the latest Python version.