### PR TITLE
Update hitran online and all hitran IO routines to use different

### DIFF
--- a/python/pyarts/__init__.py
+++ b/python/pyarts/__init__.py
@@ -8,6 +8,7 @@ from pyarts import xml  # noqa
 from pyarts import classes  # noqa
 from pyarts import workspace  # noqa
 from pyarts.common import *  # noqa
+from pyarts import hitran  # noqa
 
 __all__ = [s for s in dir() if not s.startswith('_')]
 __version__ = "@ARTS_VERSION@"

--- a/python/pyarts/hitran.py
+++ b/python/pyarts/hitran.py
@@ -1,14 +1,24 @@
 from urllib.request import urlopen
 
+# Map Hitran to ARTS species names
+_HITRAN_TO_ARTS_NAMES = {
+    "CH3CN-2124": "CH3CN-211124",
+    "CO2-827": "CO2-728",
+    "H2CO-126": "H2CO-1126",
+    "H2CO-128": "H2CO-1128",
+    "H2CO-136": "H2CO-1136",
+    "HC3N-1224": "HC3N-12224",
+    "HCOOH-126": "HCOOH-1261",
+}
+
 
 def gen_latest_molparam_map(molparam_txt_file=None):
     """ Generates a version of latest_molparam_map used in hitran_species.cc
 
     The variable is simply printed to stream with print() as the intent is
-    to use this output in ARTS directly.  Note, to keep this simple, however,
-    that since HITRAN does not know about ARTS tags, the species name is
-    given as Species-AFGL.  ARTS does not use AFGL notation internally so
-    some of these have to be manually changed.
+    to use this output in ARTS directly.  ARTS does not use AFGL notation
+    internally, but species names that are different from Hitran are mapped to
+    ARTS names in the output.
     """
     def pos2char(ind):
         """ Convert an isotoplogue index to a HITRAN char for that index """
@@ -47,6 +57,9 @@ def gen_latest_molparam_map(molparam_txt_file=None):
     for spec in out:
         print ('{',out[spec][0][0], ', {  // ', spec, sep='')
         for isot in out[spec]:
-            print ('{', pos2char(isot[1]), ', "{}-{}"'.format(spec, isot[2]), '},', sep='')
+            isoname = f"{spec}-{isot[2]}"
+            if isoname in _HITRAN_TO_ARTS_NAMES:
+                isoname = _HITRAN_TO_ARTS_NAMES[isoname]
+            print ('{', pos2char(isot[1]), ', "', isoname, '"},', sep='')
         print ('}},')
     print ('};')

