### PR TITLE
Add missing c_void_p to LineShapeModel argtypes

### DIFF
--- a/python/pyarts/classes/LineShapeModel.py
+++ b/python/pyarts/classes/LineShapeModel.py
@@ -103,7 +103,7 @@ lib.getelemLineShapeModel.restype = c.c_void_p
 lib.getelemLineShapeModel.argtypes = [c.c_long, c.c_void_p]
 
 lib.sizeLineShapeModel.restype = c.c_long
-lib.sizeLineShapeModel.argtypes = []
+lib.sizeLineShapeModel.argtypes = [c.c_void_p]
 
 lib.resizeLineShapeModel.restype = None
-lib.resizeLineShapeModel.argtypes = [c.c_long]
+lib.resizeLineShapeModel.argtypes = [c.c_long, c.c_void_p]


### PR DESCRIPTION
sizeLineShapeModel and resizeLineshapeModel argtypes definition was missing
the c_void_p argument leading to immediate segfault on arm64 when importing
pyarts.