### PR TITLE
Additional issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a report to help us improve ARTS
 title: ''
 labels: bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -1,0 +1,22 @@
+---
+name: Documentation request
+about: Suggest an idea or improvement for the documentation of ARTS
+title: ''
+labels: documentation
+assignees: ''
+
+---
+
+**Which part of the documentation do you suggest an improvement for?**
+User/Theory/Developer Guide
+Built-in/docserver documentation
+Doxygen documentation
+
+**Describe the problem**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -8,9 +8,11 @@ assignees: ''
 ---
 
 **Which part of the documentation do you suggest an improvement for?**
+Delete the non-applicable items from the list:
 User/Theory/Developer Guide
 Built-in/docserver documentation
 Doxygen documentation
+PyARTS documentation
 
 **Describe the problem**
 A clear and concise description of what the problem is.

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -6,6 +6,8 @@ labels: documentation
 assignees: ''
 
 ---
+For corrections of errors in the documentation, please consider submitting
+a pull request with the changes instead of opening an issue.
 
 **Which part of the documentation do you suggest an improvement for?**
 Delete the non-applicable items from the list:
@@ -19,6 +21,9 @@ A clear and concise description of what the problem is.
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
+
+**Are you willing to help adding this improvement?**
+Describe the extend of your commitment/contribution.
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,13 +1,13 @@
 ---
-name: Feature request
-about: Suggest a new feature for ARTS
+name: Enhancement request
+about: Suggest an improvement for an existing feature in ARTS
 title: ''
-labels: feature
+labels: enhancement
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+**Is your enhancement request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 **Describe the solution you'd like**

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -16,5 +16,8 @@ A clear and concise description of what you want to happen.
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
 
+**Are you willing to help adding this enhancement?**
+Describe the extend of your commitment/contribution to implement this feature.
+
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,13 +8,16 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+A clear and concise description of what the problem is.
 
 **Describe the solution you'd like**
 A clear and concise description of what you want to happen.
 
 **Describe alternatives you've considered**
 A clear and concise description of any alternative solutions or features you've considered.
+
+**Are you willing to help adding this feature?**
+Describe the extend of your commitment/contribution to implement this feature.
 
 **Additional context**
 Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This PR adds new issue templates for documentation, feature and enhancement related topics.
You can look at the new templates in action on my fork:

https://github.com/olemke/arts/issues/new/choose

Since we have to separate labels defined for "feature" and "enhancement", I've also added two separate templates to cover those cases.

Any comments / feedback / improvement ideas on these templates?