### PR TITLE
Faster LBL derivatives?

### DIFF
--- a/src/absorption.cc
+++ b/src/absorption.cc
@@ -679,7 +679,7 @@ void xsec_species(Matrix& xsec,
       // absorption cross-section
       MapToEigen(xsec).col(ip).noalias() += sum.F.real();
       for (Index j = 0; j < nj; j++) {
-        if (not propmattype(jacobian_quantities[j])) continue;
+        if (not jacobian_quantities[j].propmattype()) continue;
         MapToEigen(dxsec_dx[j]).col(ip).noalias() += sum.dF.col(j).real();
       }
 
@@ -687,7 +687,7 @@ void xsec_species(Matrix& xsec,
       if (not phase.empty()) {
         MapToEigen(phase).col(ip).noalias() += sum.F.imag();
         for (Index j = 0; j < nj; j++) {
-          if (not propmattype(jacobian_quantities[j])) continue;
+          if (not jacobian_quantities[j].propmattype()) continue;
           MapToEigen(dphase_dx[j]).col(ip).noalias() += sum.dF.col(j).imag();
         }
       }
@@ -696,7 +696,7 @@ void xsec_species(Matrix& xsec,
       if (do_nonlte) {
         MapToEigen(source).col(ip).noalias() += sum.N.real();
         for (Index j = 0; j < nj; j++) {
-          if (not propmattype(jacobian_quantities[j])) continue;
+          if (not jacobian_quantities[j].propmattype()) continue;
           MapToEigen(dsource_dx[j]).col(ip).noalias() += sum.dN.col(j).real();
         }
       }

--- a/src/jacobian.cc
+++ b/src/jacobian.cc
@@ -999,27 +999,12 @@ void dxdvmrscf(Numeric& x,
 //             Propmat partials descriptions
 //======================================================================
 
-bool propmattype(const RetrievalQuantity& rt) noexcept {
-  return rt == Jacobian::Type::Line or
-         rt == Jacobian::Type::Atm or
-         rt.Target() == Jacobian::Special::ArrayOfSpeciesTagVMR
-         ;
-}
-
-bool is_wind_parameter(const RetrievalQuantity& t) noexcept {
-  return t.Target().isWind();
-}
-
 bool is_frequency_parameter(const RetrievalQuantity& t) noexcept {
   return t.Target().isWind() or t.Target().isFrequency();
 }
 
 bool is_derived_magnetic_parameter(const RetrievalQuantity& t) noexcept {
   return t == Jacobian::Atm::MagneticMagnitude;
-}
-
-bool is_magnetic_parameter(const RetrievalQuantity& t) noexcept {
-  return t.Target().isMagnetic();
 }
 
 bool is_nlte_parameter(const RetrievalQuantity& t) noexcept {
@@ -1188,7 +1173,7 @@ bool do_frequency_jacobian(const ArrayOfRetrievalQuantity& js) noexcept {
 }
 
 bool do_magnetic_jacobian(const ArrayOfRetrievalQuantity& js) noexcept {
-  return std::any_of(js.cbegin(), js.cend(), [](auto& j){return is_magnetic_parameter(j);});
+  return std::any_of(js.cbegin(), js.cend(), [](auto& j){return j.is_mag();});
 }
 
 Numeric temperature_perturbation(const ArrayOfRetrievalQuantity& js) noexcept {
@@ -1208,7 +1193,7 @@ Numeric frequency_perturbation(const ArrayOfRetrievalQuantity& js) noexcept {
 }
 
 Numeric magnetic_field_perturbation(const ArrayOfRetrievalQuantity& js) noexcept {
-  auto p = std::find_if(js.cbegin(), js.cend(), [](auto& j){return is_magnetic_parameter(j);});
+  auto p = std::find_if(js.cbegin(), js.cend(), [](auto& j){return j.is_mag();});
   if (p not_eq js.cend())
     return p -> Target().Perturbation();
   else

--- a/src/jacobian.h
+++ b/src/jacobian.h
@@ -520,7 +520,18 @@ class RetrievalQuantity {
    * @param[in] qi The identity of this Jacobian
    */
   void QuantumIdentity(const QuantumIdentifier& qi) { mjac.QuantumIdentity() = qi; }
-
+  
+  /** Returns if this is a propagation matrix type */
+  bool propmattype() const noexcept {
+    return mjac == Jacobian::Type::Line or 
+           mjac == Jacobian::Type::Atm or 
+           mjac == Jacobian::Special::ArrayOfSpeciesTagVMR;
+  }
+  
+  bool is_wind() const noexcept {return mjac.isWind();}
+  
+  bool is_mag() const noexcept {return mjac.isMagnetic();}
+  
   /** Transformation
    * 
    * FIXMEDOC@Simon The transformations are yours to fix and document
@@ -991,13 +1002,6 @@ void dxdvmrscf(Numeric& x,
 //             Propmat partials descriptions
 //======================================================================
 
-/** Returns if the indexed value is a propagation matrix value
- * 
- * @param[in] rt A retrieval quantitiy
- * @return true if rt can be used in propmat calculations
- */
-bool propmattype(const RetrievalQuantity& rt) noexcept;
-
 /** Returns the temperature perturbation if it exists
  * 
  * @param[in] js As jacobian_quantities WSV
@@ -1033,14 +1037,6 @@ String propmattype_string(const RetrievalQuantity& rq);
 //             Propmat partials boolean functions
 //======================================================================
 
-/** Returns if the Retrieval quantity is a wind parameter
- * 
- * @param[in] t A retrieval quantity
- * @return true if it is
- * @return false if it is not
- */
-bool is_wind_parameter(const RetrievalQuantity& t) noexcept;
-
 /** Returns if the Retrieval quantity is a frequency parameter in propagation matrix calculations
  * 
  * @param[in] t A retrieval quantity
@@ -1056,14 +1052,6 @@ bool is_frequency_parameter(const RetrievalQuantity& t) noexcept;
  * @return false if it is not
  */
 bool is_derived_magnetic_parameter(const RetrievalQuantity& t) noexcept;
-
-/** Returns if the Retrieval quantity is a magnetic parameter
- * 
- * @param[in] t A retrieval quantity
- * @return true if it is
- * @return false if it is not
- */
-bool is_magnetic_parameter(const RetrievalQuantity& t) noexcept;
 
 /** Returns if the Retrieval quantity is a NLTE parameter
  * 

--- a/src/linefunctions.cc
+++ b/src/linefunctions.cc
@@ -274,13 +274,13 @@ void Linefunctions::set_lorentz(
     for (auto iq = 0; iq < nppd; iq++) {
       const auto& deriv = derivatives_data[iq];
       
-      if (not propmattype(deriv)) continue;
+      if (not deriv.propmattype()) continue;
 
       if (deriv == Jacobian::Atm::Temperature) {
         dF.col(iq).noalias() = Complex(dT.G0, dT.D0 + dT.DV) * dw;
       } else if (is_frequency_parameter(deriv)) {
         dF.col(iq).noalias() = -iz * dw;
-      } else if (is_magnetic_parameter(deriv)) {
+      } else if (deriv.is_mag()) {
         dF.col(iq).noalias() = iz * zeeman_df * dw;
       } else if (deriv.Target().needQuantumIdentity()) {
         const Absorption::QuantumIdentifierLineTarget lt(deriv.Target().QuantumIdentity(), band, line_ind);
@@ -350,7 +350,7 @@ void Linefunctions::set_voigt(
     for (auto iq = 0; iq < nppd; iq++) {
       const auto& deriv = derivatives_data[iq];
       
-      if (not propmattype(deriv)) continue;
+      if (not deriv.propmattype()) continue;
 
       if (is_frequency_parameter(deriv)) {
         dF.col(iq).noalias() = invGD * dw;
@@ -358,7 +358,7 @@ void Linefunctions::set_voigt(
         dF.col(iq).noalias() =
             dw * Complex(-dT.D0 - dT.DV, dT.G0) * invGD -
             F * dGD_dT * invGD - dw.cwiseProduct(z) * dGD_dT * invGD;
-      } else if (is_magnetic_parameter(deriv)) {
+      } else if (deriv.is_mag()) {
         dF.col(iq).noalias() = dw * (-zeeman_df * invGD);
       } else if (deriv.Target().needQuantumIdentity()) {
         const Absorption::QuantumIdentifierLineTarget lt(deriv.Target().QuantumIdentity(), band, line_ind);
@@ -410,7 +410,7 @@ void Linefunctions::set_doppler(
   for (auto iq = 0; iq < nppd; iq++) {
     const auto& deriv = derivatives_data[iq];
     
-    if (not propmattype(deriv)) continue;
+    if (not deriv.propmattype()) continue;
 
     if (is_frequency_parameter(deriv)) {
       dF.col(iq).noalias() = -2 * invGD * F.cwiseProduct(x);
@@ -451,7 +451,7 @@ void Linefunctions::apply_linemixing_scaling_and_mirroring(
     for (auto iq = 0; iq < nppd; iq++) {
       const auto& deriv = derivatives_data[iq];
       
-      if (not propmattype(deriv)) continue;
+      if (not deriv.propmattype()) continue;
 
       if (deriv == Jacobian::Atm::Temperature) {
         const auto c = Complex(dT.G, -dT.Y);
@@ -474,7 +474,7 @@ void Linefunctions::apply_linemixing_scaling_and_mirroring(
     for (auto iq = 0; iq < nppd; iq++) {
       const auto& deriv = derivatives_data[iq];
       
-      if (not propmattype(deriv)) continue;
+      if (not deriv.propmattype()) continue;
 
       if (deriv == Jacobian::Atm::Temperature) {
         dF.col(iq).noalias() += F * Complex(dT.G, -dT.Y);
@@ -530,7 +530,7 @@ void Linefunctions::apply_rosenkranz_quadratic_scaling(
     for (auto iq = 0; iq < nppd; iq++) {
       const auto& deriv = derivatives_data[iq];
       
-      if (not propmattype(deriv)) continue;
+      if (not deriv.propmattype()) continue;
 
       dF(iv, iq) *= fun;
       if (deriv == Jacobian::Atm::Temperature) {
@@ -583,7 +583,7 @@ void Linefunctions::apply_VVH_scaling(
   for (auto iq = 0; iq < nppd; iq++) {
     const auto& deriv = derivatives_data[iq];
     
-    if (not propmattype(deriv)) continue;
+    if (not deriv.propmattype()) continue;
 
     if (deriv == Jacobian::Atm::Temperature) {
       dF.col(iq).noalias() +=
@@ -627,7 +627,7 @@ void Linefunctions::apply_VVW_scaling(
     for (auto iq = 0; iq < nppd; iq++) {
       const auto& deriv = derivatives_data[iq];
       
-      if (not propmattype(deriv)) continue;
+      if (not deriv.propmattype()) continue;
 
       // The factor is applied to all partial derivatives
       dF(iv, iq) *= fac;
@@ -689,7 +689,7 @@ void Linefunctions::apply_linestrength_scaling_by_lte(
   for (auto iq = 0; iq < nppd; iq++) {
     const auto& deriv = derivatives_data[iq];
     
-    if (not propmattype(deriv)) continue;
+    if (not deriv.propmattype()) continue;
 
     if (deriv == Jacobian::Atm::Temperature) {
       dF.col(iq).noalias() +=
@@ -755,7 +755,7 @@ void Linefunctions::apply_linestrength_scaling_by_vibrational_nlte(
   for (auto iq = 0; iq < nppd; iq++) {
     const auto& deriv = derivatives_data[iq];
     
-    if (not propmattype(deriv)) continue;
+    if (not deriv.propmattype()) continue;
 
     if (deriv == Jacobian::Atm::Temperature) {
       const Numeric dS_dT_abs =
@@ -822,7 +822,7 @@ void Linefunctions::apply_lineshapemodel_jacobian_scaling(
   for (auto iq = 0; iq < nppd; iq++) {
     const auto& rt = derivatives_data[iq];
     
-    if (not propmattype(rt)) continue;
+    if (not rt.propmattype()) continue;
     
     if (is_lineshape_parameter(rt)) {
       const Absorption::QuantumIdentifierLineTarget lt(rt.Target().QuantumIdentity(), band, line_ind);
@@ -924,7 +924,7 @@ void Linefunctions::apply_linestrength_from_nlte_level_distributions(
   for (auto iq = 0; iq < nppd; iq++) {
     const auto& deriv = derivatives_data[iq];
     
-    if (not propmattype(deriv)) continue;
+    if (not deriv.propmattype()) continue;
 
     if (deriv == Jacobian::Atm::Temperature) {
       dN.col(iq).noalias() += F * e * Constant::h * F0 * exp_T / (c2 * Constant::k * T * T);
@@ -1080,7 +1080,7 @@ void Linefunctions::set_htp(Eigen::Ref<Eigen::VectorXcd> F,
     for (auto iq = 0; iq < derivatives_data.nelem(); iq++) {
       const auto& rt = derivatives_data[iq];
       
-      if (not propmattype(rt)) continue;
+      if (not rt.propmattype()) continue;
       
       const Absorption::QuantumIdentifierLineTarget lt = rt.Target().needQuantumIdentity() ?
         Absorption::QuantumIdentifierLineTarget(rt.Target().QuantumIdentity(), band, line_ind) :
@@ -1130,7 +1130,7 @@ void Linefunctions::set_htp(Eigen::Ref<Eigen::VectorXcd> F,
       const Complex dY = (-2 * dcte / cte - 2 * dc2t / c2t) * Y;  // for all
 
       Complex dX;
-      if (is_magnetic_parameter(rt))
+      if (rt.is_mag())
         dX = -iz * freq2kaycm(zeeman_df_si) / c2t;  // for H
       else if (rt == Jacobian::Line::Center and lt == Absorption::QuantumIdentifierLineTargetType::Line)
         dX = -iz / c2t;  // for sg0
@@ -1144,7 +1144,7 @@ void Linefunctions::set_htp(Eigen::Ref<Eigen::VectorXcd> F,
       Complex dAterm, dBterm;
       if (abs(c2t) == 0) {
         Complex dZ1;
-        if (is_magnetic_parameter(rt))
+        if (rt.is_mag())
           dZ1 = -iz * cte * freq2kaycm(zeeman_df_si);  // for H
         else if (rt == Jacobian::Line::Center and lt == Absorption::QuantumIdentifierLineTargetType::Line)
           dZ1 = -iz * cte;  // for sg0
@@ -1171,7 +1171,7 @@ void Linefunctions::set_htp(Eigen::Ref<Eigen::VectorXcd> F,
               pow4(Z1);  // for all
       } else if (abs(X) <= 3e-8 * abs(Y)) {
         Complex dZ1;
-        if (is_magnetic_parameter(rt))
+        if (rt.is_mag())
           dZ1 = -iz * cte * freq2kaycm(zeeman_df_si);  // for H
         else if (rt == Jacobian::Line::Center and lt == Absorption::QuantumIdentifierLineTargetType::Line)
           dZ1 = -iz * cte;  // for sg0
@@ -1295,7 +1295,7 @@ void Linefunctions::set_htp(Eigen::Ref<Eigen::VectorXcd> F,
   for (auto iq = 0; iq < derivatives_data.nelem(); iq++) {
     const auto& rt = derivatives_data[iq];
     
-    if (not propmattype(rt)) continue;
+    if (not rt.propmattype()) continue;
 
     if (rt == Jacobian::Line::Center or is_frequency_parameter(rt) or
         is_pressure_broadening_G0(rt) or is_pressure_broadening_D0(rt) or
@@ -1435,7 +1435,7 @@ void Linefunctions::set_cross_section_of_band(
         for (Index ij = 0; ij < nj; ij++) {
           const auto& deriv = derivatives_data[ij];
           
-          if (not propmattype(deriv)) continue;
+          if (not deriv.propmattype()) continue;
           dF.col(ij).array() -= dFc[ij];
         }
       }
@@ -1489,7 +1489,7 @@ void Linefunctions::set_cross_section_of_band(
         for (Index ij = 0; ij < nj; ij++) {
           const auto& deriv = derivatives_data[ij];
           
-          if (not propmattype(deriv)) continue;
+          if (not deriv.propmattype()) continue;
           dN.col(ij).array() -= dNc[ij];
         }
       }
@@ -1561,13 +1561,13 @@ void Linefunctions::set_cross_section_of_band(
     for (Index ij=0; ij<nj; ij++) {
       const auto& deriv = derivatives_data[ij];
       
-      if (not propmattype(deriv)) continue;
+      if (not deriv.propmattype()) continue;
       sum.dF.col(ij) = reset_zeroes.select(Complex(0, 0), sum.dF.col(ij));
     }
     for (Index ij=0; ij<nj; ij++) {
       const auto& deriv = derivatives_data[ij];
       
-      if (not propmattype(deriv)) continue;
+      if (not deriv.propmattype()) continue;
       sum.dN.col(ij) = reset_zeroes.select(Complex(0, 0), sum.dN.col(ij));
     }
     sum.F = reset_zeroes.select(Complex(0, 0), sum.F);

--- a/src/lineshape.cc
+++ b/src/lineshape.cc
@@ -2393,7 +2393,7 @@ void frequency_loop(ComputeValues &com,
     for (Index ij = 0; ij < nj; ij++) {
       const auto& deriv = jacobian_quantities[ij];
       
-      if (not propmattype(deriv)) continue;
+      if (not deriv.propmattype()) continue;
 
       if (deriv == Jacobian::Atm::Temperature) {
         const auto &dXdT = derivs[ij].value.o;
@@ -2417,14 +2417,14 @@ void frequency_loop(ComputeValues &com,
           com.dN[com.jac_pos(iv, ij)] += DS * (LM * dFls + dLM * Fls) +
                         Sz * (dSn * Si + Sn * dDSi) * LM * Fls;
         }
-      } else if (is_wind_parameter(deriv)) {
+      } else if (deriv.is_wind()) {
         const Complex dFm = std::visit([](auto &&LS) { return std::conj(LS.dFdf()); }, ls_mirr);
         const Complex dFls = std::visit([](auto &&LS) { return LS.dFdf(); }, ls) + dFm;
         com.dF[com.jac_pos(iv, ij)] += S * LM * dFls;
         if (do_nlte) {
           com.dN[com.jac_pos(iv, ij)] += DS * LM * dFls;
         }
-      } else if (is_magnetic_parameter(deriv)) {
+      } else if (deriv.is_mag()) {
         const Complex dFm = std::visit([dfdH](auto &&LS) { return std::conj(LS.dFdH(-dfdH)); }, ls_mirr);
         const Complex dFls = std::visit([dfdH](auto &&LS) { return LS.dFdH(dfdH); }, ls) + dFm;
         com.dF[com.jac_pos(iv, ij)] += S * LM * dFls;
@@ -2887,7 +2887,7 @@ void line_loop(ComputeData &com,
     for (Index ij = 0; ij < nj; ij++) {
       const auto& deriv = jacobian_quantities[ij];
       
-      if (not propmattype(deriv)) continue;
+      if (not deriv.propmattype()) continue;
 
       if (deriv == Jacobian::Atm::Temperature) {
         derivs[ij].value.o = band.ShapeParameters_dT(i, T, P, vmrs);

--- a/src/m_abs.cc
+++ b/src/m_abs.cc
@@ -315,7 +315,7 @@ void abs_coefCalcFromXsec(  // WS Output:
   for (Index ii = 0; ii < jacobian_quantities.nelem(); ii++) {
     const auto& deriv = jacobian_quantities[ii];
     
-    if (not propmattype(deriv)) continue;
+    if (not deriv.propmattype()) continue;
     
     dabs_coef_dx[ii].resize(abs_xsec_per_species[0].nrows(),
                             abs_xsec_per_species[0].ncols());
@@ -364,7 +364,7 @@ void abs_coefCalcFromXsec(  // WS Output:
         for (Index iq = 0; iq < jacobian_quantities.nelem(); iq++) {
           const auto& deriv = jacobian_quantities[iq];
           
-          if (not propmattype(deriv)) continue;
+          if (not deriv.propmattype()) continue;
           
           if (deriv == Jacobian::Atm::Temperature) {
             dabs_coef_dx[iq](k, j) +=
@@ -786,7 +786,7 @@ void abs_xsec_per_speciesAddConts(  // WS Output:
                    iq++) {
                 const auto& deriv = jacobian_quantities[iq];
                 
-                if (not propmattype(deriv)) continue;
+                if (not deriv.propmattype()) continue;
                 
                 if (is_frequency_parameter(deriv))
                   dabs_xsec_per_species_dx[i][iq](iv, ip) +=
@@ -893,7 +893,7 @@ void nlte_sourceFromTemperatureAndSrcCoefPerSpecies(  // WS Output:
   for (Index ii = 0; ii < jacobian_quantities.nelem(); ii++) {
     const auto& deriv = jacobian_quantities[ii];
     
-    if (not propmattype(deriv)) continue;
+    if (not deriv.propmattype()) continue;
     
     if (deriv == Jacobian::Atm::Temperature) {
       const Vector dB = dplanck_dt(f_grid, rtp_temperature);
@@ -1328,7 +1328,7 @@ void propmat_clearskyAddParticles(
       for (Index iq = 0; iq < jacobian_quantities.nelem(); iq++) {
         const auto& deriv = jacobian_quantities[iq];
         
-        if (not propmattype(deriv)) continue;
+        if (not deriv.propmattype()) continue;
         
         if (deriv == Jacobian::Atm::Temperature) {
           if (use_abs_as_ext) {
@@ -1388,7 +1388,7 @@ void propmat_clearskyAddParticles(
     for (Index iq = 0; iq < jacobian_quantities.nelem(); iq++) {
       const auto& deriv = jacobian_quantities[iq];
       
-      if (not propmattype(deriv)) continue;
+      if (not deriv.propmattype()) continue;
       
       if (deriv == Jacobian::Atm::Particulates) {
         dpropmat_clearsky_dx[iq] /= rtp_vmr_sum;
@@ -1565,7 +1565,7 @@ void propmat_clearskyAddLines(  // Workspace reference:
       for (Index j=0; j<nq; j++) {
         auto& deriv = jacobian_quantities[j];
         
-        if (not propmattype(deriv)) continue;
+        if (not deriv.propmattype()) continue;
         
         if (deriv == abs_species[ispecies]) {
           dpropmat_clearsky_dx[j].Kjj() += com.F.real();  // FIXME: Without this, the complex-variables would never need reset
@@ -1582,7 +1582,7 @@ void propmat_clearskyAddLines(  // Workspace reference:
         for (Index j=0; j<nq; j++) {
           auto& deriv = jacobian_quantities[j];
           
-          if (not propmattype(deriv)) continue;
+          if (not deriv.propmattype()) continue;
           
           if (deriv == abs_species[ispecies]) {
             dnlte_source_dx[j].Kjj() += com.N.real();  // FIXME: Without this, the complex-variables would never need reset
@@ -1619,7 +1619,7 @@ void propmat_clearskyAddLines(  // Workspace reference:
     
     // Sum up the Jacobian
     for (Index j=0; j<nq; j++) {
-      if (not propmattype(jacobian_quantities[j])) continue;
+      if (not jacobian_quantities[j].propmattype()) continue;
       dpropmat_clearsky_dx[j].Kjj() += com.dF.real()(joker, j);
     }
     
@@ -1629,7 +1629,7 @@ void propmat_clearskyAddLines(  // Workspace reference:
       
       // Sum up the Jacobian
       for (Index j=0; j<nq; j++) {
-        if (not propmattype(jacobian_quantities[j])) continue;
+        if (not jacobian_quantities[j].propmattype()) continue;
         dnlte_source_dx[j].Kjj() += com.dN.real()(joker, j);
       }
     }

--- a/src/m_abs_lookup.cc
+++ b/src/m_abs_lookup.cc
@@ -2106,7 +2106,7 @@ void propmat_clearskyAddFromLookup(
         for (Index iq = 0; iq < jacobian_quantities.nelem(); iq++) {
           const auto& deriv = jacobian_quantities[iq];
           
-          if (not propmattype(deriv)) continue;
+          if (not deriv.propmattype()) continue;
           
           if (deriv == Jacobian::Atm::Temperature) {
             dpropmat_clearsky_dx[iq].Kjj()[iv] +=

--- a/src/m_cia.cc
+++ b/src/m_cia.cc
@@ -228,7 +228,7 @@ void abs_xsec_per_speciesAddCIA(  // WS Output:
                  iq++) {
               const auto& deriv = jacobian_quantities[iq];
             
-            if (not propmattype(deriv)) continue;
+            if (not deriv.propmattype()) continue;
               
             if (is_frequency_parameter(deriv))
                 dabs_xsec_per_species_dx[i][iq](iv, ip) +=

--- a/src/m_hitran_xsec.cc
+++ b/src/m_hitran_xsec.cc
@@ -191,7 +191,7 @@ void abs_xsec_per_speciesAddHitranXsec(  // WS Output:
             for (Index iq = 0; iq < jacobian_quantities.nelem(); iq++) {
               const auto& deriv = jacobian_quantities[ii];
               
-              if (not propmattype(deriv)) continue;
+              if (not deriv.propmattype()) continue;
               
               if (is_frequency_parameter(deriv))
                 this_dxsec[iq](iv, ip) +=

--- a/src/m_linemixing.cc
+++ b/src/m_linemixing.cc
@@ -179,7 +179,7 @@ void propmat_clearskyAddOnTheFlyLineMixing(PropagationMatrix& propmat_clearsky,
         for (Index j=0; j<jacobian_quantities.nelem(); j++) {
           const auto& deriv = jacobian_quantities[j];
           
-          if (not propmattype(deriv)) continue;
+          if (not deriv.propmattype()) continue;
           
           if (deriv == abs_species[i]) {
             dpropmat_clearsky_dx[j].Kjj() += abs.real();
@@ -250,7 +250,7 @@ void propmat_clearskyAddOnTheFlyLineMixingWithZeeman(PropagationMatrix& propmat_
           for (Index j=0; j<jacobian_quantities.nelem(); j++) {
             const auto& deriv = jacobian_quantities[j];
             
-            if (not propmattype(deriv)) continue;
+            if (not deriv.propmattype()) continue;
             
             if (deriv == Jacobian::Atm::MagneticU) {
               Zeeman::dsum(dpropmat_clearsky_dx[j], abs, dabs[j],

--- a/src/predefined_absorption_models.cc
+++ b/src/predefined_absorption_models.cc
@@ -306,7 +306,7 @@ void Absorption::PredefinedModel::makarov2020_o2_lines_mpm(Matrix& xsec,
           for (Index iq=0; iq<jacs.nelem(); iq++) {
             const auto& deriv = jacs[iq];
             
-            if (not propmattype(deriv)) continue;
+            if (not deriv.propmattype()) continue;
             
             
             if (deriv == Jacobian::Atm::Temperature) {

--- a/src/rte.cc
+++ b/src/rte.cc
@@ -76,7 +76,7 @@ void adapt_stepwise_partial_derivatives(
   for (Index i = 0; i < nq; i++) {
     if (jacobian_quantities[i] == Jacobian::Type::Sensor or jacobian_quantities[i] == Jacobian::Special::SurfaceString) continue;
 
-    if (is_wind_parameter(jacobian_quantities[i])) {
+    if (jacobian_quantities[i].is_wind()) {
       const auto scale = get_stepwise_f_partials(ppath_line_of_sight, ppath_f_grid, jacobian_quantities[i].Target().AtmType(), atmosphere_dim);
       dK_dx[i] *= scale;
       if (not lte) dS_dx[i] *= scale;

--- a/src/zeeman.cc
+++ b/src/zeeman.cc
@@ -187,7 +187,7 @@ void zeeman_on_the_fly(
         for (Index j=0; j<nq; j++) {
           auto& deriv = jacobian_quantities[j];
           
-          if (not propmattype(deriv)) continue;
+          if (not deriv.propmattype()) continue;
           
           if (deriv == Jacobian::Atm::MagneticU) {
             Zeeman::dsum(dpropmat_clearsky_dx[j], com.F, com.dF(joker, j),
@@ -216,7 +216,7 @@ void zeeman_on_the_fly(
           for (Index j=0; j<nq; j++) {
             auto& deriv = jacobian_quantities[j];
             
-            if (not propmattype(deriv)) continue;
+            if (not deriv.propmattype()) continue;
             
             if (deriv == Jacobian::Atm::MagneticU) {
               Zeeman::dsum(dnlte_source_dx[j], com.N, com.dN(joker, j),
@@ -263,7 +263,7 @@ void zeeman_on_the_fly(
       for (Index j=0; j<nq; j++) {
         auto& deriv = jacobian_quantities[j];
         
-        if (not propmattype(deriv)) continue;
+        if (not deriv.propmattype()) continue;
         
         if (deriv == Jacobian::Atm::MagneticU) {
           Zeeman::dsum(dpropmat_clearsky_dx[j], com.F, com.dF(joker, j),
@@ -290,7 +290,7 @@ void zeeman_on_the_fly(
         for (Index j=0; j<nq; j++) {
           auto& deriv = jacobian_quantities[j];
           
-          if (not propmattype(deriv)) continue;
+          if (not deriv.propmattype()) continue;
           
           if (deriv == Jacobian::Atm::MagneticU) {
             Zeeman::dsum(dnlte_source_dx[j], com.N, com.dN(joker, j),


### PR DESCRIPTION
Here's my output from the script Oliver provided in a currently open issue:

Time per pressure/temperature combination
CASE 1 - All species w/ jacobian ArrayOfSpeciesTagVMR: 1.586376s
CASE 2 - All species w/ jacobian Line::VMR           : 3.782718s
CASE 3 - All species w/o jacobian                    : 1.323047s
CASE 4 - One species at a time                       : 1.330896s
