### PR TITLE
Add native classes support to .value

### DIFF
--- a/python/pyarts/workspace/variables.py
+++ b/python/pyarts/workspace/variables.py
@@ -411,6 +411,8 @@ class WorkspaceVariable:
             workspace.
         """
         from pyarts.xml import load
+        from pyarts.types import classes as arts_classes
+        from pyarts import classes as native_classes
 
         if not self.ws:
             raise Exception("Cannot retrieve the value of a variable without "
@@ -418,7 +420,12 @@ class WorkspaceVariable:
         with tempfile.TemporaryDirectory() as tmpdir:
             tfile = os.path.join(tmpdir, 'wsv.xml')
             self.ws.WriteXML("binary", self, tfile)
-            v = load(tfile)
+            if self.group in arts_classes:
+                v = load(tfile)
+            else:
+                cls = getattr(native_classes, self.group)
+                v = cls()
+                v.readxml(tfile)
 
         return v
 

--- a/python/pyarts/workspace/variables.py
+++ b/python/pyarts/workspace/variables.py
@@ -305,6 +305,7 @@ class WorkspaceVariable:
 
         """
         from pyarts.types import classes as arts_classes
+        from pyarts import classes as native_classes
 
 
         if (self.ws):
@@ -360,11 +361,14 @@ class WorkspaceVariable:
             else:
                 return np.zeros(shape)
         else:
-            try:
-                return self.to_arts()
-            except:
-                raise Exception("Type of workspace variable is not supported "
-                                + " by the interface.")
+            if self.group in arts_classes:
+                try:
+                    return self.to_arts()
+                except:
+                    raise Exception("Type of workspace variable is not supported "
+                                    + " by the interface.")
+            else:
+                return native_classes.from_workspace(self)
 
     def update(self):
         """ Update data references of the object.
@@ -411,8 +415,6 @@ class WorkspaceVariable:
             workspace.
         """
         from pyarts.xml import load
-        from pyarts.types import classes as arts_classes
-        from pyarts import classes as native_classes
 
         if not self.ws:
             raise Exception("Cannot retrieve the value of a variable without "
@@ -420,12 +422,7 @@ class WorkspaceVariable:
         with tempfile.TemporaryDirectory() as tmpdir:
             tfile = os.path.join(tmpdir, 'wsv.xml')
             self.ws.WriteXML("binary", self, tfile)
-            if self.group in arts_classes:
-                v = load(tfile)
-            else:
-                cls = getattr(native_classes, self.group)
-                v = cls()
-                v.readxml(tfile)
+            v = load(tfile)
 
         return v
 

--- a/python/test/workspace/test_variables.py
+++ b/python/test/workspace/test_variables.py
@@ -152,6 +152,18 @@ class TestVariables:
         self.ws.tensor_7 = t_0
         assert np.all(t_0 == self.ws.tensor_7.value)
 
+    def test_time(self):
+        """
+        Create and set Time variable.
+        """
+        times = ["2020-01-02 03:04:05", "2021-02-03 04:05:06"]
+        self.ws.ArrayOfTimeCreate("time_1")
+        self.ws.ArrayOfTimeNLinSpace(self.ws.time_1, 2, times[0], times[1])
+        assert (
+                times[0] == str(self.ws.time_1.value[0])[0:19]
+                and times[1] == str(self.ws.time_1.value[1])[0:19]
+        )
+
     def test_creation(self):
         """
         Test creation of WSVs.

--- a/src/xml_io_basic_types.cc
+++ b/src/xml_io_basic_types.cc
@@ -1587,7 +1587,7 @@ void xml_write_to_stream(ostream& os_xml,
  */
 void xml_read_from_stream(istream& is_xml,
                           Time& t,
-                          bifstream* pbifs,
+                          bifstream* pbifs [[maybe_unused]],
                           const Verbosity& verbosity) {
   ArtsXMLTag tag(verbosity);
   
@@ -1598,8 +1598,6 @@ void xml_read_from_stream(istream& is_xml,
   tag.get_attribute_value("version", version);
   ARTS_USER_ERROR_IF (version not_eq 1,
                       "Your version of ARTS can only handle version 1 of Time");
-  
-  ARTS_USER_ERROR_IF (pbifs, "Cannot read binary Time");
   
   is_xml >> t;
   if (is_xml.fail()) {
@@ -1619,7 +1617,7 @@ void xml_read_from_stream(istream& is_xml,
  */
 void xml_write_to_stream(ostream& os_xml,
                          const Time& t,
-                         bofstream* pbofs,
+                         bofstream* pbofs [[maybe_unused]],
                          const String&,
                          const Verbosity& verbosity) {
   ArtsXMLTag open_tag(verbosity);
@@ -1630,7 +1628,6 @@ void xml_write_to_stream(ostream& os_xml,
   open_tag.write_to_stream(os_xml);
 
   xml_set_stream_precision(os_xml);
-  ARTS_USER_ERROR_IF (pbofs, "Cannot write binary time");
   
   os_xml << ' ' << t << ' ';
 


### PR DESCRIPTION
When accessing WSV with .value that don't have a native Python class implementation, fall back to use Richard's native classes to pass the value from ARTS to Python, e.g. ws.time.value works now.