### PR TITLE
Add xml load/save support for ARTS C++ classes

### DIFF
--- a/python/pyarts/classes/__init__.py
+++ b/python/pyarts/classes/__init__.py
@@ -47,7 +47,7 @@ from pyarts.classes.Timer import Timer
 from pyarts.classes.TransmissionMatrix import TransmissionMatrix, ArrayOfTransmissionMatrix, ArrayOfArrayOfTransmissionMatrix
 from pyarts.classes.Vector import Vector, ArrayOfVector, ArrayOfArrayOfVector
 from pyarts.classes.Verbosity import Verbosity
-from pyarts.classes.XsecRecord import ArrayOfXsecRecord
+from pyarts.classes.XsecRecord import XsecRecord, ArrayOfXsecRecord
 
 
 # Attempt at conversions


### PR DESCRIPTION
Add compatibility to the xml load/save PyARTS functions for ARTS
classes that are only available through the C++ API.

load first tries to read the file with the Python interface.
If that fails, it uses the C++ classes interface.

save checks if the variable contains a savexml function which all the C++
ARTS classes do. If not, it falls back to the Python XML writer.