### PR TITLE
Fix debug build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,6 +15,7 @@ jobs:
           ubuntu-gcc-8,
           ubuntu-gcc-9,
           ubuntu-gcc-10,
+          ubuntu-gcc-10-debug,
           ubuntu-clang-11-nofortran,
           macos-gcc-10,
         ]
@@ -29,6 +30,7 @@ jobs:
             fortran: "no"
             check: "no"
             libcxx: "no"
+            buildtype: "Release"
 
           - name: ubuntu-gcc-8
             os: ubuntu-18.04
@@ -39,6 +41,7 @@ jobs:
             fortran: "yes"
             check: "yes"
             libcxx: "no"
+            buildtype: "Release"
 
           - name: ubuntu-gcc-9
             os: ubuntu-18.04
@@ -49,6 +52,7 @@ jobs:
             fortran: "yes"
             check: "yes"
             libcxx: "no"
+            buildtype: "Release"
 
           - name: ubuntu-gcc-10
             os: ubuntu-18.04
@@ -59,6 +63,18 @@ jobs:
             fortran: "yes"
             check: "yes"
             libcxx: "no"
+            buildtype: "Release"
+
+          - name: ubuntu-gcc-10-debug
+            os: ubuntu-18.04
+            compiler: gcc
+            version: "10"
+            doc: "no"
+            arts: "yes"
+            fortran: "yes"
+            check: "yes"
+            libcxx: "no"
+            buildtype: "RelWithDebInfo"
 
           - name: ubuntu-clang-11-nofortran
             os: ubuntu-18.04
@@ -69,6 +85,7 @@ jobs:
             fortran: "no"
             check: "yes"
             libcxx: "yes"
+            buildtype: "Release"
 
           - name: macos-gcc-10
             os: macos-latest
@@ -79,6 +96,7 @@ jobs:
             fortran: "yes"
             check: "yes"
             libcxx: "no"
+            buildtype: "Release"
 
     steps:
       - uses: actions/checkout@v1
@@ -151,7 +169,7 @@ jobs:
         run: |
           mkdir cmake-build
           cd cmake-build
-          cmake -DENABLE_FORTRAN=$USEFORTRAN ..
+          cmake -DCMAKE_BUILD_TYPE=${{ matrix.buildtype }} -DENABLE_FORTRAN=$USEFORTRAN ..
 
       - name: Build (Linux / macOS)
         if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.arts == 'yes'

--- a/src/arts_api.cc
+++ b/src/arts_api.cc
@@ -141,6 +141,10 @@ void agenda_insert_set(InteractiveWorkspace *workspace,
     if (wsv_group_names[group_id] == "Matrix") {
       t = TokVal(*reinterpret_cast<Matrix *>(workspace->operator[](id)));
     }
+    // ArrayOfSpeciesTag
+    if (wsv_group_names[group_id] == "ArrayOfSpeciesTag") {
+      t = TokVal(*reinterpret_cast<ArrayOfSpeciesTag *>(workspace->operator[](id)));
+    }
     mr = MRecord(m_id, output, input, t, Agenda{});
   }
   a->push_back(mr);

--- a/src/token.cc
+++ b/src/token.cc
@@ -60,7 +60,7 @@ TokVal::operator ArrayOfIndex() const {
 }
 
 TokVal::operator ArrayOfSpeciesTag() const {
-  ARTS_ASSERT(mtype == Array_SpeciesTa_t);
+  ARTS_ASSERT(mtype == Array_SpeciesTag_t);
   return mnst;
 }
 


### PR DESCRIPTION
Since we switched to Release builds by default, the CI was not building
any debug versions anymore. This let bugs only triggered in debug mode
slip past.

Fixed by adding one debug build with gcc.