### PR TITLE
Select species

### DIFF
--- a/controlfiles-python/classes/TestSpeciesTag.py
+++ b/controlfiles-python/classes/TestSpeciesTag.py
@@ -42,3 +42,6 @@ assert str(ws.ast.value) == '""'
 
 ws.ArrayOfSpeciesTagSet(ws.ast, ArrayOfSpeciesTag([SpeciesTag("O2-66")]))
 assert str(ws.ast.value) == '"O2-66-*-*"'
+
+ws.ArrayOfSpeciesTagSet(ws.ast, [SpeciesTag("O2-66"), SpeciesTag("O2-68")])
+assert str(ws.ast.value) == '"O2-66-*-*, O2-68-*-*"'

--- a/controlfiles-python/classes/TestSpeciesTag.py
+++ b/controlfiles-python/classes/TestSpeciesTag.py
@@ -1,5 +1,6 @@
 from pyarts.workspace import Workspace
-from pyarts.classes.SpeciesTag import SpeciesTag, ArrayOfArrayOfSpeciesTag
+from pyarts.classes.SpeciesTag import (SpeciesTag, ArrayOfSpeciesTag,
+                                       ArrayOfArrayOfSpeciesTag)
 from pyarts.classes import from_workspace
 
 
@@ -20,3 +21,24 @@ aast.savexml("tmp.aast.xml", "binary")
 aast2 = ArrayOfArrayOfSpeciesTag()
 aast2.readxml("tmp.aast.xml")
 assert aast == aast2
+
+# Test ArrayOfSpeciesTag
+ws.ArrayOfSpeciesTagCreate("ast")
+
+ws.ArrayOfSpeciesTagSet(ws.ast, "O2-66, O2-68")
+assert str(ws.ast.value) == '"O2-66-*-*, O2-68-*-*"'
+
+ws.ArrayOfSpeciesTagSet(ws.ast, ["O2-66", "O2-68"])
+assert str(ws.ast.value) == '"O2-66-*-*, O2-68-*-*"'
+
+ws.ArrayOfSpeciesTagSet(ws.ast, "O2-66")
+assert str(ws.ast.value) == '"O2-66-*-*"'
+
+ws.ArrayOfSpeciesTagSet(ws.ast, "")
+assert str(ws.ast.value) == '""'
+
+ws.ArrayOfSpeciesTagSet(ws.ast, None)
+assert str(ws.ast.value) == '""'
+
+ws.ArrayOfSpeciesTagSet(ws.ast, ArrayOfSpeciesTag([SpeciesTag("O2-66")]))
+assert str(ws.ast.value) == '"O2-66-*-*"'

