### PR TITLE
Disable OpenMP in Eigen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ if (NOT INDEX)
 endif (NOT INDEX)
 
 add_definitions (-DHAVE_CONFIG_H)
+add_definitions (-DEIGEN_DONT_PARALLELIZE)
 
 if (NO_ASSERT)
   add_definitions (-DNDEBUG)


### PR DESCRIPTION
Eigen's OpenMP parallization can lead to wrong results in certain cases likely
due to interference with our own parallelization as reported in #344. Seems to
also be compiler dependent since the problem was only reproducable in GCC 9.

See also:
https://eigen.tuxfamily.org/dox/TopicMultiThreading.html

Adding `Eigen::initParallel()` is not enough to solve the issue in #344.
Only setting the number of threads to 1 with `Eigen::setNbThreads(1)`
fixes it, therefore disabling OpenMP altogether in Eigen seems the safest
solution.

Turning OpenMP off in Eigen didn't show any negative performance impact for
the test provided in #344.