### PR TITLE
Remove no longer existing types from docs

### DIFF
--- a/python/doc/source/pyarts_datatypes.rst
+++ b/python/doc/source/pyarts_datatypes.rst
@@ -10,16 +10,7 @@ pyarts.catalogues
 .. autosummary::
    :toctree: generated
 
-   ArrayOfLineRecord
-   CIARecord
-   GasAbsLookup
-   LineMixingRecord
-   QuantumIdentifier
-   QuantumNumberRecord
-   QuantumNumbers
    Sparse
-   SpeciesAuxData
-   SpeciesTag
 
 pyarts.covariancematrix
 =======================
@@ -53,34 +44,6 @@ pyarts.griddedfield
    griddedfield_from_netcdf
    griddedfield_from_xarray
 
-pyarts.internals
-================
-
-.. automodule:: pyarts.internals
-
-.. currentmodule:: pyarts.internals
-
-.. autosummary::
-   :toctree: generated
-
-   LineMixing
-   ARTSCAT5
-   Rational
-   PartitionFunctions
-   PressureBroadening
-
-pyarts.retrieval
-================
-
-.. automodule:: pyarts.retrieval
-
-.. currentmodule:: pyarts.retrieval
-
-.. autosummary::
-   :toctree: generated
-
-   RetrievalQuantity
-
 pyarts.scattering
 =================
 
@@ -108,15 +71,3 @@ pyarts.sensor
    get_f_backend_rel_width
    get_f_backend_const_width
 
-
-pyarts.xsec
-===========
-
-.. automodule:: pyarts.xsec
-
-.. currentmodule:: pyarts.xsec
-
-.. autosummary::
-   :toctree: generated
-
-   XsecRecord


### PR DESCRIPTION
Python implementations of several datatypes where removed and are now covered in `pyarts/classes`. Dead references to those from the datatypes rst file have been removed.