### PR TITLE
Fix codesign issue on M1 Macs

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import remove
-from os.path import abspath, dirname, join
+from os.path import abspath, dirname, isfile, join
 
 import builtins
 
@@ -33,7 +33,8 @@ here = abspath(dirname(__file__))
 try:
     arts_libname = "libarts_api.so"
     lib_path = join("@ARTS_BINARY_DIR@", "src", arts_libname)
-    remove(join("pyarts", "workspace", arts_libname))
+    if isfile(join("pyarts", "workspace", arts_libname)):
+        remove(join("pyarts", "workspace", arts_libname))
     shutil.copy(lib_path, join("pyarts", "workspace"))
 except:
     raise Exception(

--- a/python/setup.py
+++ b/python/setup.py
@@ -17,6 +17,7 @@ from setuptools import setup, find_packages
 
 # To use a consistent encoding
 from codecs import open
+from os import remove
 from os.path import abspath, dirname, join
 
 import builtins
@@ -30,8 +31,10 @@ STABLE = int(VERSION_TUPLE[1]) % 2 == 0
 here = abspath(dirname(__file__))
 
 try:
-    lib_path = join("@ARTS_BINARY_DIR@", "src", "libarts_api.so")
-    shutil.copy(lib_path, "pyarts/workspace")
+    arts_libname = "libarts_api.so"
+    lib_path = join("@ARTS_BINARY_DIR@", "src", arts_libname)
+    remove(join("pyarts", "workspace", arts_libname))
+    shutil.copy(lib_path, join("pyarts", "workspace"))
 except:
     raise Exception(
         "Could not find ARTS API, which is required for the Python "


### PR DESCRIPTION
On M1 Macs, the Python process gets killed by the OS when importing
pyarts after recompiling the libarts_api library.

macOS codesigns libraries and executables on first execution.  This
signature is verified on each further execution to ensure the binary has
not been tampered with.  The file is not allowed to be changed and
re-signed.  The inode of the file has to change to be able to generate a
new signature for the file.

shutil.copy, used in setup.py to overwrite the old library with the
recompiled version, replaces the contents of the old file without
changing its inode.  This leads to a mismatched signature on the next
import of the library into Python.

This problem is avoided by deleting the old library before copying the
new one into pyarts/workspace.