--- a/controlfiles/artscomponents/lineshapes/TestLorentzLM.arts
+++ b/controlfiles/artscomponents/lineshapes/TestLorentzLM.arts
@@ -68,7 +68,7 @@ Arts2{
   # Perform calculations for analytical propagation matrix and derivatives
   lbl_checkedCalc
   propmat_clearskyInit
-  propmat_clearskyAddLines
+  propmat_clearskyAddLines(select_speciestags="O2-66")
   #WriteXML("ascii", propmat_clearsky, "testdata/test-lm-lp/propmat.xml")
   #WriteXML("ascii", dpropmat_clearsky_dx, "testdata/test-lm-lp/dpropmat.xml")
   ReadXML(testdata, "testdata/test-lm-lp/propmat.xml")

--- a/python/pyarts/classes/ArrayBase.py
+++ b/python/pyarts/classes/ArrayBase.py
@@ -119,7 +119,10 @@ def array_base(var):
                 self.size = len(val)
                 n = self.size
                 for i in range(n):
-                    self[i] = val[i]
+                    try:
+                        self[i] = val[i]
+                    except:
+                        self[i] = BASENAME(val[i])
             else:
                 raise TypeError("Expects list of values")
 

--- a/python/pyarts/classes/SpeciesTag.py
+++ b/python/pyarts/classes/SpeciesTag.py
@@ -4,6 +4,7 @@ from pyarts.workspace.api import arts_api as lib
 
 from pyarts.classes.io import correct_save_arguments, correct_read_arguments
 from pyarts.classes.ArrayBase import array_base
+from pyarts.classes.BasicTypes import String
 
 
 class SpeciesTag:
@@ -197,6 +198,11 @@ class SpeciesTag:
     def cia_type(self):
         """ Returns the CIA type """
         return lib.string2indexTypeSpeciesTag(self.__data__, "TYPE_CIA".encode("ascii"))
+    
+    @property
+    def as_string(self):
+        """ Returns the name as a String """
+        return String(c.c_void_p(lib.getNameSpeciesTag(self.__data__)), delete=True)
 
     def validCIASpecies(self):
         """ Returns whether cia species is a valid species according to ARTS
@@ -396,6 +402,9 @@ lib.setTypeSpeciesTag.argtypes = [c.c_void_p, c.c_long]
 
 lib.setCIASecondSpeciesTag.restype = None
 lib.setCIASecondSpeciesTag.argtypes = [c.c_void_p, c.c_long]
+
+lib.getNameSpeciesTag.restype = c.c_void_p
+lib.getNameSpeciesTag.argtypes = [c.c_void_p]
 
 lib.setCIADatasetSpeciesTag.restype = None
 lib.setCIADatasetSpeciesTag.argtypes = [c.c_void_p, c.c_long]

--- a/python/pyarts/classes/SpeciesTag.py
+++ b/python/pyarts/classes/SpeciesTag.py
@@ -349,6 +349,26 @@ exec(array_base(SpeciesTag))
 exec(array_base(ArrayOfSpeciesTag))
 
 
+class ArrayOfSpeciesTagAdapted(ArrayOfSpeciesTag):
+    @property
+    def data(self):
+        return super().data
+
+    @data.setter
+    def data(self, val):
+        if isinstance(val, str) and val == "":
+            return
+        if isinstance(val, str):
+            val = [s.strip() for s in val.split(",")]
+        super(self.__class__, self.__class__).data.fset(self, val)
+
+    def __str__(self):
+        return '"' + ", ".join([str(s.as_string) for s in self.data]) + '"'
+
+
+ArrayOfSpeciesTag = ArrayOfSpeciesTagAdapted
+ArrayOfSpeciesTag.__name__ = "ArrayOfSpeciesTag"
+
 lib.createSpeciesTag.restype = c.c_void_p
 lib.createSpeciesTag.argtypes = []
 

--- a/python/pyarts/classes/__init__.py
+++ b/python/pyarts/classes/__init__.py
@@ -33,7 +33,7 @@ from pyarts.classes.ScatteringMetaData import ScatteringMetaData, ArrayOfScatter
 from pyarts.classes.SingleScatteringData import SingleScatteringData, ArrayOfSingleScatteringData, ArrayOfArrayOfSingleScatteringData
 from pyarts.classes.Sparse import Sparse, ArrayOfSparse
 from pyarts.classes.SpeciesAuxData import SpeciesAuxData
-from pyarts.classes.SpeciesTag import ArrayOfArrayOfSpeciesTag
+from pyarts.classes.SpeciesTag import ArrayOfSpeciesTag, ArrayOfArrayOfSpeciesTag
 from pyarts.classes.StokesVector import StokesVector, ArrayOfStokesVector, ArrayOfArrayOfStokesVector
 from pyarts.classes.TelsemAtlas import TelsemAtlas, ArrayOfTelsemAtlas
 from pyarts.classes.Tensor3 import Tensor3, ArrayOfTensor3, ArrayOfArrayOfTensor3

--- a/python/pyarts/classes/__init__.py
+++ b/python/pyarts/classes/__init__.py
@@ -33,7 +33,7 @@ from pyarts.classes.ScatteringMetaData import ScatteringMetaData, ArrayOfScatter
 from pyarts.classes.SingleScatteringData import SingleScatteringData, ArrayOfSingleScatteringData, ArrayOfArrayOfSingleScatteringData
 from pyarts.classes.Sparse import Sparse, ArrayOfSparse
 from pyarts.classes.SpeciesAuxData import SpeciesAuxData
-from pyarts.classes.SpeciesTag import ArrayOfSpeciesTag, ArrayOfArrayOfSpeciesTag
+from pyarts.classes.SpeciesTag import SpeciesTag, ArrayOfSpeciesTag, ArrayOfArrayOfSpeciesTag
 from pyarts.classes.StokesVector import StokesVector, ArrayOfStokesVector, ArrayOfArrayOfStokesVector
 from pyarts.classes.TelsemAtlas import TelsemAtlas, ArrayOfTelsemAtlas
 from pyarts.classes.Tensor3 import Tensor3, ArrayOfTensor3, ArrayOfArrayOfTensor3

--- a/python/pyarts/workspace/variables.py
+++ b/python/pyarts/workspace/variables.py
@@ -152,6 +152,7 @@ class WorkspaceVariable:
                  or None if the type is not supported.
         """
         import numpy as np
+        from pyarts import classes as native_classes
         if isinstance(value, WorkspaceVariable):
             return group_ids[value.group]
         elif isinstance(value, Agenda):
@@ -213,6 +214,9 @@ class WorkspaceVariable:
                         f"Nested array with internal type "
                         f"{type(nested_value)} not supported.")
         elif hasattr(value, 'write_xml') and type(value).__name__ in group_names:
