### PR TITLE
Add python unit tests to pyarts ctest cases

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -114,12 +114,12 @@ jobs:
           fi
 
           sudo apt-get install -y python3-minimal python3-pip python3-setuptools zlib1g-dev libopenblas-dev libfftw3-dev
-          sudo pip3 install docutils lark-parser matplotlib netCDF4 numpy pytest scipy
+          sudo pip3 install docutils lark-parser matplotlib netCDF4 numpy pytest scipy xarray
 
       - name: Setup (macOS)
         if: runner.os == 'macOS'
         run: |
-          sudo pip3 install docutils lark-parser matplotlib netCDF4 numpy pytest scipy
+          sudo pip3 install docutils lark-parser matplotlib netCDF4 numpy pytest scipy xarray
           if [ "${{ matrix.compiler }}" = "gcc" ]; then
             brew install gcc@${{ matrix.version }}
             echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV

--- a/cmake/modules/CheckPythonModule.cmake
+++ b/cmake/modules/CheckPythonModule.cmake
@@ -11,7 +11,8 @@ macro (CHECK_PYTHON_MODULES)
     numpy
     pytest
     scipy
-    setuptools)
+    setuptools
+    xarray)
 
   set(PYPI_NAMES
     docutils
@@ -21,7 +22,8 @@ macro (CHECK_PYTHON_MODULES)
     numpy
     pytest
     scipy
-    setuptools)
+    setuptools
+    xarray)
 
   list(LENGTH REQUIRED_MODULES len1)
   math(EXPR len2 "${len1} - 1")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -52,6 +52,11 @@ add_custom_target(python_tests
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS pyarts
   COMMENT "Converting *.arts controlfiles to Python")
+add_test(
+  NAME arts.pyarts.pytest
+  COMMAND ${PYTHON_EXECUTABLE} -m pytest test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
 
 file(COPY test/reference DESTINATION test/)
 file(COPY test/xml/reference DESTINATION test/xml/)


### PR DESCRIPTION
Python unit tests are executed as part of the ctest suite. They can be
run directly with 'ctest -V -R pytest'