### PR TITLE
Make PyARTS recognize numpy int types as Index

### DIFF
--- a/python/pyarts/xml/write.py
+++ b/python/pyarts/xml/write.py
@@ -5,6 +5,8 @@
 This package contains the internal implementation for writing ARTS XML files.
 """
 
+import numbers
+
 import numpy as np
 
 from .names import dimension_names
@@ -121,7 +123,7 @@ class ARTSXMLWriter:
             var.write_xml(self, attr)
         elif isinstance(var, np.ndarray):
             self.write_ndarray(var, attr)
-        elif isinstance(var, int):
+        elif isinstance(var, numbers.Integral):
             self.write_basic_type('Index', var, attr)
         elif isinstance(var, float):
             self.write_basic_type('Numeric', var, attr, self.precision)

--- a/python/test/xml/test_matpack_types.py
+++ b/python/test/xml/test_matpack_types.py
@@ -188,9 +188,10 @@ class TestSave:
             if os.path.isfile(f):
                 os.remove(f)
 
-    def test_save_index(self):
+    @pytest.mark.parametrize("inttype", (int, np.int32, np.int64))
+    def test_save_index(self, inttype):
         """Save Index to file, read it and compare the results."""
-        reference = 0
+        reference = inttype(0)
         xml.save(reference, self.f)
         test_data = xml.load(self.f)
         assert test_data == reference
@@ -273,16 +274,18 @@ class TestSave:
         test_data = xml.load(self.f)
         assert np.array_equal(test_data, reference)
 
-    def test_save_arrayofindex(self):
+    @pytest.mark.parametrize("inttype", (int, np.int32, np.int64))
+    def test_save_arrayofindex(self, inttype):
         """Save ArrayOfIndex to file, read it and compare the results."""
-        reference = [1., 2., 3.]
+        reference = [inttype(i) for i in [1., 2., 3.]]
         xml.save(reference, self.f)
         test_data = xml.load(self.f)
         assert np.array_equal(test_data, reference)
 
-    def test_save_arrayofindex_binary(self):
+    @pytest.mark.parametrize("inttype", (int, np.int32, np.int64))
+    def test_save_arrayofindex_binary(self, inttype):
         """Save ArrayOfIndex to binary file, read it and compare the result."""
-        reference = [1., 2., 3.]
+        reference = [inttype(i) for i in [1., 2., 3.]]
         xml.save(reference, self.f, format='binary')
         test_data = xml.load(self.f)
         assert np.array_equal(test_data, reference)


### PR DESCRIPTION
`ARTSXMLWriter.write_xml` did not recognize numpy int types correctly as
Index. This code failed:

```
x = [numpy.int32(i) for i in [1,2,3]]
pyarts.xml.save(x, "foobar.xml")
```

TypeError: Can't map 'int32' to any ARTS type.