### PR TITLE
Add custom check-deps target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,25 +411,27 @@ if (CMAKE_GENERATOR STREQUAL "Xcode")
   set (CTEST_MISC_OPTIONS -C \${CONFIGURATION})
 endif (CMAKE_GENERATOR STREQUAL "Xcode")
 
+add_custom_target(check-deps)
+
 add_custom_target(check
-  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} -E '\(python.|.pyarts.|.nocheck.|.slow.|.xmldata.|.planettoolbox.\)' DEPENDS arts)
+  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} -E '\(python.|.pyarts.|.nocheck.|.slow.|.xmldata.|.planettoolbox.\)' DEPENDS check-deps)
 
 add_custom_target(check-python
-  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} -R '\(python.|.pyarts.|.cmdline.|.doc.\)' -E '\(.nocheck.|.slow.|.xmldata.|.planettoolbox.\)' DEPENDS python_tests arts)
+  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} -R '\(python.|.pyarts.|.cmdline.|.doc.\)' -E '\(.nocheck.|.slow.|.xmldata.|.planettoolbox.\)' DEPENDS check-deps python_tests)
 
 add_custom_target(check-xmldata
-  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} -R '\(python.|.xmldata.\)' DEPENDS arts)
+  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} -R '\(python.|.xmldata.\)' DEPENDS check-deps)
 
 add_dependencies(check-xmldata mkdir-arts-results)
 
 add_custom_target(check-planettoolbox
-  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} -R '\(.planettoolbox.\)' DEPENDS arts)
+  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} -R '\(.planettoolbox.\)' DEPENDS check-deps)
 
 add_custom_target(check-all
-  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} -E '.nocheck.' DEPENDS arts pyarts python_tests)
+  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} -E '.nocheck.' DEPENDS check-deps pyarts python_tests)
 
 add_custom_target(check-all-controlfiles
-  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} -E '^python.|.pyarts.|.nocheck.' DEPENDS arts)
+  COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} -E '^python.|.pyarts.|.nocheck.' DEPENDS check-deps)
 
 add_custom_target(check-pyarts-only
   COMMAND ${CMAKE_CTEST_COMMAND} ${CTEST_MISC_OPTIONS} --output-on-failure ${CTEST_JOBS} -R '\.pyarts\.' DEPENDS pyarts)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,6 +67,7 @@ add_custom_command (
 
 add_executable (arts main.cc)
 add_dependencies (arts auto_version_h)
+add_dependencies(check-deps arts)
 
 target_link_libraries (arts ${ALL_ARTS_LIBRARIES})
 
@@ -577,6 +578,7 @@ add_custom_target(make_autoarts_h_target SOURCES ${ARTS_BINARY_DIR}/src/autoarts
 # Generate autoarts.h for the ARTS interface
 add_executable(test_cpp_api test_cpp_api.cc)
 target_link_libraries(test_cpp_api public_arts_interface)
+add_dependencies(check-deps test_cpp_api)
 add_test(NAME "arts.cpp_api.fast.silly_groundbased_water_test" COMMAND test_cpp_api)
 ########################################################################################
 


### PR DESCRIPTION
'make check' did not trigger a build of test_cpp_api. This commit
introduces a custom target 'check-deps' to which essential dependencies
for checks can be added to. Currently contains arts and test_cpp_api.