--- a/python/pyarts/hitran.py
+++ b/python/pyarts/hitran.py
@@ -1,4 +1,7 @@
-def gen_latest_molparam_map(molparam_txt_file):
+from urllib.request import urlopen
+
+
+def gen_latest_molparam_map(molparam_txt_file=None):
     """ Generates a version of latest_molparam_map used in hitran_species.cc
 
     The variable is simply printed to stream with print() as the intent is
@@ -17,8 +20,12 @@ def gen_latest_molparam_map(molparam_txt_file):
             return "'A'"
         elif ind == 12:
             return "'B'"
-    
-    molparam_txt = open(molparam_txt_file, 'r').read().split('\n')
+
+    if molparam_txt_file:
+        molparam_txt = open(molparam_txt_file, 'r').read().split('\n')
+    else:
+        molparam_txt = urlopen("https://hitran.org/media/molparam.txt").read(
+        ).decode("utf-8").split('\n')
     molparam_txt.pop(0)  # erase header
 
     out = {}

--- a/python/pyarts/hitran.py
+++ b/python/pyarts/hitran.py
@@ -1,0 +1,45 @@
+def gen_latest_molparam_map(molparam_txt_file):
+    """ Generates a version of latest_molparam_map used in hitran_species.cc
+
+    The variable is simply printed to stream with print() as the intent is
+    to use this output in ARTS directly.  Note, to keep this simple, however,
+    that since HITRAN does not know about ARTS tags, the species name is
+    given as Species-AFGL.  ARTS does not use AFGL notation internally so
+    some of these have to be manually changed.
+    """
+    def pos2char(ind):
+        """ Convert an isotoplogue index to a HITRAN char for that index """
+        if ind < 10:
+            return "'{}'".format(ind)
+        elif ind == 10:
+            return "'0'"
+        elif ind == 11:
+            return "'A'"
+        elif ind == 12:
+            return "'B'"
+    
+    molparam_txt = open(molparam_txt_file, 'r').read().split('\n')
+    molparam_txt.pop(0)  # erase header
+
+    out = {}
+    for i in range(len(molparam_txt)):
+        line = molparam_txt[i]
+        vec = line.split()
+        if len(vec) == 0:
+            continue
+        elif len(vec) == 2:
+            spec = vec[0]
+            specnum = int(eval(vec[1]))
+            pos = 1
+            out [spec] = []
+        else:
+            out[spec].append([specnum, pos, vec[0]])
+            pos += 1
+
+    print ('static const std::map<Index, std::map<char, const char * const>> latest_molparam_map{')
+    for spec in out:
+        print ('{',out[spec][0][0], ', {  // ', spec, sep='')
+        for isot in out[spec]:
+            print ('{', pos2char(isot[1]), ', "{}-{}"'.format(spec, isot[2]), '},', sep='')
+        print ('}},')
+    print ('};')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,6 +201,7 @@ add_library (artscore STATIC
   geodetic.cc
   gridded_fields.cc
   gzstream.cc
+  hitran_species.cc
   hitran_xsec.cc
   interpolation.cc
   interpolation_lagrange.cc
@@ -530,6 +531,11 @@ target_link_libraries(test_covariance_matrix test_utils ${ALL_ARTS_LIBRARIES})
 
 add_executable (test_telsem test_telsem.cc)
 target_link_libraries(test_telsem ${ALL_ARTS_LIBRARIES})
+
+########### next testcase ###############
+
+add_executable (test_hitran test_hitran.cc)
+target_link_libraries(test_hitran ${ALL_ARTS_LIBRARIES})
 
 ########### subdirs ###############
 

--- a/src/absorption.h
+++ b/src/absorption.h
@@ -56,13 +56,11 @@ class IsotopologueRecord {
                      const Numeric& abundance,
                      const Numeric& mass,
                      const Index& mytrantag,
-                     const Index& hitrantag,
                      const ArrayOfIndex& jpltags)
       : mname(name),
         mabundance(abundance),
         mmass(mass),
         mmytrantag(mytrantag),
-        mhitrantag(hitrantag),
         mjpltags(jpltags),
         mqcoeff(),
         mqcoefftype(PF_NOTHING),
@@ -74,7 +72,6 @@ class IsotopologueRecord {
     {
       /* 1. All the tags must be positive or -1 */
       ARTS_ASSERT((0 < mmytrantag) || (-1 == mmytrantag));
-      ARTS_ASSERT((0 < mhitrantag) || (-1 == mhitrantag));
       for (Index i = 0; i < mjpltags.nelem(); ++i)
         ARTS_ASSERT((0 < mjpltags[i]) || (-1 == mjpltags[i]));
     }
@@ -90,8 +87,6 @@ class IsotopologueRecord {
   const Numeric& Mass() const { return mmass; }
   /** MYTRAN2 tag numbers for all isotopologues. -1 means not included. */
   const Index& MytranTag() const { return mmytrantag; }
-  /** HITRAN-96 tag numbers for all isotopologues. -1 means not included. */
-  const Index& HitranTag() const { return mhitrantag; }
   /** JPL tag numbers for all isotopologues. Empty array means not included. There
       can be more than one JPL tag for an isotopologue species, because in
       JPL different vibrational states have different tags. */
@@ -131,7 +126,6 @@ class IsotopologueRecord {
   Numeric mabundance;
   Numeric mmass;
   Index mmytrantag;
-  Index mhitrantag;
   ArrayOfIndex mjpltags;
   Vector mqcoeff;
   Index mqcoefftype;
@@ -176,18 +170,6 @@ class SpeciesRecord {
           // Also check that the tags have the same base number:
           ARTS_ASSERT(misotopologue[i].MytranTag() / 10 ==
                  misotopologue[i].MytranTag() / 10);
-        }
-      }
-
-      /* Check that the Hitran tags are correctly sorted. */
-      for (Index i = 0; i < misotopologue.nelem() - 1; ++i) {
-        if ((0 < misotopologue[i].HitranTag()) &&
-            (0 < misotopologue[i + 1].HitranTag())) {
-          //                ARTS_ASSERT( misotopologue[i].HitranTag() < misotopologue[i+1].HitranTag() );
-
-          // Also check that the tags have the same base number:
-          ARTS_ASSERT(misotopologue[i].HitranTag() / 10 ==
-                 misotopologue[i + 1].HitranTag() / 10);
         }
       }
     }

--- a/src/absorptionlines.cc
+++ b/src/absorptionlines.cc
@@ -727,6 +727,282 @@ Absorption::SingleLineExternal Absorption::ReadFromArtscat5Stream(istream& is) {
   return data;
 }
 
+Absorption::SingleLineExternal Absorption::ReadFromHitran2012Stream(istream& is) {
+  // Default data and values for this type
+  SingleLineExternal data;
+  data.selfbroadening = true;
+  data.bathbroadening = true;
+  data.lineshapetype = LineShape::Type::VP;
+  data.species.resize(2);
+  
+  // Global species lookup data:
+  using global_data::species_data;
+  
+  // This contains the rest of the line to parse. At the beginning the
+  // entire line. Line gets shorter and shorter as we continue to
+  // extract stuff from the beginning.
+  String line;
+  
+  // The first item is the molecule number:
+  Index mo;
+  
+  // Look for more comments?
+  bool comment = true;
+  
+  while (comment) {
+    // Return true if eof is reached:
+    if (is.eof()) return data;
+    
+    // Throw runtime_error if stream is bad:
+    ARTS_USER_ERROR_IF (!is, "Stream bad.");
+    
+    // Read line from file into linebuffer:
+    getline(is, line);
+    
+    // It is possible that we were exactly at the end of the file before
+    // calling getline. In that case the previous eof() was still false
+    // because eof() evaluates only to true if one tries to read after the
+    // end of the file. The following check catches this.
+    if (line.nelem() == 0 && is.eof()) return data;
+    
+    // If the catalogue is in dos encoding, throw away the
+    // additional carriage return
+    if (line[line.nelem() - 1] == 13) {
+      line.erase(line.nelem() - 1, 1);
+    }
+    
+    mo = 0;
+    // Initialization of mo is important, because mo stays the same
+    // if line is empty.
+    extract(mo, line, 2);
+    comment = false;
+  }
+  
+  // Extract isotopologue:
+  char iso;
+  extract(iso, line, 1);
+  
+  // Set line data
+  data.quantumidentity = Hitran::from_lookup(mo, iso);
+  
+  // Position.
+  {
+    // HITRAN position in wavenumbers (cm^-1):
+    Numeric v;
+    // Conversion from wavenumber to Hz. If you multiply a line
+    // position in wavenumber (cm^-1) by this constant, you get the
+    // frequency in Hz.
+    constexpr Numeric w2Hz = Constant::c * 100.;
+    
+    // Extract HITRAN postion:
+    extract(v, line, 12);
+    
+    // ARTS position in Hz:
+    data.line.F0() = v * w2Hz;
+  }
+  
+  // Intensity.
+  {
+    // HITRAN intensity is in cm-1/(molec * cm-2) at 296 Kelvin.
+    // It already includes the isotpic ratio.
+    // The first cm-1 is the frequency unit (it cancels with the
+    // 1/frequency unit of the line shape function).
+    //
+    // We need to do the following:
+    // 1. Convert frequency from wavenumber to Hz (factor 1e2 * c).
+    // 2. Convert [molec * cm-2] to [molec * m-2] (factor 1e-4).
+    // 3. Take out the isotopologue ratio.
+    
+    constexpr Numeric hi2arts = 1e-2 * Constant::c;
+    
+    Numeric s;
+    
+    // Extract HITRAN intensity:
+    extract(s, line, 10);
+    // Convert to ARTS units (Hz / (molec * m-2) ), or shorter: Hz*m^2
+    data.line.I0() = s * hi2arts;
+    // Take out isotopologue ratio:
+    data.line.I0() /= species_data[data.quantumidentity.Species()]
+    .Isotopologue()[data.quantumidentity.Isotopologue()]
+    .Abundance();
+  }
+  
+  // Einstein coefficient
+  {
+    Numeric r;
+    extract(r, line, 10);
+    data.line.A() = r;
+  }
+  
+  // Air broadening parameters.
+  Numeric agam, sgam;
+  {
+    // HITRAN parameter is in cm-1/atm at 296 Kelvin
+    // All parameters are HWHM (I hope this is true!)
+    Numeric gam;
+    // Conversion from wavenumber to Hz. If you multiply a value in
+    // wavenumber (cm^-1) by this constant, you get the value in Hz.
+    constexpr Numeric w2Hz = Constant::c * 1e2;
+    // Ok, put together the end-to-end conversion that we need:
+    constexpr Numeric hi2arts = w2Hz / Conversion::atm2pa(1);
+    
+    // Extract HITRAN AGAM value:
+    extract(gam, line, 5);
+    
+    // ARTS parameter in Hz/Pa:
+    agam = gam * hi2arts;
+    
+    // Extract HITRAN SGAM value:
+    extract(gam, line, 5);
+    
+    // ARTS parameter in Hz/Pa:
+    sgam = gam * hi2arts;
+    
+    // If zero, set to agam:
+    if (0 == sgam) sgam = agam;
+    
+    //    cout << "agam, sgam = " << magam << ", " << msgam << endl;
+  }
+  
+  // Lower state energy.
+  {
+    // HITRAN parameter is in wavenumbers (cm^-1).
+    // We have to convert this to the ARTS unit Joule.
+    
+    // Extract from Catalogue line
+    extract(data.line.E0(), line, 10);
+    
+    // Convert to Joule:
+    data.line.E0() = wavenumber_to_joule(data.line.E0());
+  }
+  
+  // Temperature coefficient of broadening parameters.
+  Numeric nair, nself;
+  {
+    // This is dimensionless, we can also extract directly.
+    extract(nair, line, 4);
+    
+    // Set self broadening temperature coefficient to the same value:
+    nself = nair;
+    //    cout << "mnair = " << mnair << endl;
+  }
+  
+  // Pressure shift.
+  Numeric psf;
+  {
+    // HITRAN value in cm^-1 / atm. So the conversion goes exactly as
+    // for the broadening parameters.
+    Numeric d;
+    // Conversion from wavenumber to Hz. If you multiply a value in
+    // wavenumber (cm^-1) by this constant, you get the value in Hz.
+    constexpr Numeric w2Hz = Constant::c * 1e2;
+    // Ok, put together the end-to-end conversion that we need:
+    constexpr Numeric hi2arts = w2Hz / Conversion::atm2pa(1);
+    
+    // Extract HITRAN value:
+    extract(d, line, 8);
+    
+    // ARTS value in Hz/Pa
+    psf = d * hi2arts;
+  }
+  // Set the accuracies using the definition of HITRAN
+  // indices. If some are missing, they are set to -1.
+  
+  static QuantumParserHITRAN2004 quantum_parser;
+  const String qstr = line.substr(0, 15 * 4);
+  
+  // Upper state global quanta
+  {
+    Index eu;
+    extract(eu, line, 15);
+  }
+  
+  // Lower state global quanta
+  {
+    Index el;
+    extract(el, line, 15);
+  }
+  
+  // Upper state local quanta
+  {
+    Index eul;
+    extract(eul, line, 15);
+  }
+  
+  // Lower state local quanta
+  {
+    Index ell;
+    extract(ell, line, 15);
+  }
+  
+  // Parse quantum numbers.
+  quantum_parser.Parse(data.quantumidentity, qstr);
+  
+  // Accuracy index for frequency
+  {
+    Index df;
+    // Extract HITRAN value:
+    extract(df, line, 1);
+  }
+  
+  // Accuracy index for intensity
+  {
+    Index di0;
+    // Extract HITRAN value:
+    extract(di0, line, 1);
+  }
+  
+  // Accuracy index for air-broadened halfwidth
+  {
+    Index dgam;
+    // Extract HITRAN value:
+    extract(dgam, line, 1);
+  }
+  
+  // Accuracy index for self-broadened half-width
+  {
+    Index dgam;
+    // Extract HITRAN value:
+    extract(dgam, line, 1);
+  }
+  
+  // Accuracy index for temperature-dependence exponent for agam
+  {
+    Index dn;
+    // Extract HITRAN value:
+    extract(dn, line, 1);
+  }
+  
+  // Accuracy index for pressure shift
+  {
+    Index dpsfi;
+    // Extract HITRAN value (given in cm-1):
+    extract(dpsfi, line, 1);
+  }
+  
+  // These were all the parameters that we can extract from
+  // HITRAN 2004. However, we still have to set the reference temperatures
+  // to the appropriate value:
+  
+  // Reference temperature for Intensity in K.
+  data.T0 = 296.0;
+  
+  // Set line shape computer
+  data.line.LineShape() = LineShape::hitran_model(sgam, nself, agam, nair, psf);
+  {
+    Index garbage;
+    extract(garbage, line, 13);
+    
+    // The statistical weights
+    extract(data.line.g_upp(), line, 7);
+    extract(data.line.g_low(), line, 7);
+  }
+  
+  // That's it!
+  data.bad = false;
+  return data;
+}
+
 Absorption::SingleLineExternal Absorption::ReadFromHitran2004Stream(istream& is) {
   // Default data and values for this type
   SingleLineExternal data;
@@ -738,85 +1014,6 @@ Absorption::SingleLineExternal Absorption::ReadFromHitran2004Stream(istream& is)
   // Global species lookup data:
   using global_data::species_data;
 
-  // This value is used to flag missing data both in species and
-  // isotopologue lists. Could be any number, it just has to be made sure
-  // that it is neither the index of a species nor of an isotopologue.
-  const Index missing = species_data.nelem() + 100;
-
-  // We need a species index sorted by HITRAN tag. Keep this in a
-  // static variable, so that we have to do this only once.  The ARTS
-  // species index is hind[<HITRAN tag>].
-  //
-  // Allow for up to 100 species in HITRAN in the future.
-  static Array<Index> hspec(100);
-
-  // This is  an array of arrays for each hitran tag. It contains the
-  // ARTS indices of the HITRAN isotopologues.
-  static Array<ArrayOfIndex> hiso(100);
-
-  // Remember if this stuff has already been initialized:
-  static bool hinit = false;
-
-  // Remember, about which missing species we have already issued a
-  // warning:
-  static ArrayOfIndex warned_missing;
-
-  if (!hinit) {
-    // Initialize hspec.
-    // The value of missing means that we don't have this species.
-    hspec = missing;  // Matpack can set all elements like this.
-
-    for (Index i = 0; i < species_data.nelem(); ++i) {
-      const SpeciesRecord& sr = species_data[i];
-
-      // We have to be careful and check for the case that all
-      // HITRAN isotopologue tags are -1 (this species is missing in HITRAN).
-
-      if (sr.Isotopologue().nelem() && 0 < sr.Isotopologue()[0].HitranTag()) {
-        // The HITRAN tags are stored as species plus isotopologue tags
-        // (MO and ISO)
-        // in the Isotopologue() part of the species record.
-        // We can extract the MO part from any of the isotopologue tags,
-        // so we use the first one. We do this by taking an integer
-        // division by 10.
-
-        Index mo = sr.Isotopologue()[0].HitranTag() / 10;
-        //          cout << "mo = " << mo << endl;
-        hspec[mo] = i;
-
-        // Get a nicer to handle array of HITRAN iso tags:
-        Index n_iso = sr.Isotopologue().nelem();
-        ArrayOfIndex iso_tags;
-        iso_tags.resize(n_iso);
-        for (Index j = 0; j < n_iso; ++j) {
-          iso_tags[j] = sr.Isotopologue()[j].HitranTag();
-        }
-
-        // Reserve elements for the isotopologue tags. How much do we
-        // need? This depends on the largest HITRAN tag that we know
-        // about!
-        // Also initialize the tags to missing.
-        //          cout << "iso_tags = " << iso_tags << endl;
-        //          cout << "static_cast<Index>(max(iso_tags))%10 + 1 = "
-        //               << static_cast<Index>(max(iso_tags))%10 + 1 << endl;
-        hiso[mo].resize(max(iso_tags) % 10 + 1);
-        hiso[mo] = missing;  // Matpack can set all elements like this.
-
-        // Set the isotopologue tags:
-        for (Index j = 0; j < n_iso; ++j) {
-          if (0 < iso_tags[j])  // ignore -1 elements
-          {
-            // To get the iso tags from HitranTag() we also have to take
-            // modulo 10 to get rid of mo.
-            hiso[mo][iso_tags[j] % 10] = j;
-          }
-        }
-      }
-    }
-
-    hinit = true;
-  }
-
   // This contains the rest of the line to parse. At the beginning the
   // entire line. Line gets shorter and shorter as we continue to
   // extract stuff from the beginning.
@@ -824,81 +1021,45 @@ Absorption::SingleLineExternal Absorption::ReadFromHitran2004Stream(istream& is)
 
   // The first item is the molecule number:
   Index mo;
-
+  
   // Look for more comments?
   bool comment = true;
-
+  
   while (comment) {
     // Return true if eof is reached:
     if (is.eof()) return data;
-
+    
     // Throw runtime_error if stream is bad:
     ARTS_USER_ERROR_IF (!is, "Stream bad.");
-
+    
     // Read line from file into linebuffer:
     getline(is, line);
-
+    
     // It is possible that we were exactly at the end of the file before
     // calling getline. In that case the previous eof() was still false
     // because eof() evaluates only to true if one tries to read after the
     // end of the file. The following check catches this.
     if (line.nelem() == 0 && is.eof()) return data;
-
+    
     // If the catalogue is in dos encoding, throw away the
     // additional carriage return
     if (line[line.nelem() - 1] == 13) {
       line.erase(line.nelem() - 1, 1);
     }
-
-    // Because of the fixed FORTRAN format, we need to break up the line
-    // explicitly in apropriate pieces. Not elegant, but works!
-
-    // Extract molecule number:
+    
     mo = 0;
     // Initialization of mo is important, because mo stays the same
     // if line is empty.
     extract(mo, line, 2);
-    //      cout << "mo = " << mo << endl;
-
-    // If mo == 0 this is just a comment line:
-    if (0 != mo) {
-      // See if we know this species.
-      if (missing != hspec[mo]) {
-        comment = false;
-
-        // Check if data record has the right number of characters for the
-        // in Hitran 2004 format
-        Index nChar = line.nelem() + 2;  // number of characters in data record;
-        ARTS_USER_ERROR_IF ((nChar == 161 && line[158] != ' ') || nChar > 161,
-          "Invalid HITRAN 2004 line data record with ", nChar,
-          " characters (expected: 160).")
-
-      }
-    }
+    comment = false;
   }
-
-  // Ok, we seem to have a valid species here.
-
-  // Set mspecies from my cool index table:
-  data.quantumidentity.Species(hspec[mo]);
-
+  
   // Extract isotopologue:
-  Index iso;
+  char iso;
   extract(iso, line, 1);
-  //  cout << "iso = " << iso << endl;
-
-  // Set misotopologue from the other cool index table.
-  // We have to be careful to issue an error for unknown iso tags. Iso
-  // could be either larger than the size of hiso[mo], or set
-  // explicitly to missing. Unfortunately we have to test both cases.
-  data.quantumidentity.Isotopologue(missing);
-  if (iso < hiso[mo].nelem())
-    if (missing != hiso[mo][iso]) data.quantumidentity.Isotopologue(hiso[mo][iso]);
-
-  // Issue error message if misotopologue is still missing:
-  ARTS_USER_ERROR_IF (missing == data.quantumidentity.Isotopologue(),
-    "Species: ", species_data[data.quantumidentity.Species()].Name(),
-    ", isotopologue iso = ", iso, " is unknown.")
+  
+  // Set line data
+  data.quantumidentity = Hitran::from_lookup(mo, iso, Hitran::Type::Pre2012CO2Change);
 
   // Position.
   {
@@ -1430,85 +1591,6 @@ Absorption::SingleLineExternal Absorption::ReadFromHitran2001Stream(istream& is)
   // Global species lookup data:
   using global_data::species_data;
 
-  // This value is used to flag missing data both in species and
-  // isotopologue lists. Could be any number, it just has to be made sure
-  // that it is neither the index of a species nor of an isotopologue.
-  const Index missing = species_data.nelem() + 100;
-
-  // We need a species index sorted by HITRAN tag. Keep this in a
-  // static variable, so that we have to do this only once.  The ARTS
-  // species index is hind[<HITRAN tag>].
-  //
-  // Allow for up to 100 species in HITRAN in the future.
-  static Array<Index> hspec(100);
-
-  // This is  an array of arrays for each hitran tag. It contains the
-  // ARTS indices of the HITRAN isotopologues.
-  static Array<ArrayOfIndex> hiso(100);
-
-  // Remember if this stuff has already been initialized:
-  static bool hinit = false;
-
-  // Remember, about which missing species we have already issued a
-  // warning:
-  static ArrayOfIndex warned_missing;
-
-  if (!hinit) {
-    // Initialize hspec.
-    // The value of missing means that we don't have this species.
-    hspec = missing;  // Matpack can set all elements like this.
-
-    for (Index i = 0; i < species_data.nelem(); ++i) {
-      const SpeciesRecord& sr = species_data[i];
-
-      // We have to be careful and check for the case that all
-      // HITRAN isotopologue tags are -1 (this species is missing in HITRAN).
-
-      if (sr.Isotopologue().nelem() && 0 < sr.Isotopologue()[0].HitranTag()) {
-        // The HITRAN tags are stored as species plus isotopologue tags
-        // (MO and ISO)
-        // in the Isotopologue() part of the species record.
-        // We can extract the MO part from any of the isotopologue tags,
-        // so we use the first one. We do this by taking an integer
-        // division by 10.
-
-        Index mo = sr.Isotopologue()[0].HitranTag() / 10;
-        //          cout << "mo = " << mo << endl;
-        hspec[mo] = i;
-
-        // Get a nicer to handle array of HITRAN iso tags:
-        Index n_iso = sr.Isotopologue().nelem();
-        ArrayOfIndex iso_tags;
-        iso_tags.resize(n_iso);
-        for (Index j = 0; j < n_iso; ++j) {
-          iso_tags[j] = sr.Isotopologue()[j].HitranTag();
-        }
-
-        // Reserve elements for the isotopologue tags. How much do we
-        // need? This depends on the largest HITRAN tag that we know
-        // about!
-        // Also initialize the tags to missing.
-        //          cout << "iso_tags = " << iso_tags << endl;
-        //          cout << "static_cast<Index>(max(iso_tags))%10 + 1 = "
-        //               << static_cast<Index>(max(iso_tags))%10 + 1 << endl;
-        hiso[mo].resize(max(iso_tags) % 10 + 1);
-        hiso[mo] = missing;  // Matpack can set all elements like this.
-
-        // Set the isotopologue tags:
-        for (Index j = 0; j < n_iso; ++j) {
-          if (0 < iso_tags[j])  // ignore -1 elements
-          {
-            // To get the iso tags from HitranTag() we also have to take
-            // modulo 10 to get rid of mo.
-            hiso[mo][iso_tags[j] % 10] = j;
-          }
-        }
-      }
-    }
-
-    hinit = true;
-  }
-
   // This contains the rest of the line to parse. At the beginning the
   // entire line. Line gets shorter and shorter as we continue to
   // extract stuff from the beginning.
@@ -1516,81 +1598,45 @@ Absorption::SingleLineExternal Absorption::ReadFromHitran2001Stream(istream& is)
 
   // The first item is the molecule number:
   Index mo;
-
+  
   // Look for more comments?
   bool comment = true;
-
+  
   while (comment) {
     // Return true if eof is reached:
     if (is.eof()) return data;
-
+    
     // Throw runtime_error if stream is bad:
     ARTS_USER_ERROR_IF (!is, "Stream bad.");
-
+    
     // Read line from file into linebuffer:
     getline(is, line);
-
+    
     // It is possible that we were exactly at the end of the file before
     // calling getline. In that case the previous eof() was still false
     // because eof() evaluates only to true if one tries to read after the
     // end of the file. The following check catches this.
     if (line.nelem() == 0 && is.eof()) return data;
-
+    
     // If the catalogue is in dos encoding, throw away the
     // additional carriage return
     if (line[line.nelem() - 1] == 13) {
       line.erase(line.nelem() - 1, 1);
     }
-
-    // Because of the fixed FORTRAN format, we need to break up the line
-    // explicitly in apropriate pieces. Not elegant, but works!
-
-    // Extract molecule number:
+    
     mo = 0;
     // Initialization of mo is important, because mo stays the same
     // if line is empty.
     extract(mo, line, 2);
-    //      cout << "mo = " << mo << endl;
-
-    // If mo == 0 this is just a comment line:
-    if (0 != mo) {
-      // See if we know this species. Exit with an error if the species is unknown.
-      if (missing != hspec[mo]) {
-        comment = false;
-
-        // Check if data record has the right number of characters for the
-        // in Hitran 1986-2001 format
-        Index nChar = line.nelem() + 2;  // number of characters in data record;
-        ARTS_USER_ERROR_IF (nChar != 100,
-          "Invalid HITRAN 1986-2001 line data record with ", nChar,
-          " characters (expected: 100).\n",
-          line, " n: ", line.nelem())
-      }
-    }
+    comment = false;
   }
-
-  // Ok, we seem to have a valid species here.
-
-  // Set mspecies from my cool index table:
-  data.quantumidentity.Species(hspec[mo]);
-
+  
   // Extract isotopologue:
-  Index iso;
+  char iso;
   extract(iso, line, 1);
-  //  cout << "iso = " << iso << endl;
-
-  // Set misotopologue from the other cool index table.
-  // We have to be careful to issue an error for unknown iso tags. Iso
-  // could be either larger than the size of hiso[mo], or set
-  // explicitly to missing. Unfortunately we have to test both cases.
-  data.quantumidentity.Isotopologue(missing);
-  if (iso < hiso[mo].nelem())
-    if (missing != hiso[mo][iso]) data.quantumidentity.Isotopologue(hiso[mo][iso]);
-
-  // Issue error message if misotopologue is still missing:
-  ARTS_USER_ERROR_IF (missing == data.quantumidentity.Isotopologue(),
-    "Species: ", species_data[data.quantumidentity.Species()].Name(),
-    ", isotopologue iso = ", iso, " is unknown.")
+  
+  // Set line data
+  data.quantumidentity = Hitran::from_lookup(mo, iso, Hitran::Type::Pre2012CO2Change);
 
   // Position.
   {
@@ -1786,82 +1832,6 @@ Absorption::SingleLineExternal Absorption::ReadFromLBLRTMStream(istream& is) {
   // Global species lookup data:
   using global_data::species_data;
 
-  // This value is used to flag missing data both in species and
-  // isotopologue lists. Could be any number, it just has to be made sure
-  // that it is neither the index of a species nor of an isotopologue.
-  const Index missing = species_data.nelem() + 100;
-
-  // We need a species index sorted by HITRAN tag. Keep this in a
-  // static variable, so that we have to do this only once.  The ARTS
-  // species index is hind[<HITRAN tag>].
-  //
-  // Allow for up to 100 species in HITRAN in the future.
-  static Array<Index> hspec(100);
-
-  // This is  an array of arrays for each hitran tag. It contains the
-  // ARTS indices of the HITRAN isotopologues.
-  static Array<ArrayOfIndex> hiso(100);
-
-  // Remember if this stuff has already been initialized:
-  static bool hinit = false;
-
-  // Remember, about which missing species we have already issued a
-  // warning:
-  static ArrayOfIndex warned_missing;
-
-  if (!hinit) {
-    // Initialize hspec.
-    // The value of missing means that we don't have this species.
-    hspec = missing;  // Matpack can set all elements like this.
-    for (Index i = 0; i < species_data.nelem(); ++i) {
-      const SpeciesRecord& sr = species_data[i];
-      // We have to be careful and check for the case that all
-      // HITRAN isotopologue tags are -1 (this species is missing in HITRAN).
-      if (sr.Isotopologue().nelem() && 0 < sr.Isotopologue()[0].HitranTag()) {
-        // The HITRAN tags are stored as species plus isotopologue tags
-        // (MO and ISO)
-        // in the Isotopologue() part of the species record.
-        // We can extract the MO part from any of the isotopologue tags,
-        // so we use the first one. We do this by taking an integer
-        // division by 10.
-
-        Index mo = sr.Isotopologue()[0].HitranTag() / 10;
-        //          cout << "mo = " << mo << endl;
-        hspec[mo] = i;
-
-        // Get a nicer to handle array of HITRAN iso tags:
-        Index n_iso = sr.Isotopologue().nelem();
-        ArrayOfIndex iso_tags;
-        iso_tags.resize(n_iso);
-        for (Index j = 0; j < n_iso; ++j) {
-          iso_tags[j] = sr.Isotopologue()[j].HitranTag();
-        }
-
-        // Reserve elements for the isotopologue tags. How much do we
-        // need? This depends on the largest HITRAN tag that we know
-        // about!
-        // Also initialize the tags to missing.
-        //          cout << "iso_tags = " << iso_tags << endl;
-        //          cout << "static_cast<Index>(max(iso_tags))%10 + 1 = "
-        //               << static_cast<Index>(max(iso_tags))%10 + 1 << endl;
-        hiso[mo].resize(max(iso_tags) % 10 + 1);
-        hiso[mo] = missing;  // Matpack can set all elements like this.
-
-        // Set the isotopologue tags:
-        for (Index j = 0; j < n_iso; ++j) {
-          if (0 < iso_tags[j])  // ignore -1 elements
-          {
-            // To get the iso tags from HitranTag() we also have to take
-            // modulo 10 to get rid of mo.
-            hiso[mo][iso_tags[j] % 10] = j;
-          }
-        }
-      }
-    }
-    
-    hinit = true;
-  }
-
   // This contains the rest of the line to parse. At the beginning the
   // entire line. Line gets shorter and shorter as we continue to
   // extract stuff from the beginning.
@@ -1869,82 +1839,45 @@ Absorption::SingleLineExternal Absorption::ReadFromLBLRTMStream(istream& is) {
 
   // The first item is the molecule number:
   Index mo;
-
+  
   // Look for more comments?
   bool comment = true;
-
+  
   while (comment) {
     // Return true if eof is reached:
     if (is.eof()) return data;
-
+    
     // Throw runtime_error if stream is bad:
     ARTS_USER_ERROR_IF (!is, "Stream bad.");
-
+    
     // Read line from file into linebuffer:
     getline(is, line);
-
+    
     // It is possible that we were exactly at the end of the file before
     // calling getline. In that case the previous eof() was still false
     // because eof() evaluates only to true if one tries to read after the
     // end of the file. The following check catches this.
     if (line.nelem() == 0 && is.eof()) return data;
-
+    
     // If the catalogue is in dos encoding, throw away the
     // additional carriage return
     if (line[line.nelem() - 1] == 13) {
       line.erase(line.nelem() - 1, 1);
     }
-
-    // Because of the fixed FORTRAN format, we need to break up the line
-    // explicitly in apropriate pieces. Not elegant, but works!
-
-    // Extract molecule number:
+    
     mo = 0;
     // Initialization of mo is important, because mo stays the same
     // if line is empty.
     extract(mo, line, 2);
-    //      cout << "mo = " << mo << endl;
-
-    // If mo == 0 this is just a comment line:
-    if (0 != mo) {
-      // See if we know this species. Exit with an error if the species is unknown.
-      if (missing != hspec[mo]) {
-        comment = false;
-
-        // Check if data record has the right number of characters for the
-        // in Hitran 1986-2001 format
-        Index nChar = line.nelem() + 2;  // number of characters in data record;
-        ARTS_USER_ERROR_IF (nChar != 100,
-          "Invalid HITRAN 1986-2001 line data record with ", nChar,
-          " characters (expected: 100).\n",
-          line, " n: ", line.nelem())
-
-      }
-    }
+    comment = false;
   }
-
-  // Ok, we seem to have a valid species here.
-
-  // Set mspecies from my cool index table:
-  data.quantumidentity.Species(hspec[mo]);
-
+  
   // Extract isotopologue:
-  Index iso;
+  char iso;
   extract(iso, line, 1);
-  //  cout << "iso = " << iso << endl;
-
-  // Set misotopologue from the other cool index table.
-  // We have to be careful to issue an error for unknown iso tags. Iso
-  // could be either larger than the size of hiso[mo], or set
-  // explicitly to missing. Unfortunately we have to test both cases.
-  data.quantumidentity.Isotopologue(missing);
-  if (iso < hiso[mo].nelem())
-    if (missing != hiso[mo][iso]) data.quantumidentity.Isotopologue(hiso[mo][iso]);
-
-  // Issue error message if misotopologue is still missing:
-  ARTS_USER_ERROR_IF (missing == data.quantumidentity.Isotopologue(),
-    "Species: ", species_data[data.quantumidentity.Species()].Name(),
-    ", isotopologue iso = ", iso, " is unknown.")
+  
+  // Set line data
+  data.quantumidentity = Hitran::from_lookup(mo, iso);
 
   // Position.
   {

--- a/src/absorptionlines.h
+++ b/src/absorptionlines.h
@@ -1188,6 +1188,62 @@ SingleLineExternal ReadFromArtscat5Stream(istream& is);
 SingleLineExternal ReadFromLBLRTMStream(istream& is);
 
 /** Read from newer HITRAN
+ * 
+ * The HITRAN format is as follows:
+ *
+ * @verbatim
+ E ach line consists of 160 ASCII characters, followed by* a line feed (ASCII 10)
+ and carriage return (ASCII 13) character, for a total of 162 bytes per line.
+ 
+ Each item is defined below, with its Fortran format shown in parenthesis.
+ 
+ (I2)     molecule number
+ (I1)     isotopologue number (1 = most abundant, 2 = second, etc)
+ (F12.6)  vacuum wavenumbers (cm-1)
+ (E10.3)  intensity in cm-1/(molec * cm-2) at 296 Kelvin
+ (E10.3)  Einstein-A coefficient (s-1)
+ (F5.4)   air-broadened halfwidth (HWHM) in cm-1/atm at 296 Kelvin
+ (F5.4)   self-broadened halfwidth (HWHM) in cm-1/atm at 296 Kelvin
+ (F10.4)  lower state energy (cm-1)
+ (F4.2)   coefficient of temperature dependence of air-broadened halfwidth
+ (F8.6)   air-broadened pressure shift of line transition at 296 K (cm-1)
+ (A15)    upper state global quanta
+ (A15)    lower state global quanta
+ (A15)    upper state local quanta
+ (A15)    lower state local quanta
+ (I1)     uncertainty index for wavenumber
+ (I1)     uncertainty index for intensity
+ (I1)     uncertainty index for air-broadened half-width
+ (I1)     uncertainty index for self-broadened half-width
+ (I1)     uncertainty index for temperature dependence
+ (I1)     uncertainty index for pressure shift
+ (I2)     index for table of references correspond. to wavenumber
+ (I2)     index for table of references correspond. to intensity
+ (I2)     index for table of references correspond. to air-broadened half-width
+ (I2)     index for table of references correspond. to self-broadened half-width
+ (I2)     index for table of references correspond. to temperature dependence
+ (I2)     index for table of references correspond. to pressure shift
+ (A1)     flag (*) for lines supplied with line-coupling algorithm
+ (F7.1)   upper state statistical weight
+ (F7.1)   lower state statistical weight
+ 
+ The molecule numbers are encoded as shown in the table below:
+ 
+ 0= Null    1=  H2O    2=  CO2    3=   O3    4=  N2O    5=    CO
+ 6=  CH4    7=   O2    8=   NO    9=  SO2   10=  NO2   11=   NH3
+ 12= HNO3   13=   OH   14=   HF   15=  HCl   16=  HBr   17=    HI
+ 18=  ClO   19=  OCS   20= H2CO   21= HOCl   22=   N2   23=   HCN
+ 24=CH3Cl   25= H2O2   26= C2H2   27= C2H6   28=  PH3   29=  COF2
+ 30=  SF6   31=  H2S   32=HCOOH   33=  HO2   34=    O   35=ClONO2
+ 36=  NO+   37= HOBr   38= C2H4
+ * @endverbatim
+ * 
+ * @param[in] is Input stream
+ * @return SingleLineExternal 
+ */
+SingleLineExternal ReadFromHitran2012Stream(istream& is);
+
+/** Read from newer HITRAN
  *
  * The HITRAN format is as follows:
  *

--- a/src/constants.h
+++ b/src/constants.h
@@ -556,6 +556,14 @@ namespace Options {
   ENUMCLASS(BasicCatParamJacobian, char,
             LineStrength,
             LineCenter)
+  
+  /** Possible HITRAN types of catalogs */
+  ENUMCLASS(HitranType, char,
+            Pre2004,  // 2004 version changed the .par-length
+            From2004To2012, // New par length but old isotopologues order
+            Post2012, // 2012 version changed the order of isotopologues
+            Online    // Onine expects a modern .par line followed by Upper then Lower quantum numbers
+  )
 }
 
 #endif

--- a/src/hitran_species.cc
+++ b/src/hitran_species.cc
@@ -495,6 +495,8 @@ const std::map<Index, std::map<char, const char * const>> latest_molparam_map{
 std::map<Index, std::map<char, SpeciesTag>> to_species_map(const std::map<Index, std::map<char, const char * const>>& string_map) {
   std::map<Index, std::map<char, SpeciesTag>> species_map;
   for (auto& specs: string_map) {
+    ARTS_ASSERT(specs.second.find('1') not_eq specs.second.cend(),
+                "Must have species '1' in map")
     for (auto& isot: specs.second) {
       species_map[specs.first][isot.first] = SpeciesTag(isot.second);
     }
@@ -547,7 +549,7 @@ template <Type t> QuantumIdentifier from_mol_iso(Index molnum, char isonum) {
     } else {
       ARTS_USER_ERROR("Species ", molnum, " has no isotopologue ", isonum,
                       " in ARTS' HITRAN implementation.\n",
-                      "(This species's first entry is \'", from_mol_iso<t>(molnum, '1').SpeciesName(), "\')\n"
+                      "(Species is ", hitmap.at(molnum).at('1').SpeciesNameMain(), ")\n"
                       "If you are using a new version of HITRAN that has added the isotopologue, please consider\n"
                       "contacting the ARTS developers so we can append the species to our list and make this work.\n"
                       "Note that you are calling this templated function as the ", t, " template")

--- a/src/hitran_species.cc
+++ b/src/hitran_species.cc
@@ -1,0 +1,940 @@
+#include "hitran_species.h"
+
+#include "abs_species_tags.h"
+#include "enums.h"
+
+namespace Hitran {
+QuantumIdentifier from_mol_iso(Index molnum, Index isonum) {
+  switch (molnum) {
+    case 1:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("H2O-161");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("H2O-181");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("H2O-171");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 4: {
+          static const SpeciesTag spec("H2O-162");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 5: {
+          static const SpeciesTag spec("H2O-182");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 6: {
+          static const SpeciesTag spec("H2O-172");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 7: {
+          static const SpeciesTag spec("H2O-262");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 2:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("CO2-626");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("CO2-636");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("CO2-628");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 4: {
+          static const SpeciesTag spec("CO2-627");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 5: {
+          static const SpeciesTag spec("CO2-638");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 6: {
+          static const SpeciesTag spec("CO2-637");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 7: {
+          static const SpeciesTag spec("CO2-828");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 8: {
+          static const SpeciesTag spec("CO2-728");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 9: {
+          static const SpeciesTag spec("CO2-727");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 10: {
+          static const SpeciesTag spec("CO2-838");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 11: {
+          static const SpeciesTag spec("CO2-837");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 12: {
+          static const SpeciesTag spec("CO2-737");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 3:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("O3-666");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("O3-668");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("O3-686");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 4: {
+          static const SpeciesTag spec("O3-667");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 5: {
+          static const SpeciesTag spec("O3-676");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 4:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("N2O-446");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("N2O-456");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("N2O-546");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 4: {
+          static const SpeciesTag spec("N2O-448");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 5: {
+          static const SpeciesTag spec("N2O-447");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 5:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("CO-26");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("CO-36");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("CO-28");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 4: {
+          static const SpeciesTag spec("CO-27");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 5: {
+          static const SpeciesTag spec("CO-38");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 6: {
+          static const SpeciesTag spec("CO-37");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 6:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("CH4-211");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("CH4-311");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("CH4-212");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 4: {
+          static const SpeciesTag spec("CH4-312");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 7:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("O2-66");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("O2-68");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("O2-67");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 8:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("NO-46");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("NO-56");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("NO-48");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 9:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("SO2-626");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("SO2-646");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 10:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("NO2-646");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("NO2-656");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 11:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("NH3-4111");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("NH3-5111");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 12:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("HNO3-146");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("HNO3-156");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 13:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("OH-61");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("OH-81");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("OH-62");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 14:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("HF-19");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("HF-29");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 15:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("HCl-15");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("HCl-17");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("HCl-25");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 4: {
+          static const SpeciesTag spec("HCl-27");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 16:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("HBr-19");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("HBr-11");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("HBr-29");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 4: {
+          static const SpeciesTag spec("HBr-21");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 17:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("HI-17");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("HI-27");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 18:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("ClO-56");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("ClO-76");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 19:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("OCS-622");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("OCS-624");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("OCS-632");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 4: {
+          static const SpeciesTag spec("OCS-623");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 5: {
+          static const SpeciesTag spec("OCS-822");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 6: {
+          static const SpeciesTag spec("OCS-634");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 20:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("H2CO-1126");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("H2CO-1136");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("H2CO-1128");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 21:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("HOCl-165");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("HOCl-167");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 22:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("N2-44");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("N2-45");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 23:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("HCN-124");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("HCN-134");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("HCN-125");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 24:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("CH3Cl-215");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("CH3Cl-217");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 25:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("H2O2-1661");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 26:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("C2H2-1221");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("C2H2-1231");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("C2H2-1222");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 27:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("C2H6-1221");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("C2H6-1231");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 28:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("PH3-1111");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 29:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("COF2-269");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("COF2-369");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 30:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("SF6-29");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 31:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("H2S-121");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("H2S-141");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("H2S-131");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 32:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("HCOOH-1261");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 33:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("HO2-166");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 34:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("O-6");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 35:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("ClONO2-5646");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("ClONO2-7646");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 36:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("NO+-46");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 37:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("HOBr-169");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("HOBr-161");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 38:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("C2H4-221");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("C2H4-231");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 39:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("CH3OH-2161");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 40:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("CH3Br-219");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("CH3Br-211");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 41:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("CH3CN-211124");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 42:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("CF4-29");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 43:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("C4H2-2211");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 44:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("HC3N-12224");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 45:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("H2-11");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("H2-12");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 46:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("CS-22");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("CS-24");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("CS-32");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 4: {
+          static const SpeciesTag spec("CS-23");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 47:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("SO3-26");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 48:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("C2N2-4224");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 49:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("COCl2-2655");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("COCl2-2657");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
+      break;
+    case 53:
+      switch (isonum) {
+        case 1: {
+          static const SpeciesTag spec("CS2-222");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 2: {
+          static const SpeciesTag spec("CS2-222");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 3: {
+          static const SpeciesTag spec("CS2-223");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+        case 4: {
+          static const SpeciesTag spec("CS2-232");
+          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
+                                   spec.Species(), spec.Isotopologue());
+        } break;
+      }
+      break;
+  }
+
+  ARTS_USER_ERROR("[HITRAN SPECIES] Does not recognize species ", molnum, " iso ", isonum);
+}
+
+QuantumIdentifier from_lookup(Index mol, char isochar) {
+  Index iso;
+  if (isochar == '1') iso = 1;
+  if (isochar == '2') iso = 2;
+  if (isochar == '3') iso = 3;
+  if (isochar == '4') iso = 4;
+  if (isochar == '5') iso = 5;
+  if (isochar == '6') iso = 6;
+  if (isochar == '7') iso = 7;
+  if (isochar == '8') iso = 8;
+  if (isochar == '9') iso = 9;
+  if (isochar == '0') iso = 10;
+  if (isochar == 'A') iso = 11;
+  if (isochar == 'B') iso = 12;
+  return from_mol_iso(mol, iso);
+}
+
+}  // namespace Hitran

--- a/src/hitran_species.cc
+++ b/src/hitran_species.cc
@@ -1,940 +1,574 @@
+#include <map>
+
 #include "hitran_species.h"
 
 #include "abs_species_tags.h"
-#include "enums.h"
 
 namespace Hitran {
-QuantumIdentifier from_mol_iso(Index molnum, Index isonum) {
-  switch (molnum) {
-    case 1:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("H2O-161");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("H2O-181");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("H2O-171");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 4: {
-          static const SpeciesTag spec("H2O-162");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 5: {
-          static const SpeciesTag spec("H2O-182");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 6: {
-          static const SpeciesTag spec("H2O-172");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 7: {
-          static const SpeciesTag spec("H2O-262");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 2:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("CO2-626");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("CO2-636");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("CO2-628");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 4: {
-          static const SpeciesTag spec("CO2-627");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 5: {
-          static const SpeciesTag spec("CO2-638");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 6: {
-          static const SpeciesTag spec("CO2-637");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 7: {
-          static const SpeciesTag spec("CO2-828");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 8: {
-          static const SpeciesTag spec("CO2-728");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 9: {
-          static const SpeciesTag spec("CO2-727");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 10: {
-          static const SpeciesTag spec("CO2-838");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 11: {
-          static const SpeciesTag spec("CO2-837");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 12: {
-          static const SpeciesTag spec("CO2-737");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 3:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("O3-666");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("O3-668");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("O3-686");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 4: {
-          static const SpeciesTag spec("O3-667");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 5: {
-          static const SpeciesTag spec("O3-676");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 4:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("N2O-446");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("N2O-456");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("N2O-546");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 4: {
-          static const SpeciesTag spec("N2O-448");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 5: {
-          static const SpeciesTag spec("N2O-447");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 5:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("CO-26");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("CO-36");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("CO-28");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 4: {
-          static const SpeciesTag spec("CO-27");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 5: {
-          static const SpeciesTag spec("CO-38");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 6: {
-          static const SpeciesTag spec("CO-37");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 6:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("CH4-211");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("CH4-311");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("CH4-212");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 4: {
-          static const SpeciesTag spec("CH4-312");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 7:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("O2-66");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("O2-68");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("O2-67");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 8:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("NO-46");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("NO-56");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("NO-48");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 9:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("SO2-626");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("SO2-646");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 10:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("NO2-646");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("NO2-656");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 11:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("NH3-4111");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("NH3-5111");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 12:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("HNO3-146");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("HNO3-156");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 13:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("OH-61");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("OH-81");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("OH-62");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 14:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("HF-19");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("HF-29");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 15:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("HCl-15");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("HCl-17");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("HCl-25");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 4: {
-          static const SpeciesTag spec("HCl-27");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 16:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("HBr-19");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("HBr-11");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("HBr-29");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 4: {
-          static const SpeciesTag spec("HBr-21");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 17:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("HI-17");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("HI-27");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 18:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("ClO-56");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("ClO-76");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 19:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("OCS-622");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("OCS-624");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("OCS-632");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 4: {
-          static const SpeciesTag spec("OCS-623");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 5: {
-          static const SpeciesTag spec("OCS-822");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 6: {
-          static const SpeciesTag spec("OCS-634");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 20:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("H2CO-1126");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("H2CO-1136");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("H2CO-1128");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 21:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("HOCl-165");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("HOCl-167");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 22:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("N2-44");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("N2-45");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 23:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("HCN-124");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("HCN-134");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("HCN-125");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 24:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("CH3Cl-215");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("CH3Cl-217");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 25:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("H2O2-1661");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 26:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("C2H2-1221");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("C2H2-1231");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("C2H2-1222");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 27:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("C2H6-1221");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("C2H6-1231");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 28:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("PH3-1111");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 29:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("COF2-269");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("COF2-369");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 30:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("SF6-29");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 31:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("H2S-121");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("H2S-141");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("H2S-131");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 32:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("HCOOH-1261");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 33:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("HO2-166");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 34:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("O-6");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 35:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("ClONO2-5646");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("ClONO2-7646");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 36:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("NO+-46");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 37:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("HOBr-169");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("HOBr-161");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 38:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("C2H4-221");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("C2H4-231");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 39:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("CH3OH-2161");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 40:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("CH3Br-219");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("CH3Br-211");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 41:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("CH3CN-211124");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 42:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("CF4-29");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 43:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("C4H2-2211");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 44:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("HC3N-12224");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 45:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("H2-11");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("H2-12");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 46:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("CS-22");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("CS-24");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("CS-32");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 4: {
-          static const SpeciesTag spec("CS-23");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 47:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("SO3-26");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 48:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("C2N2-4224");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 49:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("COCl2-2655");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("COCl2-2657");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      ARTS_USER_ERROR("Cannot understand isotopologue for: ", isonum, " for species with first entry: ", from_mol_iso(molnum, 1).SpeciesName())
-      break;
-    case 53:
-      switch (isonum) {
-        case 1: {
-          static const SpeciesTag spec("CS2-222");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 2: {
-          static const SpeciesTag spec("CS2-222");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 3: {
-          static const SpeciesTag spec("CS2-223");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-        case 4: {
-          static const SpeciesTag spec("CS2-232");
-          return QuantumIdentifier(QuantumIdentifier::TRANSITION,
-                                   spec.Species(), spec.Isotopologue());
-        } break;
-      }
-      break;
-  }
+/** In 2012 the order if isotopologues were changed in HITRAN
+ * 
+ * This version takes that into account.  Note that the other species
+ * are left as they were in the latest_molparam_map map at the time
+ * of creating this file (2021-03-10)
+ */
+const std::map<Index, std::map<char, const char * const>> pre2012co2change_molparam_map{
+  {1, {  // H2O
+    {'1', "H2O-161"},
+    {'2', "H2O-181"},
+    {'3', "H2O-171"},
+    {'4', "H2O-162"},
+    {'5', "H2O-182"},
+    {'6', "H2O-172"},
+    {'7', "H2O-262"},
+  }},
+  {2, {  // CO2
+    {'1', "CO2-626"},
+    {'2', "CO2-636"},
+    {'3', "CO2-628"},
+    {'4', "CO2-627"},
+    {'5', "CO2-638"},
+    {'6', "CO2-637"},
+    {'7', "CO2-828"},
+    {'8', "CO2-728"},  // Modified from HITRAN because ARTS does not use AFGL notation
+    {'9', "CO2-838"},  // This is different for HITRAN2008 and earlier cf original map
+  }},
+  {3, {  // O3
+    {'1', "O3-666"},
+    {'2', "O3-668"},
+    {'3', "O3-686"},
+    {'4', "O3-667"},
+    {'5', "O3-676"},
+  }},
+  {4, {  // N2O
+    {'1', "N2O-446"},
+    {'2', "N2O-456"},
+    {'3', "N2O-546"},
+    {'4', "N2O-448"},
+    {'5', "N2O-447"},
+  }},
+  {5, {  // CO
+    {'1', "CO-26"},
+    {'2', "CO-36"},
+    {'3', "CO-28"},
+    {'4', "CO-27"},
+    {'5', "CO-38"},
+    {'6', "CO-37"},
+  }},
+  {6, {  // CH4
+    {'1', "CH4-211"},
+    {'2', "CH4-311"},
+    {'3', "CH4-212"},
+    {'4', "CH4-312"},
+  }},
+  {7, {  // O2
+    {'1', "O2-66"},
+    {'2', "O2-68"},
+    {'3', "O2-67"},
+  }},
+  {8, {  // NO
+    {'1', "NO-46"},
+    {'2', "NO-56"},
+    {'3', "NO-48"},
+  }},
+  {9, {  // SO2
+    {'1', "SO2-626"},
+    {'2', "SO2-646"},
+  }},
+  {10, {  // NO2
+    {'1', "NO2-646"},
+    {'2', "NO2-656"},
+  }},
+  {11, {  // NH3
+    {'1', "NH3-4111"},
+    {'2', "NH3-5111"},
+  }},
+  {12, {  // HNO3
+    {'1', "HNO3-146"},
+    {'2', "HNO3-156"},
+  }},
+  {13, {  // OH
+    {'1', "OH-61"},
+    {'2', "OH-81"},
+    {'3', "OH-62"},
+  }},
+  {14, {  // HF
+    {'1', "HF-19"},
+    {'2', "HF-29"},
+  }},
+  {15, {  // HCl
+    {'1', "HCl-15"},
+    {'2', "HCl-17"},
+    {'3', "HCl-25"},
+    {'4', "HCl-27"},
+  }},
+  {16, {  // HBr
+    {'1', "HBr-19"},
+    {'2', "HBr-11"},
+    {'3', "HBr-29"},
+    {'4', "HBr-21"},
+  }},
+  {17, {  // HI
+    {'1', "HI-17"},
+    {'2', "HI-27"},
+  }},
+  {18, {  // ClO
+    {'1', "ClO-56"},
+    {'2', "ClO-76"},
+  }},
+  {19, {  // OCS
+    {'1', "OCS-622"},
+    {'2', "OCS-624"},
+    {'3', "OCS-632"},
+    {'4', "OCS-623"},
+    {'5', "OCS-822"},
+    {'6', "OCS-634"},
+  }},
+  {20, {  // H2CO
+    {'1', "H2CO-1126"},  // Modified from HITRAN because ARTS does not use AFGL notation
+    {'2', "H2CO-1136"},  // Modified from HITRAN because ARTS does not use AFGL notation
+    {'3', "H2CO-1128"},  // Modified from HITRAN because ARTS does not use AFGL notation
+  }},
+  {21, {  // HOCl
+    {'1', "HOCl-165"},
+    {'2', "HOCl-167"},
+  }},
+  {22, {  // N2
+    {'1', "N2-44"},
+    {'2', "N2-45"},
+  }},
+  {23, {  // HCN
+    {'1', "HCN-124"},
+    {'2', "HCN-134"},
+    {'3', "HCN-125"},
+  }},
+  {24, {  // CH3Cl
+    {'1', "CH3Cl-215"},
+    {'2', "CH3Cl-217"},
+  }},
+  {25, {  // H2O2
+    {'1', "H2O2-1661"},
+  }},
+  {26, {  // C2H2
+    {'1', "C2H2-1221"},
+    {'2', "C2H2-1231"},
+    {'3', "C2H2-1222"},
+  }},
+  {27, {  // C2H6
+    {'1', "C2H6-1221"},
+    {'2', "C2H6-1231"},
+  }},
+  {28, {  // PH3
+    {'1', "PH3-1111"},
+  }},
+  {29, {  // COF2
+    {'1', "COF2-269"},
+    {'2', "COF2-369"},
+  }},
+  {30, {  // SF6
+    {'1', "SF6-29"},
+  }},
+  {31, {  // H2S
+    {'1', "H2S-121"},
+    {'2', "H2S-141"},
+    {'3', "H2S-131"},
+  }},
+  {32, {  // HCOOH
+    {'1', "HCOOH-1261"},  // Modified from HITRAN because ARTS does not use AFGL notation
+  }},
+  {33, {  // HO2
+    {'1', "HO2-166"},
+  }},
+  {34, {  // O
+    {'1', "O-6"},
+  }},
+  {35, {  // ClONO2
+    {'1', "ClONO2-5646"},
+    {'2', "ClONO2-7646"},
+  }},
+  {36, {  // NO+
+    {'1', "NO+-46"},
+  }},
+  {37, {  // HOBr
+    {'1', "HOBr-169"},
+    {'2', "HOBr-161"},
+  }},
+  {38, {  // C2H4
+    {'1', "C2H4-221"},
+    {'2', "C2H4-231"},
+  }},
+  {39, {  // CH3OH
+    {'1', "CH3OH-2161"},
+  }},
+  {40, {  // CH3Br
+    {'1', "CH3Br-219"},
+    {'2', "CH3Br-211"},
+  }},
+  {41, {  // CH3CN
+    {'1', "CH3CN-211124"},  // Modified from HITRAN because ARTS does not use AFGL notation
+  }},
+  {42, {  // CF4
+    {'1', "CF4-29"},
+  }},
+  {43, {  // C4H2
+    {'1', "C4H2-2211"},
+  }},
+  {44, {  // HC3N
+    {'1', "HC3N-12224"},  // Modified from HITRAN because ARTS does not use AFGL notation
+  }},
+  {45, {  // H2
+    {'1', "H2-11"},
+    {'2', "H2-12"},
+  }},
+  {46, {  // CS
+    {'1', "CS-22"},
+    {'2', "CS-24"},
+    {'3', "CS-32"},
+    {'4', "CS-23"},
+  }},
+  {47, {  // SO3
+    {'1', "SO3-26"},
+  }},
+  {48, {  // C2N2
+    {'1', "C2N2-4224"},
+  }},
+  {49, {  // COCl2
+    {'1', "COCl2-2655"},
+    {'2', "COCl2-2657"},
+  }},
+  {53, {  // CS2
+    {'1', "CS2-222"},
+    {'2', "CS2-224"},
+    {'3', "CS2-223"},
+    {'4', "CS2-232"},
+  }},
+};
 
-  ARTS_USER_ERROR("[HITRAN SPECIES] Does not recognize species ", molnum, " iso ", isonum);
+/** The latest version of the HITRAN online molparam.txt file as a map
+ * 
+ * Note that ARTS does not use AFGL notation as HITRAN so several species has
+ * to be changed manually when recreating this map.  Please keep the comments
+ * of this change around so that it is easy to do this recreation.  Thanks!
+ * 
+ * To recreate this map, run the pyarts.hitran.gen_latest_molparam_map.  If more
+ * species names mismatch between ARTS and HITRAN, do please add a comment to indicate
+ * this when you update this variable
+ */
+const std::map<Index, std::map<char, const char * const>> latest_molparam_map{
+  {1, {  // H2O
+    {'1', "H2O-161"},
+    {'2', "H2O-181"},
+    {'3', "H2O-171"},
+    {'4', "H2O-162"},
+    {'5', "H2O-182"},
+    {'6', "H2O-172"},
+    {'7', "H2O-262"},
+  }},
+  {2, {  // CO2
+    {'1', "CO2-626"},
+    {'2', "CO2-636"},
+    {'3', "CO2-628"},
+    {'4', "CO2-627"},
+    {'5', "CO2-638"},
+    {'6', "CO2-637"},
+    {'7', "CO2-828"},
+    {'8', "CO2-728"},  // Modified from HITRAN because ARTS does not use AFGL notation
+    {'9', "CO2-727"},
+    {'0', "CO2-838"},
+    {'A', "CO2-837"},
+    {'B', "CO2-737"},
+  }},
+  {3, {  // O3
+    {'1', "O3-666"},
+    {'2', "O3-668"},
+    {'3', "O3-686"},
+    {'4', "O3-667"},
+    {'5', "O3-676"},
+  }},
+  {4, {  // N2O
+    {'1', "N2O-446"},
+    {'2', "N2O-456"},
+    {'3', "N2O-546"},
+    {'4', "N2O-448"},
+    {'5', "N2O-447"},
+  }},
+  {5, {  // CO
+    {'1', "CO-26"},
+    {'2', "CO-36"},
+    {'3', "CO-28"},
+    {'4', "CO-27"},
+    {'5', "CO-38"},
+    {'6', "CO-37"},
+  }},
+  {6, {  // CH4
+    {'1', "CH4-211"},
+    {'2', "CH4-311"},
+    {'3', "CH4-212"},
+    {'4', "CH4-312"},
+  }},
+  {7, {  // O2
+    {'1', "O2-66"},
+    {'2', "O2-68"},
+    {'3', "O2-67"},
+  }},
+  {8, {  // NO
+    {'1', "NO-46"},
+    {'2', "NO-56"},
+    {'3', "NO-48"},
+  }},
+  {9, {  // SO2
+    {'1', "SO2-626"},
+    {'2', "SO2-646"},
+  }},
+  {10, {  // NO2
+    {'1', "NO2-646"},
+    {'2', "NO2-656"},
+  }},
+  {11, {  // NH3
+    {'1', "NH3-4111"},
+    {'2', "NH3-5111"},
+  }},
+  {12, {  // HNO3
+    {'1', "HNO3-146"},
+    {'2', "HNO3-156"},
+  }},
+  {13, {  // OH
+    {'1', "OH-61"},
+    {'2', "OH-81"},
+    {'3', "OH-62"},
+  }},
+  {14, {  // HF
+    {'1', "HF-19"},
+    {'2', "HF-29"},
+  }},
+  {15, {  // HCl
+    {'1', "HCl-15"},
+    {'2', "HCl-17"},
+    {'3', "HCl-25"},
+    {'4', "HCl-27"},
+  }},
+  {16, {  // HBr
+    {'1', "HBr-19"},
+    {'2', "HBr-11"},
+    {'3', "HBr-29"},
+    {'4', "HBr-21"},
+  }},
+  {17, {  // HI
+    {'1', "HI-17"},
+    {'2', "HI-27"},
+  }},
+  {18, {  // ClO
+    {'1', "ClO-56"},
+    {'2', "ClO-76"},
+  }},
+  {19, {  // OCS
+    {'1', "OCS-622"},
+    {'2', "OCS-624"},
+    {'3', "OCS-632"},
+    {'4', "OCS-623"},
+    {'5', "OCS-822"},
+    {'6', "OCS-634"},
+  }},
+  {20, {  // H2CO
+    {'1', "H2CO-1126"},  // Modified from HITRAN because ARTS does not use AFGL notation
+    {'2', "H2CO-1136"},  // Modified from HITRAN because ARTS does not use AFGL notation
+    {'3', "H2CO-1128"},  // Modified from HITRAN because ARTS does not use AFGL notation
+  }},
+  {21, {  // HOCl
+    {'1', "HOCl-165"},
+    {'2', "HOCl-167"},
+  }},
+  {22, {  // N2
+    {'1', "N2-44"},
+    {'2', "N2-45"},
+  }},
+  {23, {  // HCN
+    {'1', "HCN-124"},
+    {'2', "HCN-134"},
+    {'3', "HCN-125"},
+  }},
+  {24, {  // CH3Cl
+    {'1', "CH3Cl-215"},
+    {'2', "CH3Cl-217"},
+  }},
+  {25, {  // H2O2
+    {'1', "H2O2-1661"},
+  }},
+  {26, {  // C2H2
+    {'1', "C2H2-1221"},
+    {'2', "C2H2-1231"},
+    {'3', "C2H2-1222"},
+  }},
+  {27, {  // C2H6
+    {'1', "C2H6-1221"},
+    {'2', "C2H6-1231"},
+  }},
+  {28, {  // PH3
+    {'1', "PH3-1111"},
+  }},
+  {29, {  // COF2
+    {'1', "COF2-269"},
+    {'2', "COF2-369"},
+  }},
+  {30, {  // SF6
+    {'1', "SF6-29"},
+  }},
+  {31, {  // H2S
+    {'1', "H2S-121"},
+    {'2', "H2S-141"},
+    {'3', "H2S-131"},
+  }},
+  {32, {  // HCOOH
+    {'1', "HCOOH-1261"},  // Modified from HITRAN because ARTS does not use AFGL notation
+  }},
+  {33, {  // HO2
+    {'1', "HO2-166"},
+  }},
+  {34, {  // O
+    {'1', "O-6"},
+  }},
+  {35, {  // ClONO2
+    {'1', "ClONO2-5646"},
+    {'2', "ClONO2-7646"},
+  }},
+  {36, {  // NO+
+    {'1', "NO+-46"},
+  }},
+  {37, {  // HOBr
+    {'1', "HOBr-169"},
+    {'2', "HOBr-161"},
+  }},
+  {38, {  // C2H4
+    {'1', "C2H4-221"},
+    {'2', "C2H4-231"},
+  }},
+  {39, {  // CH3OH
+    {'1', "CH3OH-2161"},
+  }},
+  {40, {  // CH3Br
+    {'1', "CH3Br-219"},
+    {'2', "CH3Br-211"},
+  }},
+  {41, {  // CH3CN
+    {'1', "CH3CN-211124"},  // Modified from HITRAN because ARTS does not use AFGL notation
+  }},
+  {42, {  // CF4
+    {'1', "CF4-29"},
+  }},
+  {43, {  // C4H2
+    {'1', "C4H2-2211"},
+  }},
+  {44, {  // HC3N
+    {'1', "HC3N-12224"},  // Modified from HITRAN because ARTS does not use AFGL notation
+  }},
+  {45, {  // H2
+    {'1', "H2-11"},
+    {'2', "H2-12"},
+  }},
+  {46, {  // CS
+    {'1', "CS-22"},
+    {'2', "CS-24"},
+    {'3', "CS-32"},
+    {'4', "CS-23"},
+  }},
+  {47, {  // SO3
+    {'1', "SO3-26"},
+  }},
+  {48, {  // C2N2
+    {'1', "C2N2-4224"},
+  }},
+  {49, {  // COCl2
+    {'1', "COCl2-2655"},
+    {'2', "COCl2-2657"},
+  }},
+  {53, {  // CS2
+    {'1', "CS2-222"},
+    {'2', "CS2-224"},
+    {'3', "CS2-223"},
+    {'4', "CS2-232"},
+  }},
+};
+
+
+/** Turns the string-map required at compile time into a species-map
+ * to be used as a static runtime map
+ */
+std::map<Index, std::map<char, SpeciesTag>> to_species_map(const std::map<Index, std::map<char, const char * const>>& string_map) {
+  std::map<Index, std::map<char, SpeciesTag>> species_map;
+  for (auto& specs: string_map) {
+    for (auto& isot: specs.second) {
+      species_map[specs.first][isot.first] = SpeciesTag(isot.second);
+    }
+  }
+  return species_map;
 }
 
-QuantumIdentifier from_lookup(Index mol, char isochar) {
-  Index iso;
-  if (isochar == '1') iso = 1;
-  if (isochar == '2') iso = 2;
-  if (isochar == '3') iso = 3;
-  if (isochar == '4') iso = 4;
-  if (isochar == '5') iso = 5;
-  if (isochar == '6') iso = 6;
-  if (isochar == '7') iso = 7;
-  if (isochar == '8') iso = 8;
-  if (isochar == '9') iso = 9;
-  if (isochar == '0') iso = 10;
-  if (isochar == 'A') iso = 11;
-  if (isochar == 'B') iso = 12;
-  return from_mol_iso(mol, iso);
+/** Selects the map and returns it.  Uses templates to avoid weird warnings */
+template <Type t>
+const std::map<Index, std::map<char, SpeciesTag>> select_hitran_map() {
+  static_assert(good_enum(t), "Bad enum encountered, something is amiss");
+  
+  /*
+  // Debug code to uncomment to check that the output is as expected
+  auto x = to_species_map(latest_molparam_map);
+  for (auto y: x) {
+    std::cout << y.first << '\n';
+    for (auto z: y.second) {
+      std:: cout << z.first << ' ' << z.second << '\n';
+    }
+  }
+  */
+  
+  if constexpr (t == Type::Newest) {
+    return to_species_map(latest_molparam_map);
+  } else if constexpr (t == Type::Pre2012CO2Change) {
+    return to_species_map(pre2012co2change_molparam_map);
+  } else {
+    std::terminate();
+  }
+}
+
+/** Returns the species if possible or throws an error if it cannot be found
+ * 
+ * @param[in] molnum The hitran molecular number
+ * @param[in] isonum The hitran character representing an isotopologue
+ * @return An ARTS identifier of the species' as a transition
+ */
+template <Type t> QuantumIdentifier from_mol_iso(Index molnum, char isonum) {
+  static_assert(good_enum(t), "Bad enum encountered, something is amiss. enum is: ");
+  
+  // Map of all HITRAN species
+  static const std::map<Index, std::map<char, SpeciesTag>> hitmap = select_hitran_map<t>();
+  
+  // Search the map with pointers so that we can throw manually if something is bad
+  if (auto species_list = hitmap.find(molnum); species_list not_eq hitmap.cend()) {
+    if (auto species_name = species_list -> second.find(isonum); species_name not_eq species_list -> second.cend()) {
+      const SpeciesTag& spec = species_name -> second;
+      return QuantumIdentifier(QuantumIdentifier::TRANSITION, spec.Species(), spec.Isotopologue());
+    } else {
+      ARTS_USER_ERROR("Species ", molnum, " has no isotopologue ", isonum,
+                      " in ARTS' HITRAN implementation.\n",
+                      "(This species's first entry is \'", from_mol_iso<t>(molnum, '1').SpeciesName(), "\')\n"
+                      "If you are using a new version of HITRAN that has added the isotopologue, please consider\n"
+                      "contacting the ARTS developers so we can append the species to our list and make this work.\n"
+                      "Note that you are calling this templated function as the ", t, " template")
+    }
+  } else {
+    ARTS_USER_ERROR("Species ", molnum, " does not exist in ARTS' HITRAN implementation\n"
+                    "If you are using a new version of HITRAN that has added the species, please consider\n"
+                    "contacting the ARTS developers so we can append the species to our list and make this work.\n"
+                    "Note that you are calling this templated function as the ", t, " template");
+  }
+}
+
+QuantumIdentifier from_lookup(Index mol, char isochar, Type type) {
+  switch (type) {
+    case Type::Pre2012CO2Change:
+      return from_mol_iso<Type::Pre2012CO2Change>(mol, isochar);
+    case Type::Newest:
+      return from_mol_iso<Type::Newest>(mol, isochar);
+    case Type::FINAL: {/* leave last */}
+  }
+  return {};
 }
 
 }  // namespace Hitran

--- a/src/hitran_species.h
+++ b/src/hitran_species.h
@@ -2,9 +2,23 @@
 #define hitran_species_h
 
 #include "quantum.h"
+#include "enums.h"
 
 namespace Hitran {
-  QuantumIdentifier from_lookup(Index mol, char isochar);
+  /** Hitran type for selection of data map
+   * 
+   * Note that this should be appended as few time as possible.
+   * 
+   * Each type here has to correspond to a data-map in the .cc-file
+   * 
+   * Only add a new type here if HITRAN changes significantly the
+   * interpretation of their data
+   */
+  ENUMCLASS(Type, char,
+            Pre2012CO2Change,
+            Newest)
+  
+  QuantumIdentifier from_lookup(Index mol, char isochar, Type type=Type::Newest);
 }
 
 #endif

--- a/src/hitran_species.h
+++ b/src/hitran_species.h
@@ -1,0 +1,10 @@
+#ifndef hitran_species_h
+#define hitran_species_h
+
+#include "quantum.h"
+
+namespace Hitran {
+  QuantumIdentifier from_lookup(Index mol, char isochar);
+}
+
+#endif

--- a/src/lineshapemodel.cc
+++ b/src/lineshapemodel.cc
@@ -1027,6 +1027,63 @@ Model::Model(Numeric sgam,
   }
 }
 
+Model hitran_model(Numeric sgam,
+                   Numeric nself,
+                   Numeric agam,
+                   Numeric nair,
+                   Numeric psf) {
+  Model m(2);
+  
+  m.Data().front().G0() = {TemperatureModel::T1, sgam, nself, 0, 0};
+  m.Data().front().D0() = {TemperatureModel::T0, psf, 0, 0, 0};
+
+  m.Data().back().G0() = {TemperatureModel::T1, agam, nair, 0, 0};
+  m.Data().back().D0() = {TemperatureModel::T0, psf, 0, 0, 0};
+  
+  return m;
+}
+
+Model lblrtm_model(Numeric sgam,
+                   Numeric nself,
+                   Numeric agam,
+                   Numeric nair,
+                   Numeric psf,
+                   std::array<Numeric, 12> aer_interp) {
+  Model m(2);
+  
+  m.Data().front().G0() = {TemperatureModel::T1, sgam, nself, 0, 0};
+  m.Data().front().D0() = {TemperatureModel::T0, psf, 0, 0, 0};
+
+  m.Data().back().G0() = {TemperatureModel::T1, agam, nair, 0, 0};
+  m.Data().back().D0() = {TemperatureModel::T0, psf, 0, 0, 0};
+  
+  if (std::any_of(aer_interp.cbegin(), aer_interp.cend(), [](auto x){return x not_eq 0;})) {
+    m.Data().front().Y().type = TemperatureModel::LM_AER;
+    m.Data().front().Y().X0 = aer_interp[4];
+    m.Data().front().Y().X1 = aer_interp[5];
+    m.Data().front().Y().X2 = aer_interp[6];
+    m.Data().front().Y().X3 = aer_interp[7];
+    m.Data().front().G().type = TemperatureModel::LM_AER;
+    m.Data().front().G().X0 = aer_interp[8];
+    m.Data().front().G().X1 = aer_interp[9];
+    m.Data().front().G().X2 = aer_interp[10];
+    m.Data().front().G().X3 = aer_interp[11];
+    
+    m.Data().back().Y().type = TemperatureModel::LM_AER;
+    m.Data().back().Y().X0 = aer_interp[4];
+    m.Data().back().Y().X1 = aer_interp[5];
+    m.Data().back().Y().X2 = aer_interp[6];
+    m.Data().back().Y().X3 = aer_interp[7];
+    m.Data().back().G().type = TemperatureModel::LM_AER;
+    m.Data().back().G().X0 = aer_interp[8];
+    m.Data().back().G().X1 = aer_interp[9];
+    m.Data().back().G().X2 = aer_interp[10];
+    m.Data().back().G().X3 = aer_interp[11];
+  }
+  
+  return m;
+}
+
 bool Model::OK(Type type, bool self, bool bath,
                const std::vector<SpeciesTag>& species) const noexcept {
   Index n = mdata.size();

--- a/src/lineshapemodel.h
+++ b/src/lineshapemodel.h
@@ -868,6 +868,20 @@ class Model {
   bofstream& write(bofstream& bof) const;
 };  // Model;
 
+
+Model hitran_model(Numeric sgam,
+                   Numeric nself,
+                   Numeric agam,
+                   Numeric nair,
+                   Numeric psf);
+
+Model lblrtm_model(Numeric sgam,
+                   Numeric nself,
+                   Numeric agam,
+                   Numeric nair,
+                   Numeric psf,
+                   std::array<Numeric, 12> aer_interp = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+
 std::ostream& operator<<(std::ostream&, const Model&);
 
 std::istream& operator>>(std::istream&, Model&);

--- a/src/m_absorptionlines.cc
+++ b/src/m_absorptionlines.cc
@@ -407,12 +407,6 @@ void ReadSplitARTSCAT(ArrayOfAbsorptionLines& abs_lines,
   abs_linesSetLinemixingLimit(abs_lines, linemixinglimit_value, verbosity);
 }
 
-ENUMCLASS(HitranType, char,
-  Pre2004,
-  Post2004,
-  Online
-)
-
 /* Workspace method: Doxygen documentation will be auto-generated */
 void ReadHITRAN(ArrayOfAbsorptionLines& abs_lines,
                 const String& hitran_file,
@@ -439,7 +433,7 @@ void ReadHITRAN(ArrayOfAbsorptionLines& abs_lines,
   const std::vector<QuantumNumberType> local_nums = string2vecqn(localquantumnumbers);
   
   // HITRAN type
-  const HitranType hitran_version = toHitranTypeOrThrow(hitran_type);
+  const Options::HitranType hitran_version = Options::toHitranTypeOrThrow(hitran_type);
   
   // Hitran data
   ifstream is;
@@ -449,13 +443,16 @@ void ReadHITRAN(ArrayOfAbsorptionLines& abs_lines,
   while (go_on) {
     Absorption::SingleLineExternal sline;
     switch (hitran_version) {
-      case HitranType::Post2004:
+      case Options::HitranType::Post2012:
+        sline = Absorption::ReadFromHitran2012Stream(is);
+        break;
+      case Options::HitranType::From2004To2012:
         sline = Absorption::ReadFromHitran2004Stream(is);
         break;
-      case HitranType::Pre2004:
+      case Options::HitranType::Pre2004:
         sline = Absorption::ReadFromHitran2001Stream(is);
         break;
-      case HitranType::Online:
+      case Options::HitranType::Online:
         sline = Absorption::ReadFromHitranOnlineStream(is);
         break;
       default:

--- a/src/m_absorptionlines.cc
+++ b/src/m_absorptionlines.cc
@@ -430,6 +430,8 @@ void ReadHITRAN(ArrayOfAbsorptionLines& abs_lines,
                 const Numeric& linemixinglimit_value,
                 const Verbosity& verbosity)
 {
+  abs_lines.resize(0);
+  
   // Global numbers
   const std::vector<QuantumNumberType> global_nums = string2vecqn(globalquantumnumbers);
   
@@ -437,52 +439,70 @@ void ReadHITRAN(ArrayOfAbsorptionLines& abs_lines,
   const std::vector<QuantumNumberType> local_nums = string2vecqn(localquantumnumbers);
   
   // HITRAN type
-  const HitranType hitran_version = toHitranType(hitran_type);
-  check_enum_error(hitran_version, "Cannot understand hitran_type: ", hitran_type);
+  const HitranType hitran_version = toHitranTypeOrThrow(hitran_type);
   
   // Hitran data
   ifstream is;
   open_input_file(is, hitran_file);
   
-  std::vector<Absorption::SingleLineExternal> v(0);
-  
   bool go_on = true;
   while (go_on) {
+    Absorption::SingleLineExternal sline;
     switch (hitran_version) {
       case HitranType::Post2004:
-        v.push_back(Absorption::ReadFromHitran2004Stream(is));
+        sline = Absorption::ReadFromHitran2004Stream(is);
         break;
       case HitranType::Pre2004:
-        v.push_back(Absorption::ReadFromHitran2001Stream(is));
+        sline = Absorption::ReadFromHitran2001Stream(is);
         break;
       case HitranType::Online:
-        v.push_back(Absorption::ReadFromHitranOnlineStream(is));
+        sline = Absorption::ReadFromHitranOnlineStream(is);
         break;
       default:
-        ARTS_ASSERT(false, "[DEV error] The HitranType enum class has to be fully updated!\n");
+        ARTS_ASSERT(false, "The HitranType enum class has to be fully updated!\n");
     }
     
-    if (v.back().bad) {
-      v.pop_back();
-      go_on = false;
-    } else if (v.back().line.F0() < fmin) {
-        v.pop_back();
-    } else if (v.back().line.F0() > fmax) {
-      v.pop_back();
-      go_on = false;
+    if (sline.bad) {
+      if (is.eof()) {
+        break;
+      } else {
+        ARTS_USER_ERROR("Cannot read line ", nelem(abs_lines) + 1);
+      }
+    } else if (sline.line.F0() < fmin) {
+      continue; // Skip this line
+    } else if (sline.line.F0() > fmax) {
+      break;  // We assume sorted so quit here
     }
-  }
-  
-  for (auto& x: v)
-    x.line.Zeeman() = Zeeman::GetAdvancedModel(x.quantumidentity);
-  
-  auto x = Absorption::split_list_of_external_lines(v, local_nums, global_nums);
-  abs_lines.resize(0);
-  abs_lines.reserve(x.size());
-  while (x.size()) {
-    abs_lines.push_back(x.back());
-    abs_lines.back().sort_by_frequency();
-    x.pop_back();
+    
+    // Set Zeeman if implemented
+    sline.line.Zeeman() = Zeeman::GetAdvancedModel(sline.quantumidentity);
+    
+    // Get the global quantum number identifier
+    QuantumIdentifier global_qid(QuantumIdentifier::TRANSITION, sline.quantumidentity.Species(), sline.quantumidentity.Isotopologue());
+    for(auto qn: global_nums) {
+      global_qid.LowerQuantumNumber(qn) = sline.quantumidentity.LowerQuantumNumber(qn);
+      global_qid.UpperQuantumNumber(qn) = sline.quantumidentity.UpperQuantumNumber(qn);
+    }
+    
+    // Get local quantum numbers into the line
+    sline.line.LowerQuantumNumbers().reserve(local_nums.size());
+    sline.line.UpperQuantumNumbers().reserve(local_nums.size());
+    for(auto qn: local_nums) {
+      sline.line.LowerQuantumNumbers().emplace_back(sline.quantumidentity.LowerQuantumNumber(qn));
+      sline.line.UpperQuantumNumbers().emplace_back(sline.quantumidentity.UpperQuantumNumber(qn));
+    }
+    
+    // Either find a line like this in the list of lines or start a new Lines
+    auto band = std::find_if(abs_lines.begin(), abs_lines.end(), [&](const auto& li){return li.MatchWithExternal(sline, global_qid);});
+    if (band not_eq abs_lines.end()) {
+      band -> AppendSingleLine(sline.line);
+    } else {
+      abs_lines.emplace_back(sline.selfbroadening, sline.bathbroadening, sline.cutoff,
+                             sline.mirroring, sline.population, sline.normalization,
+                             sline.lineshapetype, sline.T0, sline.cutofffreq,
+                             sline.linemixinglimit, global_qid, local_nums, sline.species,
+                             std::vector<AbsorptionSingleLine>{sline.line});
+    }
   }
   
   abs_linesSetNormalization(abs_lines, normalization_option, verbosity);

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -14248,8 +14248,9 @@ void define_md_data_raw() {
                   "\n"
                   "The HITRAN type switch can be:\n"
                   "\t\"Pre2004\"\t-\tfor old format\n"
-                  "\t\"Post2004\"\t-\tfor new format\n"
-                  "\t\"Online\"\t-\tfor the online format with quantum numbers (highly experimental)\n"
+                  "\t\"From2004To2012\"\t-\tfor new format but old isotopologue order\n"
+                  "\t\"Post2012\"\t-\tfor new format and new isotopologue order\n"
+                  "\t\"Online\"\t-\tfor the online format with quantum numbers (recommended)\n"
                   "\n"
                   "Be careful setting the options!\n"
       ),
@@ -14265,7 +14266,7 @@ void define_md_data_raw() {
           "cutoff_value", "linemixinglimit_value"),
       GIN_TYPE("String", "Numeric", "Numeric", "String", "String", "String", "String",
                "String", "String", "String", "String", "Numeric", "Numeric"),
-      GIN_DEFAULT(NODEF, "0", "1e99", "", "", "Post2004", "None", "None", "LTE", "VP",
+      GIN_DEFAULT(NODEF, "0", "1e99", "", "", "Online", "None", "None", "LTE", "VP",
                  "None", "750e9", "-1"),
       GIN_DESC("Name of the HITRAN file",
                "Minimum frequency of read lines",

--- a/src/partition_function_data.cc
+++ b/src/partition_function_data.cc
@@ -409,6 +409,11 @@ void define_partition_species_data() {
       Qcoeff(150.0, 300.0),
       IsotopologueRecord::PF_FROMCOEFF);
   iso(it_isotopologue,
+      "737",
+      Qcoeff(0,0,0,0),
+      Qcoeff(150.0, 300.0),
+      IsotopologueRecord::PF_FROMCOEFF);
+  iso(it_isotopologue,
       "CKD241",
       Qcoeff(0, 0, 0, 0),
       Qcoeff(150.0, 300.0),
@@ -731,6 +736,11 @@ void define_partition_species_data() {
       Qcoeff(-8.761726e+02, 2.829842e+01, 5.398242e-02, 5.194329e-05),
       Qcoeff(150.0, 300.0),
       IsotopologueRecord::PF_FROMCOEFF);
+  iso(it_isotopologue,
+      "656",
+      Qcoeff(0,0,0,0),
+      Qcoeff(150.0, 300.0),
+      IsotopologueRecord::PF_FROMCOEFF);
 
   // NH3
   // Coeff: 1 1 2
@@ -919,6 +929,11 @@ void define_partition_species_data() {
       "822",
       Qcoeff(1.444298e+01, 3.686311e+00, -3.307686e-03, 1.920205e-05),
       Qcoeff(150.0, 300.0),
+      IsotopologueRecord::PF_FROMCOEFF);
+  iso(it_isotopologue,
+      "634",
+      Qcoeff(0,0,0,0),
+      Qcoeff(1, 2),
       IsotopologueRecord::PF_FROMCOEFF);
 
   // H2CO
@@ -1656,6 +1671,56 @@ void define_partition_species_data() {
       "26",
       Qcoeff(-76.2339, 6.95356, 1.30510e-07, -1.17068e-11),
       Qcoeff(150.0, 300.0),
+      IsotopologueRecord::PF_FROMCOEFF);
+
+  // CS2
+  next_species(it_species, it_isotopologue, "CS2");
+  //                    Name            c0              c1              c2              c3
+  //                    |               |               |               |               |
+  iso(it_isotopologue,
+      "222",
+      Qcoeff(0, 0, 0, 0),
+      Qcoeff(1, 2),
+      IsotopologueRecord::PF_FROMCOEFF);
+  iso(it_isotopologue,
+      "224",
+      Qcoeff(0, 0, 0, 0),
+      Qcoeff(1, 2),
+      IsotopologueRecord::PF_FROMCOEFF);
+  iso(it_isotopologue,
+      "223",
+      Qcoeff(0, 0, 0, 0),
+      Qcoeff(1, 2),
+      IsotopologueRecord::PF_FROMCOEFF);
+  iso(it_isotopologue,
+      "232",
+      Qcoeff(0, 0, 0, 0),
+      Qcoeff(1, 2),
+      IsotopologueRecord::PF_FROMCOEFF);
+  
+  // C2N2
+  next_species(it_species, it_isotopologue, "C2N2");
+  //                    Name            c0              c1              c2              c3
+  //                    |               |               |               |               |
+  iso(it_isotopologue,
+      "4224",
+      Qcoeff(0, 0, 0, 0),
+      Qcoeff(1, 2),
+      IsotopologueRecord::PF_FROMCOEFF);
+  
+  //  
+  next_species(it_species, it_isotopologue, "COCl2");
+  //                    Name            c0              c1              c2              c3
+  //                    |               |               |               |               |
+  iso(it_isotopologue,
+      "2655",
+      Qcoeff(0, 0, 0, 0),
+      Qcoeff(1, 2),
+      IsotopologueRecord::PF_FROMCOEFF);
+  iso(it_isotopologue,
+      "2657",
+      Qcoeff(0, 0, 0, 0),
+      Qcoeff(1, 2),
       IsotopologueRecord::PF_FROMCOEFF);
 
   // liquid cloud particles

--- a/src/quantum.cc
+++ b/src/quantum.cc
@@ -245,17 +245,11 @@ void update_id(QuantumIdentifier& qid, const std::vector<std::array<String, 2> >
   for (auto& keyval: upper_list) {
     auto key = string2quantumnumbertype(keyval[0]);
     if (key == QuantumNumberType::FINAL) {
-      std::ostringstream os;
-      os << "The key \"" << keyval[0] << "\" is an invalid input as a quantum number key";
-      std::cout << "WARNING: " << os.str() << '\n';
     } else {
       auto val = interpret_stringdata(key, keyval[1]);
       if (val != RATIONAL_UNDEFINED) {
         qid.UpperQuantumNumber(key) = val;
       } else {
-        std::ostringstream os;
-        os << "The key \"" << keyval[0] << "\" and value \"" << keyval[1] << "\" are invalid input as a quantum number key and value pair";
-        std::cout << "WARNING: " << os.str() << '\n';
       }
     }
   }
@@ -263,17 +257,11 @@ void update_id(QuantumIdentifier& qid, const std::vector<std::array<String, 2> >
   for (auto& keyval: lower_list) {
     auto key = string2quantumnumbertype(keyval[0]);
     if (key == QuantumNumberType::FINAL) {
-      std::ostringstream os;
-      os << "The key \"" << keyval[0] << "\" is an invalid input as a quantum number key";
-      std::cout << "WARNING: " << os.str() << '\n';
     } else {
       auto val = interpret_stringdata(key, keyval[1]);
       if (val != RATIONAL_UNDEFINED) {
         qid.LowerQuantumNumber(key) = val;
       } else {
-        std::ostringstream os;
-        os << "The key \"" << keyval[0] << "\" and value \"" << keyval[1] << "\" are invalid input as a quantum number key and value pair";
-        std::cout << "WARNING: " << os.str() << '\n';
       }
     }
   }

--- a/src/quantum.h
+++ b/src/quantum.h
@@ -723,11 +723,12 @@ class QuantumIdentifier {
  */
 constexpr bool operator==(const QuantumNumbers& a, const QuantumNumbers& b) {
   for (Index i=0; i<Index(QuantumNumberType::FINAL); i++) {
-    if (a.GetNumbers()[i].isDefined() and b.GetNumbers()[i].isDefined() and
-        a.GetNumbers()[i] not_eq b.GetNumbers()[i]) {
-      return false;
-    } else if (a.GetNumbers()[i].isDefined() or b.GetNumbers()[i].isDefined()) {
-      return false;
+    Rational ra = a.GetNumbers()[i];
+    Rational rb = b.GetNumbers()[i];
+    if (ra.isDefined() or rb.isDefined()) {
+      if (ra not_eq rb) {
+        return false;
+      }
     }
   }
   return true;
@@ -748,7 +749,7 @@ constexpr bool operator==(const QuantumIdentifier& a, const QuantumIdentifier& b
   if (!(a.Isotopologue() == b.Isotopologue() && a.Species() == b.Species() &&
         a.Type() == b.Type()))
     return false;
-
+  
   if (a.Type() == QuantumIdentifier::ENERGY_LEVEL)
     return a.QuantumMatch()[a.ENERGY_LEVEL_INDEX] == b.QuantumMatch()[b.ENERGY_LEVEL_INDEX];
   else if (a.Type() == QuantumIdentifier::TRANSITION)

--- a/src/species_data.cc
+++ b/src/species_data.cc
@@ -171,7 +171,7 @@ void define_basic_species_data() {
       ( NAME("H2O"),
         DEGFR(3),
         ISOTOPOLOGUES
-        (//   Name,     Isotopologue Ratio, Mass,   MY-tag, HI-tag, JPL-tag
+        (//   Name,     Isotopologue Ratio, Mass,   MY-tag, JPL-tag
          //             |               |       |       |       |
          REC( ""        ,               ,       ,       ,       ,TAGS() ),
          REC( ""        ,               ,       ,       ,       ,TAGS() )
@@ -205,37 +205,37 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("H2O"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //   Name,             Isotop. Ratio,  Mass,          MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //   Name,             Isotop. Ratio,  Mass,          MY-tag, JPL-tag
           //                     |               |              |       |       |
-          REC("161", .997317E+00, 18.010565, 11, 11, TAGS(18003, 18005)),
-          REC("181", 1.99983E-03, 20.014811, 12, 12, TAGS(20003)),
-          REC("171", 3.71884E-04, 19.014780, 13, 13, TAGS(19003)),
-          REC("162", 3.10693E-04, 19.016740, 14, 14, TAGS(19002)),
-          REC("182", 6.23003E-07, 21.020985, -1, 15, TAGS(21001)),
-          REC("172", 1.15853E-07, 20.020956, -1, 16, TAGS()),
-          REC("262", 2.41970E-08, 20.000000, -1, 17, TAGS(20001)),
-          REC("SelfContStandardType", NAN, NAN, -1, -1, TAGS()),
-          REC("ForeignContStandardType", NAN, NAN, -1, -1, TAGS()),
-          REC("ForeignContMaTippingType", NAN, NAN, -1, -1, TAGS()),
-          REC("ContMPM93", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContCKDMT100", NAN, NAN, -1, -1, TAGS()),
-          REC("ForeignContCKDMT100", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContCKDMT252", NAN, NAN, -1, -1, TAGS()),
-          REC("ForeignContCKDMT252", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContCKDMT320", NAN, NAN, -1, -1, TAGS()),
-          REC("ForeignContCKDMT320", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContCKD222", NAN, NAN, -1, -1, TAGS()),
-          REC("ForeignContCKD222", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContCKD242", NAN, NAN, -1, -1, TAGS()),
-          REC("ForeignContCKD242", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContCKD24", NAN, NAN, -1, -1, TAGS()),
-          REC("ForeignContCKD24", NAN, NAN, -1, -1, TAGS()),
-          REC("ForeignContATM01", NAN, NAN, -1, -1, TAGS()),
-          REC("CP98", NAN, NAN, -1, -1, TAGS()),
-          REC("MPM87", NAN, NAN, -1, -1, TAGS()),
-          REC("MPM89", NAN, NAN, -1, -1, TAGS()),
-          REC("MPM93", NAN, NAN, -1, -1, TAGS()),
-          REC("PWR98", NAN, NAN, -1, -1, TAGS()))));
+          REC("161", .997317E+00, 18.010565, 11, TAGS(18003, 18005)),
+          REC("181", 1.99983E-03, 20.014811, 12, TAGS(20003)),
+          REC("171", 3.71884E-04, 19.014780, 13, TAGS(19003)),
+          REC("162", 3.10693E-04, 19.016740, 14, TAGS(19002)),
+          REC("182", 6.23003E-07, 21.020985, -1, TAGS(21001)),
+          REC("172", 1.15853E-07, 20.020956, -1, TAGS()),
+          REC("262", 2.41970E-08, 20.000000, -1, TAGS(20001)),
+          REC("SelfContStandardType", NAN, NAN, -1, TAGS()),
+          REC("ForeignContStandardType", NAN, NAN, -1, TAGS()),
+          REC("ForeignContMaTippingType", NAN, NAN, -1, TAGS()),
+          REC("ContMPM93", NAN, NAN, -1, TAGS()),
+          REC("SelfContCKDMT100", NAN, NAN, -1, TAGS()),
+          REC("ForeignContCKDMT100", NAN, NAN, -1, TAGS()),
+          REC("SelfContCKDMT252", NAN, NAN, -1, TAGS()),
+          REC("ForeignContCKDMT252", NAN, NAN, -1, TAGS()),
+          REC("SelfContCKDMT320", NAN, NAN, -1, TAGS()),
+          REC("ForeignContCKDMT320", NAN, NAN, -1, TAGS()),
+          REC("SelfContCKD222", NAN, NAN, -1, TAGS()),
+          REC("ForeignContCKD222", NAN, NAN, -1, TAGS()),
+          REC("SelfContCKD242", NAN, NAN, -1, TAGS()),
+          REC("ForeignContCKD242", NAN, NAN, -1, TAGS()),
+          REC("SelfContCKD24", NAN, NAN, -1, TAGS()),
+          REC("ForeignContCKD24", NAN, NAN, -1, TAGS()),
+          REC("ForeignContATM01", NAN, NAN, -1, TAGS()),
+          REC("CP98", NAN, NAN, -1, TAGS()),
+          REC("MPM87", NAN, NAN, -1, TAGS()),
+          REC("MPM89", NAN, NAN, -1, TAGS()),
+          REC("MPM93", NAN, NAN, -1, TAGS()),
+          REC("PWR98", NAN, NAN, -1, TAGS()))));
 
   // CO2
   // (missing mainly in JPL, latest version (7/00) includes some isotopologues)
@@ -258,79 +258,71 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("CO2"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //   Name,     Isotop. Ratio,  Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //   Name,     Isotop. Ratio,  Mass,         MY-tag, JPL-tag
           //             |               |             |       |       |
-          REC("626", .984204E+00, 43.989830, 21, 21, TAGS()),
-          REC("636", 1.10574E-02, 44.993185, 22, 22, TAGS()),
-          REC("628", 3.94707E-03, 45.994076, 23, 23, TAGS(46013)),
-          REC("627", 7.33989E-04, 44.994045, 24, 24, TAGS(45012)),
-          REC("638", 4.43446E-05, 46.997431, 25, 25, TAGS()),
-          REC("637", 8.24623E-06, 45.997400, 26, 26, TAGS()),
-          REC("828", 3.95734E-06, 47.998322, 27, 27, TAGS()),
-          REC("728", 1.47180E-06, 46.998291, 28, 28, TAGS()),
-#ifdef USE_HITRAN2008
-          // version for 2008 and earlier
-          REC("727", 1.36847E-07, 45.998262, -1, -1, TAGS()),
-          REC("838", 4.44600E-08, 49.001675, -1, 29, TAGS()),
-#else
-          // version for 2012 and later
-          REC("727", 1.36847E-07, 45.998262, -1, 29, TAGS()),
-          REC("838", 4.44600E-08, 49.001675, -1, 20, TAGS()),
-#endif
-          REC("837", 1.65354E-08, 48.001646, -1, -1, TAGS()),
-          REC("737", 1.537500E-08, 47.0016182378, -1, -1, TAGS()),
-          REC("CKD241", NAN, NAN, -1, -1, TAGS()),
-          REC("CKDMT100", NAN, NAN, -1, -1, TAGS()),
-          REC("CKDMT252", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContPWR93", NAN, NAN, -1, -1, TAGS()),
-          REC("ForeignContPWR93", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContHo66", NAN, NAN, -1, -1, TAGS()),
-          REC("ForeignContHo66", NAN, NAN, -1, -1, TAGS()))));
+          REC("626", .984204E+00, 43.989830, 21, TAGS()),
+          REC("636", 1.10574E-02, 44.993185, 22, TAGS()),
+          REC("628", 3.94707E-03, 45.994076, 23, TAGS(46013)),
+          REC("627", 7.33989E-04, 44.994045, 24, TAGS(45012)),
+          REC("638", 4.43446E-05, 46.997431, 25, TAGS()),
+          REC("637", 8.24623E-06, 45.997400, 26, TAGS()),
+          REC("828", 3.95734E-06, 47.998322, 27, TAGS()),
+          REC("728", 1.47180E-06, 46.998291, 28, TAGS()),
+          REC("727", 1.36847E-07, 45.998262, -1, TAGS()),
+          REC("838", 4.44600E-08, 49.001675, -1, TAGS()),
+          REC("837", 1.65354E-08, 48.001646, -1, TAGS()),
+          REC("737", 1.537500E-08, 47.0016182378, -1, TAGS()),
+          REC("CKD241", NAN, NAN, -1, TAGS()),
+          REC("CKDMT100", NAN, NAN, -1, TAGS()),
+          REC("CKDMT252", NAN, NAN, -1, TAGS()),
+          REC("SelfContPWR93", NAN, NAN, -1, TAGS()),
+          REC("ForeignContPWR93", NAN, NAN, -1, TAGS()),
+          REC("SelfContHo66", NAN, NAN, -1, TAGS()),
+          REC("ForeignContHo66", NAN, NAN, -1, TAGS()))));
 
   // O3
   // Isotopologue Ratios: 1 1 1 1 1
   species_data.push_back(SpeciesRecord(
       NAME("O3"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,    Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,    Mass,         MY-tag, JPL-tag
           //             |                 |             |       |       |
           REC("666",
               .992901E+00,
               47.984745,
               31,
-              31,
               TAGS(48004, 48005, 48006, 48007, 48008)),
-          REC("668", 3.98194E-03, 49.988991, 32, 32, TAGS(50004, 50006)),
-          REC("686", 1.99097E-03, 49.988991, 33, 33, TAGS(50003, 50005)),
-          REC("667", 7.40475E-04, 48.988960, 34, 34, TAGS(49002)),
-          REC("676", 3.70237E-04, 48.988960, 35, 35, TAGS(49001)))));
+          REC("668", 3.98194E-03, 49.988991, 32, TAGS(50004, 50006)),
+          REC("686", 1.99097E-03, 49.988991, 33, TAGS(50003, 50005)),
+          REC("667", 7.40475E-04, 48.988960, 34, TAGS(49002)),
+          REC("676", 3.70237E-04, 48.988960, 35, TAGS(49001)))));
 
   // N2O
   // Isotopologue Ratios: 1 1 1 1 1
   species_data.push_back(SpeciesRecord(
       NAME("N2O"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, JPL-tag
           //             |                |             |       |       |
-          REC("446", .990333E+00, 44.001062, 41, 41, TAGS(44004, 44009, 44012)),
-          REC("456", 3.64093E-03, 44.998096, 42, 42, TAGS(45007)),
-          REC("546", 3.64093E-03, 44.998096, 43, 43, TAGS(45008)),
-          REC("448", 1.98582E-03, 46.005308, 44, 44, TAGS(46007)),
-          REC("447", 3.69280E-04, 45.005278, -1, 45, TAGS()))));
+          REC("446", .990333E+00, 44.001062, 41, TAGS(44004, 44009, 44012)),
+          REC("456", 3.64093E-03, 44.998096, 42, TAGS(45007)),
+          REC("546", 3.64093E-03, 44.998096, 43, TAGS(45008)),
+          REC("448", 1.98582E-03, 46.005308, 44, TAGS(46007)),
+          REC("447", 3.69280E-04, 45.005278, -1, TAGS()))));
 
   // CO
   // Isotopologue Ratios: 1 1 1 1 1 1
   species_data.push_back(SpeciesRecord(
       NAME("CO"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,      Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,      Mass,         MY-tag, JPL-tag
           //             |                   |             |       |       |
-          REC("26", .986544E+00, 27.994915, 51, 51, TAGS(28001)),
-          REC("36", 1.10836E-02, 28.998270, 52, 52, TAGS(29001)),
-          REC("28", 1.97822E-03, 29.999161, 53, 53, TAGS(30001)),
-          REC("27", 3.67867E-04, 28.999130, -1, 54, TAGS(29006)),
-          REC("38", 2.22250E-05, 31.002516, -1, 55, TAGS()),
-          REC("37", 4.13292E-06, 30.002485, -1, 56, TAGS()))));
+          REC("26", .986544E+00, 27.994915, 51, TAGS(28001)),
+          REC("36", 1.10836E-02, 28.998270, 52, TAGS(29001)),
+          REC("28", 1.97822E-03, 29.999161, 53, TAGS(30001)),
+          REC("27", 3.67867E-04, 28.999130, -1, TAGS(29006)),
+          REC("38", 2.22250E-05, 31.002516, -1, TAGS()),
+          REC("37", 4.13292E-06, 30.002485, -1, TAGS()))));
 
   // CH4
   // Degrees of freedom: jpl catalogue
@@ -342,75 +334,73 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("CH4"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,       Isotop. Ratio,   Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,       Isotop. Ratio,   Mass,         MY-tag, JPL-tag
           //              |                |             |       |       |
-          REC("211", .988274E+00, 16.031300, -1, 61, TAGS()),
-          // JM: the following version with MADE-UP JPL-TAG(!) is for SWI intercomparison ONLY!
-          //         REC("211"      ,.988274E+00     ,16.031300    ,-1     ,61     ,TAGS(16002)),
-          REC("311", 1.11031E-02, 17.034655, -1, 62, TAGS()),
-          REC("212", 6.15751E-04, 17.037475, -1, 63, TAGS(17003)),
-          REC("312", 6.91785E-06, 18.040830, -1, 64, TAGS()))));
+          REC("211", .988274E+00, 16.031300, -1, TAGS()),
+          REC("311", 1.11031E-02, 17.034655, -1, TAGS()),
+          REC("212", 6.15751E-04, 17.037475, -1, TAGS(17003)),
+          REC("312", 6.91785E-06, 18.040830, -1, TAGS()))));
 
   // O2
   // Isotopologue Ratios: 1 1 1
   species_data.push_back(SpeciesRecord(
       NAME("O2"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, JPL-tag
           //             |                |             |       |       |
-          REC("66", .995262E+00, 31.989830, 71, 71, TAGS(32001, 32002)),
-          REC("68", 3.99141E-03, 33.994076, 72, 72, TAGS(34001)),
-          REC("67", 7.42235E-04, 32.994045, 73, 73, TAGS(33002)),
-          REC("CIAfunCKDMT100", NAN, NAN, -1, -1, TAGS()),
-          REC("v0v0CKDMT100", NAN, NAN, -1, -1, TAGS()),
-          REC("v1v0CKDMT100", NAN, NAN, -1, -1, TAGS()),
-          REC("visCKDMT252", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContStandardType", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContMPM93", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContPWR93", NAN, NAN, -1, -1, TAGS()),
-          REC("PWR98", NAN, NAN, -1, -1, TAGS()),
-          REC("PWR93", NAN, NAN, -1, -1, TAGS()),
-          REC("PWR88", NAN, NAN, -1, -1, TAGS()),
-          REC("MPM93", NAN, NAN, -1, -1, TAGS()),
-          REC("TRE05", NAN, NAN, -1, -1, TAGS()),
-          REC("MPM92", NAN, NAN, -1, -1, TAGS()),
-          REC("MPM89", NAN, NAN, -1, -1, TAGS()),
-          REC("MPM87", NAN, NAN, -1, -1, TAGS()),
-          REC("MPM85", NAN, NAN, -1, -1, TAGS()),
-          REC("MPM2020", NAN, NAN, -1, -1, TAGS()))));
+          REC("66", .995262E+00, 31.989830, 71, TAGS(32001, 32002)),
+          REC("68", 3.99141E-03, 33.994076, 72, TAGS(34001)),
+          REC("67", 7.42235E-04, 32.994045, 73, TAGS(33002)),
+          REC("CIAfunCKDMT100", NAN, NAN, -1, TAGS()),
+          REC("v0v0CKDMT100", NAN, NAN, -1, TAGS()),
+          REC("v1v0CKDMT100", NAN, NAN, -1, TAGS()),
+          REC("visCKDMT252", NAN, NAN, -1, TAGS()),
+          REC("SelfContStandardType", NAN, NAN, -1, TAGS()),
+          REC("SelfContMPM93", NAN, NAN, -1, TAGS()),
+          REC("SelfContPWR93", NAN, NAN, -1, TAGS()),
+          REC("PWR98", NAN, NAN, -1, TAGS()),
+          REC("PWR93", NAN, NAN, -1, TAGS()),
+          REC("PWR88", NAN, NAN, -1, TAGS()),
+          REC("MPM93", NAN, NAN, -1, TAGS()),
+          REC("TRE05", NAN, NAN, -1, TAGS()),
+          REC("MPM92", NAN, NAN, -1, TAGS()),
+          REC("MPM89", NAN, NAN, -1, TAGS()),
+          REC("MPM87", NAN, NAN, -1, TAGS()),
+          REC("MPM85", NAN, NAN, -1, TAGS()),
+          REC("MPM2020", NAN, NAN, -1, TAGS()))));
 
   // NO
   // Isotopologue Ratios: 1 1 1
   species_data.push_back(SpeciesRecord(
       NAME("NO"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,    Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,    Mass,         MY-tag, JPL-tag
           //             |                 |             |       |       |
-          REC("46", .993974E+00, 29.997989, 81, 81, TAGS(30008)),
-          REC("56", 3.65431E-03, 30.995023, -1, 82, TAGS()),
-          REC("48", 1.99312E-03, 32.002234, -1, 83, TAGS()))));
+          REC("46", .993974E+00, 29.997989, 81, TAGS(30008)),
+          REC("56", 3.65431E-03, 30.995023, -1, TAGS()),
+          REC("48", 1.99312E-03, 32.002234, -1, TAGS()))));
 
   // SO2
   // Isotopologue Ratios: 1 1 2 2
   species_data.push_back(SpeciesRecord(
       NAME("SO2"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, JPL-tag
           //             |                |             |       |       |
-          REC("626", .945678E+00, 63.961901, 91, 91, TAGS(64002, 64005)),
-          REC("646", 4.19503E-02, 65.957695, 92, 92, TAGS(66002)),
-          REC("636", 0.0074989421, 65.00, 93, -1, TAGS(65001)),
-          REC("628", 0.0020417379, 66.00, 94, -1, TAGS(66004)))));
+          REC("626", .945678E+00, 63.961901, 91, TAGS(64002, 64005)),
+          REC("646", 4.19503E-02, 65.957695, 92, TAGS(66002)),
+          REC("636", 0.0074989421, 65.00, 93, TAGS(65001)),
+          REC("628", 0.0020417379, 66.00, 94, TAGS(66004)))));
 
   // NO2
   // Isotopologue Ratios: 1
   species_data.push_back(SpeciesRecord(
       NAME("NO2"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,     Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,     Mass,         MY-tag, JPL-tag
           //             |                  |             |       |       |
-          REC("646", .991616E+00, 45.992904, 101, 101, TAGS(46006)),
-          REC("656", 3.64564E-030, 46.989938, -1, -1, TAGS())
+          REC("646", .991616E+00, 45.992904, 101, TAGS(46006)),
+          REC("656", 3.64564E-030, 46.989938, -1, TAGS())
                    )));
 
   // NH3
@@ -418,71 +408,70 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("NH3"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, JPL-tag
           //             |                |             |       |       |
-          REC("4111", .995872E+00, 17.026549, 111, 111, TAGS(17002, 17004)),
-          REC("5111", 3.66129E-03, 18.023583, 112, 112, TAGS(18002)),
-          REC("4112", 0.00044792294, 18.00, -1, -1, TAGS(18004)))));
+          REC("4111", .995872E+00, 17.026549, 111, TAGS(17002, 17004)),
+          REC("5111", 3.66129E-03, 18.023583, 112, TAGS(18002)),
+          REC("4112", 0.00044792294, 18.00, -1, TAGS(18004)))));
 
   // HNO3
   // Isotopologue Ratios: 1 1
   species_data.push_back(SpeciesRecord(
       NAME("HNO3"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, JPL-tag
           //             |                |             |       |       |
           REC("146",
               .989110E+00,
               62.995644,
               121,
-              121,
               TAGS(63001, 63002, 63003, 63004, 63005, 63006)),
-          REC("156", 3.63600E-03, 63.992680, -1, 122, TAGS()))));
+          REC("156", 3.63600E-03, 63.992680, -1, TAGS()))));
 
   // OH
   // Isotopologue Ratios: 1 1 1
   species_data.push_back(SpeciesRecord(
       NAME("OH"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, JPL-tag
           //             |                |             |       |       |
-          REC("61", .997473E+00, 17.002740, 131, 131, TAGS(17001)),
-          REC("81", 2.00014E-03, 19.006986, 132, 132, TAGS(19001)),
-          REC("62", 1.55371E-04, 18.008915, 133, 133, TAGS(18001)))));
+          REC("61", .997473E+00, 17.002740, 131, TAGS(17001)),
+          REC("81", 2.00014E-03, 19.006986, 132, TAGS(19001)),
+          REC("62", 1.55371E-04, 18.008915, 133, TAGS(18001)))));
 
   // HF
   // Isotopologue Ratios: 1 1
   species_data.push_back(SpeciesRecord(
       NAME("HF"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, JPL-tag
           //             |                |             |       |       |
-          REC("19", .999844E+00, 20.006229, 141, 141, TAGS(20002)),
-          REC("29", 1.55741E-04, 21.012404, -1, 142, TAGS(21002)))));
+          REC("19", .999844E+00, 20.006229, 141, TAGS(20002)),
+          REC("29", 1.55741E-04, 21.012404, -1, TAGS(21002)))));
 
   // HCl
   // Isotopologue Ratios: 1 1 1 1
   species_data.push_back(SpeciesRecord(
       NAME("HCl"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, JPL-tag
           //             |                |             |       |       |
-          REC("15", .757587E+00, 35.976678, 151, 151, TAGS(36001)),
-          REC("17", .242257E+00, 37.973729, 152, 152, TAGS(38001)),
-          REC("25", 1.18005E-04, 36.982853, -1, 153, TAGS(37001)),
-          REC("27", 3.77350E-05, 38.979904, -1, 154, TAGS(39004)))));
+          REC("15", .757587E+00, 35.976678, 151, TAGS(36001)),
+          REC("17", .242257E+00, 37.973729, 152, TAGS(38001)),
+          REC("25", 1.18005E-04, 36.982853, -1, TAGS(37001)),
+          REC("27", 3.77350E-05, 38.979904, -1, TAGS(39004)))));
 
   // HBr
   // Isotopologue Ratios: 1 1 1 1
   species_data.push_back(SpeciesRecord(
       NAME("HBr"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,    Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,    Mass,         MY-tag, JPL-tag
           //             |                 |             |       |       |
-          REC("19", .506781E+00, 79.926160, 161, 161, TAGS(80001)),
-          REC("11", .493063E+00, 81.924115, 162, 162, TAGS(82001)),
-          REC("29", 7.89384E-05, 80.932336, -1, 163, TAGS()),
-          REC("21", 7.68016E-05, 82.930289, -1, 164, TAGS()))));
+          REC("19", .506781E+00, 79.926160, 161, TAGS(80001)),
+          REC("11", .493063E+00, 81.924115, 162, TAGS(82001)),
+          REC("29", 7.89384E-05, 80.932336, -1, TAGS()),
+          REC("21", 7.68016E-05, 82.930289, -1, TAGS()))));
 
   // HI
   // Degrees of freedom: guessed, since it seems to be linear
@@ -494,20 +483,20 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("HI"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, JPL-tag
           //             |                |             |       |       |
-          REC("17", .999844E+00, 127.912297, -1, 171, TAGS()),
-          REC("27", 1.55741E-04, 128.918472, -1, 172, TAGS()))));
+          REC("17", .999844E+00, 127.912297, -1, TAGS()),
+          REC("27", 1.55741E-04, 128.918472, -1, TAGS()))));
 
   // ClO
   // Isotopologue Ratios: 1 1
   species_data.push_back(SpeciesRecord(
       NAME("ClO"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,      Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,      Mass,         MY-tag, JPL-tag
           //             |                   |             |       |       |
-          REC("56", .755908E+00, 50.963768, 181, 181, TAGS(51002, 51003)),
-          REC("76", .241720E+00, 52.960819, 182, 182, TAGS(53002, 53006)))));
+          REC("56", .755908E+00, 50.963768, 181, TAGS(51002, 51003)),
+          REC("76", .241720E+00, 52.960819, 182, TAGS(53002, 53006)))));
 
   // OCS
   // Isotopologue Ratios: 1 1 1 1 1
@@ -522,14 +511,14 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("OCS"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,    Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,    Mass,         MY-tag, JPL-tag
           //             |                 |             |       |       |
-          REC("622", .937395E+00, 59.966986, 191, 191, TAGS(60001)),
-          REC("624", 4.15828E-02, 61.962780, 192, 192, TAGS(62001)),
-          REC("632", 1.05315E-02, 60.970341, 193, 193, TAGS(61001)),
-          REC("623", 7.39908E-03, 60.966371, 194, 194, TAGS()),
-          REC("822", 1.87967E-03, 61.971231, 195, 195, TAGS(62002)),
-          REC("634", 4.67508E-04, 62.966137, -1, -1, TAGS()))));
+          REC("622", .937395E+00, 59.966986, 191, TAGS(60001)),
+          REC("624", 4.15828E-02, 61.962780, 192, TAGS(62001)),
+          REC("632", 1.05315E-02, 60.970341, 193, TAGS(61001)),
+          REC("623", 7.39908E-03, 60.966371, 194, TAGS()),
+          REC("822", 1.87967E-03, 61.971231, 195, TAGS(62002)),
+          REC("634", 4.67508E-04, 62.966137, -1, TAGS()))));
 
   // H2CO
   // Isotopologue Ratios: 1 1 1 3 3
@@ -544,23 +533,23 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("H2CO"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, JPL-tag
           //             |                |             |       |       |
-          REC("1126", .986237E+00, 30.010565, 201, 201, TAGS(30004)),
-          REC("1136", 1.10802E-02, 31.013920, 202, 202, TAGS(31002)),
-          REC("1128", 1.97761E-03, 32.014811, 203, 203, TAGS(32004)),
-          REC("1226", 0.00029578940, 31.00, -1, -1, TAGS(31003)),
-          REC("2226", 2.2181076E-08, 32.00, -1, -1, TAGS(32006)))));
+          REC("1126", .986237E+00, 30.010565, 201, TAGS(30004)),
+          REC("1136", 1.10802E-02, 31.013920, 202, TAGS(31002)),
+          REC("1128", 1.97761E-03, 32.014811, 203, TAGS(32004)),
+          REC("1226", 0.00029578940, 31.00, -1, TAGS(31003)),
+          REC("2226", 2.2181076E-08, 32.00, -1, TAGS(32006)))));
 
   // HOCl
   // Isotopologue Ratios: 1 1
   species_data.push_back(SpeciesRecord(
       NAME("HOCl"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,      Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,      Mass,         MY-tag, JPL-tag
           //             |                   |             |       |       |
-          REC("165", .755790E+00, 51.971593, 211, 211, TAGS(52006)),
-          REC("167", .241683E+00, 53.968644, 212, 212, TAGS(54005)))));
+          REC("165", .755790E+00, 51.971593, 211, TAGS(52006)),
+          REC("167", .241683E+00, 53.968644, 212, TAGS(54005)))));
 
   // N2
   // Degrees of freedom: guessed, since it seems to be linear
@@ -571,50 +560,50 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("N2"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,   Mass,         MY-tag, JPL-tag
           //             |                |             |       |       |
-          REC("44", .992687E+00, 28.006148, -1, 221, TAGS()),
-          REC("45", 7.47809E-03, 29.003182, -1, 222, TAGS()),
-          REC("SelfContMPM93", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContPWR93", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContStandardType", NAN, NAN, -1, -1, TAGS()),
-          REC("SelfContBorysow", NAN, NAN, -1, -1, TAGS()),
-          REC("CIArotCKDMT100", NAN, NAN, -1, -1, TAGS()),
-          REC("CIAfunCKDMT100", NAN, NAN, -1, -1, TAGS()),
-          REC("CIArotCKDMT252", NAN, NAN, -1, -1, TAGS()),
-          REC("CIAfunCKDMT252", NAN, NAN, -1, -1, TAGS()),
-          REC("DryContATM01", NAN, NAN, -1, -1, TAGS()))));
+          REC("44", .992687E+00, 28.006148, -1, TAGS()),
+          REC("45", 7.47809E-03, 29.003182, -1, TAGS()),
+          REC("SelfContMPM93", NAN, NAN, -1, TAGS()),
+          REC("SelfContPWR93", NAN, NAN, -1, TAGS()),
+          REC("SelfContStandardType", NAN, NAN, -1, TAGS()),
+          REC("SelfContBorysow", NAN, NAN, -1, TAGS()),
+          REC("CIArotCKDMT100", NAN, NAN, -1, TAGS()),
+          REC("CIAfunCKDMT100", NAN, NAN, -1, TAGS()),
+          REC("CIArotCKDMT252", NAN, NAN, -1, TAGS()),
+          REC("CIAfunCKDMT252", NAN, NAN, -1, TAGS()),
+          REC("DryContATM01", NAN, NAN, -1, TAGS()))));
 
   // HCN
   // Isotopologue Ratios: 1 1 1 3
   species_data.push_back(SpeciesRecord(
       NAME("HCN"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,     Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,     Mass,         MY-tag, JPL-tag
           //             |                  |             |       |       |
-          REC("124", .985114E+00, 27.010899, 231, 231, TAGS(27001, 27003)),
-          REC("134", 1.10676E-02, 28.014254, 232, 232, TAGS(28002)),
-          REC("125", 3.62174E-03, 28.007933, 233, 233, TAGS(28003)),
-          REC("224", 0.00014773545, 28.00, -1, -1, TAGS(28004)))));
+          REC("124", .985114E+00, 27.010899, 231, TAGS(27001, 27003)),
+          REC("134", 1.10676E-02, 28.014254, 232, TAGS(28002)),
+          REC("125", 3.62174E-03, 28.007933, 233, TAGS(28003)),
+          REC("224", 0.00014773545, 28.00, -1, TAGS(28004)))));
 
   // CH3Cl
   // Isotopologue Ratios: 1 1
   species_data.push_back(SpeciesRecord(
       NAME("CH3Cl"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,     Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,     Mass,         MY-tag, JPL-tag
           //             |                  |             |       |       |
-          REC("215", .748937E+00, 49.992328, 241, 241, TAGS(50007)),
-          REC("217", .239491E+00, 51.989379, 242, 242, TAGS(52009)))));
+          REC("215", .748937E+00, 49.992328, 241, TAGS(50007)),
+          REC("217", .239491E+00, 51.989379, 242, TAGS(52009)))));
 
   // H2O2
   // Isotopologue Ratios: 1
   species_data.push_back(SpeciesRecord(
       NAME("H2O2"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,      Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,      Mass,         MY-tag, JPL-tag
           //             |                   |             |       |       |
-          REC("1661", .994952E+00, 34.005480, 251, 251, TAGS(34004)))));
+          REC("1661", .994952E+00, 34.005480, 251, TAGS(34004)))));
 
   // C2H2
   // Degrees of freedom: guessed, since it seems to be non linear
@@ -625,11 +614,11 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("C2H2"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,      Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,      Mass,         MY-tag, JPL-tag
           //             |                   |             |       |       |
-          REC("1221", .977599E+00, 26.015650, -1, 261, TAGS()),
-          REC("1231", 2.19663E-02, 27.019005, -1, 262, TAGS()),
-          REC("1222", 3.04550E-04, 27.021825, -1, 263, TAGS()))));
+          REC("1221", .977599E+00, 26.015650, -1, TAGS()),
+          REC("1231", 2.19663E-02, 27.019005, -1, TAGS()),
+          REC("1222", 3.04550E-04, 27.021825, -1, TAGS()))));
 
   // C2H6
   // Degrees of freedom: guessed, since it seems to be non linear
@@ -640,29 +629,29 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("C2H6"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("1221", .976990E+00, 30.046950, -1, 271, TAGS()),
-          REC("1231", 2.19526E-02, 31.050305, -1, 272, TAGS()))));
+          REC("1221", .976990E+00, 30.046950, -1, TAGS()),
+          REC("1231", 2.19526E-02, 31.050305, -1, TAGS()))));
 
   // PH3
   // Isotopologue Ratios: 1
   species_data.push_back(SpeciesRecord(
       NAME("PH3"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("1111", .999533E+00, 33.997238, 281, 281, TAGS(34003)))));
+          REC("1111", .999533E+00, 33.997238, 281, TAGS(34003)))));
 
   // COF2
   // Isotopologue Ratios: 1 1
   species_data.push_back(SpeciesRecord(
       NAME("COF2"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("269", .986544E+00, 65.991722, 291, 291, TAGS(66001)),
-          REC("369", 1.10834E-02, 66.995083, -1, 292, TAGS()))));
+          REC("269", .986544E+00, 65.991722, 291, TAGS(66001)),
+          REC("369", 1.10834E-02, 66.995083, -1, TAGS()))));
 
   // SF6
   // Degrees of freedom: guessed, since it seems to be non linear
@@ -673,27 +662,27 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("SF6"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("29", .950180E+00, 145.962492, -1, 301, TAGS()))));
+          REC("29", .950180E+00, 145.962492, -1, TAGS()))));
 
   // H2S
   // Isotopologue Ratios: 1 1 1 2
   species_data.push_back(SpeciesRecord(
       NAME("H2S"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("121", .949884E+00, 33.987721, 311, 311, TAGS(34002)),
+          REC("121", .949884E+00, 33.987721, 311, TAGS(34002)),
           // A. Perrin found, HITRAN isotopologue assignments are wrong (inconsistent
           // between molparams.txt and the line parameter files *.par. This dates back to
           // at least HITRAN1996, so it seems safe to just swap around the HITRAN tags
           // here.
           //         REC("141"      ,4.21369E-02        ,35.983515    ,-1     ,312    ,TAGS( )),
           //         REC("131"      ,7.49766E-03        ,34.987105    ,-1     ,313    ,TAGS( )),
-          REC("141", 4.21369E-02, 35.983515, -1, 313, TAGS()),
-          REC("131", 7.49766E-03, 34.987105, -1, 312, TAGS()),
-          REC("122", 0.00029991625, 35.00, -1, -1, TAGS(35001)))));
+          REC("141", 4.21369E-02, 35.983515, -1, TAGS()),
+          REC("131", 7.49766E-03, 34.987105, -1, TAGS()),
+          REC("122", 0.00029991625, 35.00, -1, TAGS(35001)))));
 
   // HCOOH
   // Isotopologue Ratios: 1 3 3 3
@@ -707,30 +696,30 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("HCOOH"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("1261", .983898E+00, 46.005480, 321, 321, TAGS(46005)),
-          REC("1361", 0.010913149, 47.00, -1, -1, TAGS(47002)),
-          REC("2261", 0.00014755369, 47.00, -1, -1, TAGS(47003)),
-          REC("1262", 0.00014755369, 47.00, -1, -1, TAGS(47004)))));
+          REC("1261", .983898E+00, 46.005480, 321, TAGS(46005)),
+          REC("1361", 0.010913149, 47.00, -1, TAGS(47002)),
+          REC("2261", 0.00014755369, 47.00, -1, TAGS(47003)),
+          REC("1262", 0.00014755369, 47.00, -1, TAGS(47004)))));
 
   // HO2
   // Isotopologue Ratios: 1
   species_data.push_back(SpeciesRecord(
       NAME("HO2"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("166", .995107E+00, 32.997655, 331, 331, TAGS(33001)))));
+          REC("166", .995107E+00, 32.997655, 331, TAGS(33001)))));
 
   // O
   // Isotopologue Ratios: 1
   species_data.push_back(SpeciesRecord(
       NAME("O"),
       DEGFR(0),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("6", .997628E+00, 15.994915, 341, 341, TAGS(16001)))));
+          REC("6", .997628E+00, 15.994915, 341, TAGS(16001)))));
 
   // ClONO2
   // Isotopologue Ratios: 1 1
@@ -738,10 +727,10 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("ClONO2"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("5646", .749570E+00, 96.956672, 351, 351, TAGS(97002)),
-          REC("7646", .239694E+00, 98.953723, 352, 352, TAGS(99001)))));
+          REC("5646", .749570E+00, 96.956672, 351, TAGS(97002)),
+          REC("7646", .239694E+00, 98.953723, 352, TAGS(99001)))));
 
   // NO+
   // Degrees of freedom: guessed, since it seems to be linear
@@ -752,38 +741,38 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("NO+"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("46", .993974E+00, 29.997989, -1, 361, TAGS(30011)))));
+          REC("46", .993974E+00, 29.997989, -1, TAGS(30011)))));
 
   // OClO
   // Isotopologue Ratios: 2 2
   species_data.push_back(SpeciesRecord(
       NAME("OClO"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,     MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,     MY-tag, JPL-tag
           //             |                    |         |       |       |
-          REC("656", 0.75509223, 67.00, 431, -1, TAGS(67001)),
-          REC("676", 0.24490632, 69.00, 432, -1, TAGS(69001)))));
+          REC("656", 0.75509223, 67.00, 431, TAGS(67001)),
+          REC("676", 0.24490632, 69.00, 432, TAGS(69001)))));
 
   // BrO
   // Isotopologue Ratios: 2 2
   species_data.push_back(SpeciesRecord(
       NAME("BrO"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,     MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,     MY-tag, JPL-tag
           //             |                    |         |       |       |
-          REC("96", 0.50582466, 95.00, 401, -1, TAGS(95001)),
-          REC("16", 0.49431069, 97.00, 402, -1, TAGS(97001)))));
+          REC("96", 0.50582466, 95.00, 401, TAGS(95001)),
+          REC("16", 0.49431069, 97.00, 402, TAGS(97001)))));
 
   // H2SO4
   // Isotopologue Ratios: 2
   species_data.push_back(SpeciesRecord(
       NAME("H2SO4"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,     MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,     MY-tag, JPL-tag
           //             |                    |         |       |       |
-          REC("126", 0.95060479, 98.00, 481, -1, TAGS(98001)))));
+          REC("126", 0.95060479, 98.00, 481, TAGS(98001)))));
 
   // Cl2O2
   // Isotopologue Ratios: 2 2
@@ -791,10 +780,10 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("Cl2O2"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,     MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,     MY-tag, JPL-tag
           //             |                    |         |       |       |
-          REC("565", 0.57016427, 102.00, 491, -1, TAGS(102001)),
-          REC("765", 0.36982818, 104.00, 492, -1, TAGS(104001)))));
+          REC("565", 0.57016427, 102.00, 491, TAGS(102001)),
+          REC("765", 0.36982818, 104.00, 492, TAGS(104001)))));
 
   // HOBr
   // Isotopologue Ratios: 1 1
@@ -802,10 +791,10 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("HOBr"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("169", .505579E+00, 95.921076, 371, 371, TAGS(96001)),
-          REC("161", .491894E+00, 97.919027, 372, 372, TAGS(98002)))));
+          REC("169", .505579E+00, 95.921076, 371, TAGS(96001)),
+          REC("161", .491894E+00, 97.919027, 372, TAGS(98002)))));
 
   // C2H4
   // Isotopologue Ratios: 1 1
@@ -813,10 +802,10 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("C2H4"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("221", .977294E+00, 28.031300, -1, 381, TAGS()),
-          REC("231", .219595E-01, 29.034655, -1, 382, TAGS()))));
+          REC("221", .977294E+00, 28.031300, -1, TAGS()),
+          REC("231", .219595E-01, 29.034655, -1, TAGS()))));
 
   // CH3OH
   // Isotopologue Ratios: 1
@@ -824,9 +813,9 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("CH3OH"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("2161", .985930E+00, 32.026215, -1, 391, TAGS(32003))
+          REC("2161", .985930E+00, 32.026215, -1, TAGS(32003))
           //         REC("2261"     ,1.0?               ,33.00        ,-1     ,-1     ,TAGS(33004)) //in JPL this is seems to be taken as separate species (IsoCorr=0)
           )));
 
@@ -836,10 +825,10 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("CH3Br"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("219", .500995E+00, 93.941811, -1, 401, TAGS()),
-          REC("211", .487433E+00, 95.939764, -1, 402, TAGS()))));
+          REC("219", .500995E+00, 93.941811, -1, TAGS()),
+          REC("211", .487433E+00, 95.939764, -1, TAGS()))));
 
   // CH3CN
   // Isotopologue Ratios: 1 3 3 3 3
@@ -855,13 +844,13 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("CH3CN"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("211124", .973866E+00, 41.026549, -1, 411, TAGS(41001, 41010)),
-          REC("311124", .102683e-01, 42.00, -1, -1, TAGS(42006)),
-          REC("211134", .102683e-01, 42.00, -1, -1, TAGS(42007)),
-          REC("211125", .347136e-02, 42.00, -1, -1, TAGS(42001)),
-          REC("211224", .441185e-03, 42.00, -1, -1, TAGS(42008)))));
+          REC("211124", .973866E+00, 41.026549, -1, TAGS(41001, 41010)),
+          REC("311124", .102683e-01, 42.00, -1, TAGS(42006)),
+          REC("211134", .102683e-01, 42.00, -1, TAGS(42007)),
+          REC("211125", .347136e-02, 42.00, -1, TAGS(42001)),
+          REC("211224", .441185e-03, 42.00, -1, TAGS(42008)))));
 
   // CF4
   // Isotopologue Ratios: 1
@@ -869,9 +858,9 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("CF4"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("29", .988890E+00, 87.993616, -1, 421, TAGS()))));
+          REC("29", .988890E+00, 87.993616, -1, TAGS()))));
 
   // HC3N
   // Isotopologue Ratios: 1 3 3 3 3 3
@@ -891,14 +880,14 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("HC3N"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("12224", .963346E+00, 51.010899, -1, 441, TAGS(51001)),
-          REC("12234", .106852e-01, 52.00, -1, -1, TAGS(52001)),
-          REC("12324", .106852e-01, 52.00, -1, -1, TAGS(52002)),
-          REC("13224", .106852e-01, 52.00, -1, -1, TAGS(52003)),
-          REC("12225", .356272e-02, 52.00, -1, -1, TAGS(52004)),
-          REC("22224", .144472e-03, 52.00, -1, -1, TAGS(52005)))));
+          REC("12224", .963346E+00, 51.010899, -1, TAGS(51001)),
+          REC("12234", .106852e-01, 52.00, -1, TAGS(52001)),
+          REC("12324", .106852e-01, 52.00, -1, TAGS(52002)),
+          REC("13224", .106852e-01, 52.00, -1, TAGS(52003)),
+          REC("12225", .356272e-02, 52.00, -1, TAGS(52004)),
+          REC("22224", .144472e-03, 52.00, -1, TAGS(52005)))));
 
   // CS
   // Isotopologue Ratios: 1 1 1 1
@@ -906,24 +895,24 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("CS"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("22", .939624E+00, 43.971036, -1, 461, TAGS(44001)),
-          REC("24", .416817E-01, 45.966787, -1, 462, TAGS(46001)),
-          REC("32", .105565E-01, 44.974368, -1, 463, TAGS(45001)),
-          REC("23", .741668E-02, 44.970399, -1, 464, TAGS()))));
+          REC("22", .939624E+00, 43.971036, -1, TAGS(44001)),
+          REC("24", .416817E-01, 45.966787, -1, TAGS(46001)),
+          REC("32", .105565E-01, 44.974368, -1, TAGS(45001)),
+          REC("23", .741668E-02, 44.970399, -1, TAGS()))));
 
   // HNC
   // Isotopologue Ratios: 3 3 3 3
   species_data.push_back(SpeciesRecord(
       NAME("HNC"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("142", .985280e+00, 27.00, -1, -1, TAGS(27002, 27003)),
-          REC("143", .109285e-01, 28.00, -1, -1, TAGS(28005)),
-          REC("152", .364384e-02, 28.00, -1, -1, TAGS(28006)),
-          REC("242", .147761e-03, 28.00, -1, -1, TAGS(28007)))));
+          REC("142", .985280e+00, 27.00, -1, TAGS(27002, 27003)),
+          REC("143", .109285e-01, 28.00, -1, TAGS(28005)),
+          REC("152", .364384e-02, 28.00, -1, TAGS(28006)),
+          REC("242", .147761e-03, 28.00, -1, TAGS(28007)))));
 
   // SO
   // Isotopologue Ratios: 2 2 2
@@ -931,11 +920,11 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("SO"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("26", .950605e+00, 48.00, -1, -1, TAGS(48001, 48002)),
-          REC("46", .420727e-01, 50.00, -1, -1, TAGS(50001)),
-          REC("28", .194089e-02, 50.00, -1, -1, TAGS(50002)))));
+          REC("26", .950605e+00, 48.00, -1, TAGS(48001, 48002)),
+          REC("46", .420727e-01, 50.00, -1, TAGS(50001)),
+          REC("28", .194089e-02, 50.00, -1, TAGS(50002)))));
 
   // C3H8
   // Isotopologue Ratios: 4
@@ -943,9 +932,9 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("C3H8"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("21", 9.66290e-01, 44.00, -1, -1, TAGS(44013)))));
+          REC("21", 9.66290e-01, 44.00, -1, TAGS(44013)))));
 
   // H2
   // Isotopologue Ratios: 1 1 4
@@ -956,10 +945,10 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("H2"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("11", .999688E+00, 2.0156500, -1, 451, TAGS()),
-          REC("12", 3.11432E-04, 3.0218250, -1, 452, TAGS(3001))
+          REC("11", .999688E+00, 2.0156500, -1, TAGS()),
+          REC("12", 3.11432E-04, 3.0218250, -1, TAGS(3001))
           //         REC("22"       ,.224838e-07        ,4.00         ,-1     ,-1     ,TAGS())
           )));
 
@@ -972,9 +961,9 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("H"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("1", 1.00, 1.00, -1, -1, TAGS()))));
+          REC("1", 1.00, 1.00, -1, TAGS()))));
 
   // He
   // Isotopologue Ratios: 0
@@ -985,9 +974,9 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("He"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("4", 1.00, 4.00, -1, -1, TAGS()))));
+          REC("4", 1.00, 4.00, -1, TAGS()))));
 
   // Ar
   // Isotopologue Ratios: 0
@@ -998,9 +987,9 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("Ar"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("8", 1.00, 18.00, -1, -1, TAGS()))));
+          REC("8", 1.00, 18.00, -1, TAGS()))));
 
   // C4H2
   // Isotopologue Ratios: 1
@@ -1008,9 +997,9 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("C4H2"),
       DEGFR(2),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("2211", .955998E+00, 50.015650, -1, 431, TAGS()))));
+          REC("2211", .955998E+00, 50.015650, -1, TAGS()))));
 
   // SO3
   // Isotopologue Ratios: 1
@@ -1018,62 +1007,62 @@ void define_basic_species_data() {
   species_data.push_back(SpeciesRecord(
       NAME("SO3"),
       DEGFR(3),
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("26", .943400E+00, 79.956820, -1, 471, TAGS()))));
+          REC("26", .943400E+00, 79.956820, -1, TAGS()))));
 
   // CS2
   species_data.push_back(SpeciesRecord(
       NAME("CS2"),
       DEGFR(3),  // FIXME: not checked
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("222", 8.92811E-01, 75.944140, -1, -1, TAGS()),
-          REC("224", 7.92600E-02, 77.939940, -1, -1, TAGS()),
-          REC("223", 1.40940E-02, 76.943256, -1, -1, TAGS()),
-          REC("232", 1.03100E-02, 76.947495, -1, -1, TAGS()),
+          REC("222", 8.92811E-01, 75.944140, -1, TAGS()),
+          REC("224", 7.92600E-02, 77.939940, -1, TAGS()),
+          REC("223", 1.40940E-02, 76.943256, -1, TAGS()),
+          REC("232", 1.03100E-02, 76.947495, -1, TAGS()),
       )));
 
   // C2N2
   species_data.push_back(SpeciesRecord(
     NAME("C2N2"),
       DEGFR(3), // FIXME: not checked
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("4224", 9.70752E-01, 52.006148 , -1, -1, TAGS())
+          REC("4224", 9.70752E-01, 52.006148 , -1, TAGS())
       )));
 
   // COCl2
   species_data.push_back(SpeciesRecord(
     NAME("COCl2"),
       DEGFR(3), // FIXME: not checked
-      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("2655", 5.66392E-01, 97.932620 , -1, -1, TAGS()),
-          REC("2657", 5.66392E-01, 97.932620 , -1, -1, TAGS())
+          REC("2655", 5.66392E-01, 97.932620 , -1, TAGS()),
+          REC("2657", 5.66392E-01, 97.932620 , -1, TAGS())
       )));
 
   species_data.push_back(SpeciesRecord(
       NAME("liquidcloud"),
       DEGFR(0),
-      ISOTOPOLOGUES(  //   Name,     Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //   Name,     Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("MPM93", NAN, NAN, -1, -1, TAGS()),
-          REC("ELL07", NAN, NAN, -1, -1, TAGS()))));
+          REC("MPM93", NAN, NAN, -1, TAGS()),
+          REC("ELL07", NAN, NAN, -1, TAGS()))));
 
   species_data.push_back(SpeciesRecord(
       NAME("icecloud"),
       DEGFR(0),
-      ISOTOPOLOGUES(  //   Name,     Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //   Name,     Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("MPM93", NAN, NAN, -1, -1, TAGS()))));
+          REC("MPM93", NAN, NAN, -1, TAGS()))));
 
   species_data.push_back(SpeciesRecord(
       NAME("rain"),
       DEGFR(0),
-      ISOTOPOLOGUES(  //   Name,     Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+      ISOTOPOLOGUES(  //   Name,     Isotop. Ratio,       Mass,         MY-tag, JPL-tag
           //             |                    |             |       |       |
-          REC("MPM93", NAN, NAN, -1, -1, TAGS()))));
+          REC("MPM93", NAN, NAN, -1, TAGS()))));
 
   species_data.push_back(
       SpeciesRecord(NAME("free_electrons"), DEGFR(0), ISOTOPOLOGUES()));

--- a/src/species_data.cc
+++ b/src/species_data.cc
@@ -278,6 +278,7 @@ void define_basic_species_data() {
           REC("838", 4.44600E-08, 49.001675, -1, 20, TAGS()),
 #endif
           REC("837", 1.65354E-08, 48.001646, -1, -1, TAGS()),
+          REC("737", 1.537500E-08, 47.0016182378, -1, -1, TAGS()),
           REC("CKD241", NAN, NAN, -1, -1, TAGS()),
           REC("CKDMT100", NAN, NAN, -1, -1, TAGS()),
           REC("CKDMT252", NAN, NAN, -1, -1, TAGS()),
@@ -408,7 +409,9 @@ void define_basic_species_data() {
       DEGFR(3),
       ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,     Mass,         MY-tag, HI-tag, JPL-tag
           //             |                  |             |       |       |
-          REC("646", .991616E+00, 45.992904, 101, 101, TAGS(46006)))));
+          REC("646", .991616E+00, 45.992904, 101, 101, TAGS(46006)),
+          REC("656", 3.64564E-030, 46.989938, -1, -1, TAGS())
+                   )));
 
   // NH3
   // Isotopologue Ratios: 1 1 3
@@ -525,7 +528,8 @@ void define_basic_species_data() {
           REC("624", 4.15828E-02, 61.962780, 192, 192, TAGS(62001)),
           REC("632", 1.05315E-02, 60.970341, 193, 193, TAGS(61001)),
           REC("623", 7.39908E-03, 60.966371, 194, 194, TAGS()),
-          REC("822", 1.87967E-03, 61.971231, 195, 195, TAGS(62002)))));
+          REC("822", 1.87967E-03, 61.971231, 195, 195, TAGS(62002)),
+          REC("634", 4.67508E-04, 62.966137, -1, -1, TAGS()))));
 
   // H2CO
   // Isotopologue Ratios: 1 1 1 3 3
@@ -1017,6 +1021,37 @@ void define_basic_species_data() {
       ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
           //             |                    |             |       |       |
           REC("26", .943400E+00, 79.956820, -1, 471, TAGS()))));
+
+  // CS2
+  species_data.push_back(SpeciesRecord(
+      NAME("CS2"),
+      DEGFR(3),  // FIXME: not checked
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+          //             |                    |             |       |       |
+          REC("222", 8.92811E-01, 75.944140, -1, -1, TAGS()),
+          REC("224", 7.92600E-02, 77.939940, -1, -1, TAGS()),
+          REC("223", 1.40940E-02, 76.943256, -1, -1, TAGS()),
+          REC("232", 1.03100E-02, 76.947495, -1, -1, TAGS()),
+      )));
+
+  // C2N2
+  species_data.push_back(SpeciesRecord(
+    NAME("C2N2"),
+      DEGFR(3), // FIXME: not checked
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+          //             |                    |             |       |       |
+          REC("4224", 9.70752E-01, 52.006148 , -1, -1, TAGS())
+      )));
+
+  // COCl2
+  species_data.push_back(SpeciesRecord(
+    NAME("COCl2"),
+      DEGFR(3), // FIXME: not checked
+      ISOTOPOLOGUES(  //  Name,      Isotop. Ratio,       Mass,         MY-tag, HI-tag, JPL-tag
+          //             |                    |             |       |       |
+          REC("2655", 5.66392E-01, 97.932620 , -1, -1, TAGS()),
+          REC("2657", 5.66392E-01, 97.932620 , -1, -1, TAGS())
+      )));
 
   species_data.push_back(SpeciesRecord(
       NAME("liquidcloud"),

--- a/src/test_hitran.cc
+++ b/src/test_hitran.cc
@@ -1,0 +1,24 @@
+#include <array>
+#include "hitran_species.h"
+
+void test001() {
+  define_species_data();
+  define_species_map();
+  
+  const Index nmols = 100;
+  std::array<char, 12> isos = {'1', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'A', 'B'};
+  
+  for (Index mol = 0; mol < nmols; mol++) {
+    for (char iso : isos) {
+      try {
+        Hitran::from_lookup(mol, iso);
+      } catch(std::runtime_error& e) {
+        std::cout << e.what() << "\n\n";
+      }
+    }
+  }
+}
+
+int main() {
+  test001();
+}

--- a/src/xml_io_compound_types.cc
+++ b/src/xml_io_compound_types.cc
@@ -1038,7 +1038,6 @@ void xml_read_from_stream(istream& is_xml,
   Numeric abundance;
   Numeric mass;
   Index mytrantag;
-  Index hitrantag;
   ArrayOfIndex jpltags;
 
   tag.read_from_stream(is_xml);
@@ -1048,14 +1047,13 @@ void xml_read_from_stream(istream& is_xml,
   xml_read_from_stream(is_xml, abundance, pbifs, verbosity);
   xml_read_from_stream(is_xml, mass, pbifs, verbosity);
   xml_read_from_stream(is_xml, mytrantag, pbifs, verbosity);
-  xml_read_from_stream(is_xml, hitrantag, pbifs, verbosity);
   xml_read_from_stream(is_xml, jpltags, pbifs, verbosity);
 
   tag.read_from_stream(is_xml);
   tag.check_name("/IsotopologueRecord");
 
   irecord =
-      IsotopologueRecord(name, abundance, mass, mytrantag, hitrantag, jpltags);
+      IsotopologueRecord(name, abundance, mass, mytrantag, jpltags);
 }
 
 //! Writes IsotopologueRecord to XML output stream
@@ -1084,8 +1082,6 @@ void xml_write_to_stream(ostream& os_xml,
   xml_write_to_stream(os_xml, irecord.Mass(), pbofs, "Mass", verbosity);
   xml_write_to_stream(
       os_xml, irecord.MytranTag(), pbofs, "MytranTag", verbosity);
-  xml_write_to_stream(
-      os_xml, irecord.HitranTag(), pbofs, "HitranTag", verbosity);
   xml_write_to_stream(os_xml, irecord.JplTags(), pbofs, "JplTags", verbosity);
 
   close_tag.set_name("/IsotopologueRecord");


### PR DESCRIPTION
default for the pressure shift.  Also update lblrtm to do the same

Doing this I ran the reading routine on a newly downloaded version
of the data and noticed that the old version hid errors in the
reading routine.  I had to add several new species to fix this but
I really don't understand where the name of these species goes into
the weird static array of the old reading routines, so I had to make
a new function from hitran's molparam.txt that adds the new species

Note that the code makes use of several static variables.  If this is undesirable, then the statics can be removed from the "hitran_species.cc" file.  I don't know if it actually makes things faster to just declare these once but the old code used static tables so it should be fine to do the same here.