+            return group_ids[type(value).__name__]
+        elif hasattr(value, 'savexml') and hasattr(native_classes,
+                                                   type(value).__name__):
             return group_ids[type(value).__name__]
         else:
             raise ValueError(f"Type {type(value)} currently not supported.")

--- a/python/pyarts/workspace/variables.py
+++ b/python/pyarts/workspace/variables.py
@@ -234,6 +234,7 @@ class WorkspaceVariable:
             (any): The converted object or None is conversion was unsuccessful.
         """
         import numpy as np
+        from pyarts import classes as native_classes
 
         try:
             gid = cls.get_group_id(value)
@@ -259,6 +260,10 @@ class WorkspaceVariable:
         if (group[:6] == "Tensor"):
             dim = int(group[6])
             return np.array(value, dtype=np.float64, order='C', ndmin=dim)
+        if (group == "ArrayOfSpeciesTag"):
+            if isinstance(value, native_classes.ArrayOfSpeciesTag):
+                return value
+            return native_classes.ArrayOfSpeciesTag(value)
         if group.startswith("ArrayOf"):
             subgroup = group[7:]
             if hasattr(value, "__iter__"):

--- a/src/arts_api_classes.cc
+++ b/src/arts_api_classes.cc
@@ -289,6 +289,11 @@ VoidArrayCAPI(ArrayOfArrayOfSpeciesTag)
 BasicInterfaceCAPI(ArrayOfArrayOfSpeciesTag)
 BasicInputOutputCAPI(ArrayOfArrayOfSpeciesTag)
 
+void * getNameSpeciesTag(void * data)
+{
+  return new String(static_cast<SpeciesTag *>(data) -> Name());
+}
+
 Index setSpeciesTag(void * data, char * newdata)
 {
   try {

--- a/src/arts_api_classes.h
+++ b/src/arts_api_classes.h
@@ -209,6 +209,7 @@ extern "C" {
     VoidArrayCAPI(ArrayOfArrayOfSpeciesTag)
     BasicInterfaceCAPI(ArrayOfArrayOfSpeciesTag)
     BasicInputOutputCAPI(ArrayOfArrayOfSpeciesTag)
+    DLL_PUBLIC void * getNameSpeciesTag(void *);
     DLL_PUBLIC Index setSpeciesTag(void *, char *);
     DLL_PUBLIC Index validSpecies(Index);
     DLL_PUBLIC Index validAllIsotopologues(Index, Index);

--- a/src/groups.cc
+++ b/src/groups.cc
@@ -119,6 +119,7 @@ void define_wsv_group_names() {
   wsv_group_names.push_back("ArrayOfRetrievalQuantity");
   wsv_group_names.push_back("ArrayOfScatteringMetaData");
   wsv_group_names.push_back("ArrayOfSingleScatteringData");
+  wsv_group_names.push_back("ArrayOfSpeciesTag");
   wsv_group_names.push_back("ArrayOfSparse");
   wsv_group_names.push_back("ArrayOfStokesVector");
   wsv_group_names.push_back("ArrayOfString");

--- a/src/m_abs.cc
+++ b/src/m_abs.cc
@@ -1482,6 +1482,7 @@ void propmat_clearskyAddLines(  // Workspace reference:
     const Numeric& sparse_df,
     const Numeric& sparse_lim,
     const String& speedup_option,
+    const ArrayOfSpeciesTag& select_species,
     // Verbosity object:
     const Verbosity& verbosity) {
   

--- a/src/m_abs.cc
+++ b/src/m_abs.cc
@@ -1482,7 +1482,7 @@ void propmat_clearskyAddLines(  // Workspace reference:
     const Numeric& sparse_df,
     const Numeric& sparse_lim,
     const String& speedup_option,
-    const ArrayOfSpeciesTag& select_species,
+    const ArrayOfSpeciesTag& select_speciestags,
     // Verbosity object:
     const Verbosity& verbosity) {
   
@@ -1536,6 +1536,8 @@ void propmat_clearskyAddLines(  // Workspace reference:
 
   if (legacy_vmr_derivative) {
     for (Index ispecies = 0; ispecies < ns; ispecies++) {
+      if (select_speciestags.nelem() and select_speciestags not_eq abs_species[ispecies]) continue;
+      
       // Skip it if there are no species or there is Zeeman requested
       if (not abs_species[ispecies].nelem() or is_zeeman(abs_species[ispecies]) or not abs_lines_per_species[ispecies].nelem())
         continue;
@@ -1595,6 +1597,8 @@ void propmat_clearskyAddLines(  // Workspace reference:
     }
   } else {
     for (Index ispecies = 0; ispecies < ns; ispecies++) {
+      if (select_speciestags.nelem() and select_speciestags not_eq abs_species[ispecies]) continue;
+      
       // Skip it if there are no species or there is Zeeman requested
       if (not abs_species[ispecies].nelem() or is_zeeman(abs_species[ispecies]) or not abs_lines_per_species[ispecies].nelem())
         continue;

--- a/src/m_basic_types.cc
+++ b/src/m_basic_types.cc
@@ -3132,3 +3132,13 @@ void PrintPhysicalConstants(const Verbosity& verbosity) {
        << "Doppler constant:       \t " << DOPPLER_CONST << '\n'
        << "---------------------------------------------------------\n";
 }
+
+
+
+/* Workspace method: Doxygen documentation will be auto-generated */
+void ArrayOfSpeciesTagSet(ArrayOfSpeciesTag& sst,
+                          const ArrayOfSpeciesTag& sst2,
+                          const Verbosity&) {
+  sst = sst2;
+}
+

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -12650,13 +12650,14 @@ void define_md_data_raw() {
          "rtp_vmr",
          "nlte_do",
          "lbl_checked"),
-      GIN("sparse_df", "sparse_lim", "speedup_option"),
-      GIN_TYPE("Numeric", "Numeric", "String"),
-      GIN_DEFAULT("0", "0", "None"),
+      GIN("sparse_df", "sparse_lim", "speedup_option", "select_species"),
+      GIN_TYPE("Numeric", "Numeric", "String", "ArrayOfSpeciesTag"),
+      GIN_DEFAULT("0", "0", "None", NODEF),
       GIN_DESC(
         "The grid sparse separation",
         "The dense-to-sparse limit",
-        "Speedup logic"
+        "Speedup logic",
+        "Species selection (will only compute for the select species in *abs_species*)"
       )));
 
   md_data_raw.push_back(create_mdrecord(

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -2972,6 +2972,21 @@ void define_md_data_raw() {
       SETMETHOD(true)));
 
   md_data_raw.push_back(create_mdrecord(
+      NAME("ArrayOfSpeciesTagSet"),
+      DESCRIPTION("Creates an ArrayOfSpeciesTag from the given ArrayOfSpeciesTag.\n"),
+      AUTHORS("Richard Larsson"),
+      OUT(),
+      GOUT("out"),
+      GOUT_TYPE("ArrayOfSpeciesTag"),
+      GOUT_DESC("Variable to initialize."),
+      IN(),
+      GIN("value"),
+      GIN_TYPE("ArrayOfSpeciesTag"),
+      GIN_DEFAULT(NODEF),
+      GIN_DESC("List of SpeciesTag for initializiation."),
+      SETMETHOD(true)));
+
+  md_data_raw.push_back(create_mdrecord(
       NAME("ArrayOfIndexSetConstant"),
       DESCRIPTION("Creates an ArrayOfIndex of length *nelem*, with all values\n"
                   "identical.\n"),
@@ -12650,9 +12665,9 @@ void define_md_data_raw() {
          "rtp_vmr",
          "nlte_do",
          "lbl_checked"),
-      GIN("sparse_df", "sparse_lim", "speedup_option", "select_species"),
+      GIN("sparse_df", "sparse_lim", "speedup_option", "select_speciestags"),
       GIN_TYPE("Numeric", "Numeric", "String", "ArrayOfSpeciesTag"),
-      GIN_DEFAULT("0", "0", "None", NODEF),
+      GIN_DEFAULT("0", "0", "None", ""),
       GIN_DESC(
         "The grid sparse separation",
         "The dense-to-sparse limit",

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -1824,6 +1824,14 @@ Index ArtsParser::read_name_or_value(String& name,
     ArrayOfIndex dummy;
     parse_intvector(dummy);
     auto_vars_values.push_back(dummy);
+  } else if (group == get_wsv_group_id("ArrayOfSpeciesTag")) {
+    String dummy;
+    parse_String(dummy);
+    ArrayOfSpeciesTag aost;
+    if (dummy.nelem()) {
+      array_species_tag_from_string(aost, dummy);
+    }
+    auto_vars_values.push_back(aost);
   } else if (group == get_wsv_group_id("Vector")) {
     Vector dummy;
     parse_numvector(dummy);

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -670,6 +670,19 @@ String ArtsParser::set_gin_to_default(const MdRecord* mdd,
         throw ParseError(os.str(), p.file(), p.line(), p.column());
       }
       tv = v;
+    } else if (mdd->GInType()[gin_index] == get_wsv_group_id("ArrayOfSpeciesTag")) {
+      ArrayOfSpeciesTag v;
+      String s = mdd->GInDefault()[gin_index];
+      if (s.nelem()) {
+        try {
+          array_species_tag_from_string(v, s);
+        } catch (std::exception& e) {
+          std::ostringstream os;
+          os << e.what() << os_default_error.str();
+          throw ParseError(os.str(), msource.File(), msource.Line(), msource.Column());
+        }
+      }
+      tv = v;
     } else {
       using global_data::wsv_group_names;
       ostringstream os;
@@ -1585,6 +1598,7 @@ void ArtsParser::tasklist_insert_set_delete(
         auto_group != get_wsv_group_id("Numeric") &&
         auto_group != get_wsv_group_id("ArrayOfIndex") &&
         auto_group != get_wsv_group_id("ArrayOfString") &&
+        auto_group != get_wsv_group_id("ArrayOfSpeciesTag") &&
         auto_group != get_wsv_group_id("String") &&
         auto_group != get_wsv_group_id("Vector") &&
         auto_group != get_wsv_group_id("Matrix")) {

--- a/src/token.cc
+++ b/src/token.cc
@@ -59,6 +59,11 @@ TokVal::operator ArrayOfIndex() const {
   return mnv;
 }
 
+TokVal::operator ArrayOfSpeciesTag() const {
+  ARTS_ASSERT(mtype == Array_SpeciesTa_t);
+  return mnst;
+}
+
 TokVal::operator Vector() const {
   ARTS_ASSERT(mtype == Vector_t);
   return mxv;

--- a/src/token.h
+++ b/src/token.h
@@ -19,6 +19,7 @@
 #define token_h
 
 #include "array.h"
+#include "abs_species_tags.h"
 #include "matpackI.h"
 #include "mystring.h"
 
@@ -30,6 +31,7 @@ enum TokValType {
   Numeric_t,
   Array_String_t,
   Array_Index_t,
+  Array_SpeciesTag_t,
   Vector_t,
   Matrix_t,
   undefined_t
@@ -41,23 +43,23 @@ class TokVal {
  public:
   /** Default Constructor. (Sets type to undefined_t) */
   TokVal()
-      : mtype(undefined_t), ms(), mn(-1), mx(0.), msv(), mnv(), mxv(), mm() {}
+      : mtype(undefined_t), ms(), mn(-1), mx(0.), msv(), mnv(), mnst(), mxv(), mm() {}
 
   /** To set TokVal from String (C - style). */
   TokVal(const char s[])
-      : mtype(String_t), ms(s), mn(-1), mx(0.), msv(), mnv(), mxv(), mm() {}
+      : mtype(String_t), ms(s), mn(-1), mx(0.), msv(), mnv(), mnst(), mxv(), mm() {}
 
   /** To set TokVal from String (C++ - style). */
   TokVal(const String& s)
-      : mtype(String_t), ms(s), mn(-1), mx(0.), msv(), mnv(), mxv(), mm() {}
+      : mtype(String_t), ms(s), mn(-1), mx(0.), msv(), mnv(), mnst(), mxv(), mm() {}
 
   /** To set TokVal from an integer. */
   TokVal(Index n)
-      : mtype(Index_t), ms(), mn(n), mx(0.), msv(), mnv(), mxv(), mm() {}
+      : mtype(Index_t), ms(), mn(n), mx(0.), msv(), mnv(), mnst(), mxv(), mm() {}
 
   /** To set TokVal from a Numeric. */
   TokVal(Numeric x)
-      : mtype(Numeric_t), ms(), mn(-1), mx(x), msv(), mnv(), mxv(), mm() {}
+      : mtype(Numeric_t), ms(), mn(-1), mx(x), msv(), mnv(), mnst(), mxv(), mm() {}
 
   /** To set TokVal from an array of Strings. */
   TokVal(ArrayOfString sv)
@@ -67,6 +69,7 @@ class TokVal {
         mx(0.),
         msv(sv),
         mnv(),
+        mnst(),
         mxv(),
         mm() {}
 
@@ -78,16 +81,29 @@ class TokVal {
         mx(0.),
         msv(),
         mnv(nv),
+        mnst(),
+        mxv(),
+        mm() {}
+
+  /** To set TokVal from an array of species tags. */
+  TokVal(ArrayOfSpeciesTag nst)
+      : mtype(Array_SpeciesTag_t),
+        ms(),
+        mn(-1),
+        mx(0.),
+        msv(),
+        mnv(),
+        mnst(nst),
         mxv(),
         mm() {}
 
   /** To set TokVal from a Vector. */
   TokVal(Vector xv)
-      : mtype(Vector_t), ms(), mn(-1), mx(0.), msv(), mnv(), mxv(xv), mm() {}
+      : mtype(Vector_t), ms(), mn(-1), mx(0.), msv(), mnv(), mnst(), mxv(xv), mm() {}
 
   /** To set TokVal from a Matrix. */
   TokVal(Matrix m)
-      : mtype(Matrix_t), ms(), mn(-1), mx(0.), msv(), mnv(), mxv(), mm(m) {}
+      : mtype(Matrix_t), ms(), mn(-1), mx(0.), msv(), mnv(), mnst(), mxv(), mm(m) {}
 
   // Conversion functions to return TokVal for the 6 different types:
 
@@ -102,6 +118,8 @@ class TokVal {
   operator ArrayOfString() const;
   /** Return array of integers. */
   operator ArrayOfIndex() const;
+  /** Return array of integers. */
+  operator ArrayOfSpeciesTag() const;
   /** Return Vector. */
   operator Vector() const;
   /** Return Matrix. */
@@ -117,6 +135,7 @@ class TokVal {
   Numeric mx;
   ArrayOfString msv;
   ArrayOfIndex mnv;
+  ArrayOfSpeciesTag mnst;
   Vector mxv;
   Matrix mm;
 };


### PR DESCRIPTION
Select a single `ArrayOfSpeciesTag` in `propmat_clearskyAddLines`.  This is in preparation for updating the lookup table.

Note limitations: If the default value of the species is not `""` or `NODEF`, the `autoarts.h` will fail to compile the test.  I think this should be quite OK and even desirable.  There's no use of having a non-empty default here (either by true empty, or by user having to choose themselves).

Note opinion: This adds `ArrayOfSpeciesTag` to the things that the parser deals with.  It expects the input to be the same as for `abs_speciesSet`.  This goes against how `Vector` and other array-types are created.  They have the form `[...]`.  I think it is better to treat `ArrayOfSpeciesTag` as its own type rather than an array, because that's how it is most often used in deep code, and how the user sees it in other places of the controlfile.

Note for future: I think `TokVal` is a bit over-designed for current generation C++.  It obviously works, but it is a bit difficult to add new types.  To do so, `TokVal` itself has to grow.  We should possibly change `TokVal` so that all classes with constructors in either the form of `class T { T(const String& s); };` or of the form `class T { T(const std::string_view sv); };` can be parsed.  It is easier to wait for C++20 for such changes as it should allow for `requires`-clauses to deal with most of the logic.  (`ArrayOfSpeciesTag` would have been redesigned using Simon's trick, and have a constructor that takes a `String` and wraps it around `array_species_tag_from_string`.)  I am not intending to do any of this in this PR but just venting an idea after having added `ArrayOfSpeciesTag`.