### PR TITLE
Make manual mirroring mirror ARTS v2.3.1277 behavior

### DIFF
--- a/src/absorptionlines.cc
+++ b/src/absorptionlines.cc
@@ -3379,7 +3379,7 @@ Numeric Lines::F_mean(const ConstVectorView wgts) const noexcept {
 Numeric Lines::CutoffFreq(size_t k, Numeric shift) const noexcept {
   switch(mcutoff) {
     case CutoffType::ByLine:
-      return F0(k) + shift + mcutofffreq;
+      return F0(k) + mcutofffreq + (mmirroring == MirroringType::Manual ? - shift : shift);
     case CutoffType::None:
       return std::numeric_limits<Numeric>::max();
     case CutoffType::FINAL: break;
@@ -3392,7 +3392,7 @@ Numeric Lines::CutoffFreq(size_t k, Numeric shift) const noexcept {
 Numeric Lines::CutoffFreqMinus(size_t k, Numeric shift) const noexcept {
   switch(mcutoff) {
     case CutoffType::ByLine:
-      return F0(k) + shift - mcutofffreq;
+      return F0(k) - mcutofffreq + (mmirroring == MirroringType::Manual ? - shift : shift);
     case CutoffType::None:
       return std::numeric_limits<Numeric>::lowest();
     case CutoffType::FINAL: break;

--- a/src/lineshape.cc
+++ b/src/lineshape.cc
@@ -1926,7 +1926,9 @@ VibrationalTemperaturesNonLocalThermodynamicEquilibrium::
 
 Calculator line_shape_selection(const Type type, const Numeric F0,
                                 const Output &X, const Numeric DC,
-                                const Numeric DZ) {
+                                const Numeric DZ, bool manually_mirrored) {
+  if (manually_mirrored) return Noshape{};
+  
   switch (type) {
   case Type::DP:
     return Doppler(F0, DC, DZ);
@@ -1953,9 +1955,9 @@ Calculator mirror_line_shape_selection(const Absorption::MirroringType mirror,
   case Absorption::MirroringType::Lorentz:
     return Lorentz(-F0, mirroredOutput(X));
   case Absorption::MirroringType::SameAsLineShape:
-    return line_shape_selection(type, -F0, mirroredOutput(X), -DC, -DZ);
+    return line_shape_selection(type, -F0, mirroredOutput(X), -DC, -DZ, false);
   case Absorption::MirroringType::Manual:
-    return Noshape{};
+    return line_shape_selection(type, F0, mirroredOutput(X), -DC, -DZ, false);
   case Absorption::MirroringType::None:
     return Noshape{};
   case Absorption::MirroringType::FINAL: { /*leave last*/
@@ -2857,7 +2859,7 @@ void cutoff_loop_sparse_linear(ComputeData &com,
     const Numeric dfdH = do_zeeman ? band.ZeemanSplitting(i, zeeman_polarization, iz) : 0;
     const Numeric Sz = do_zeeman ? band.ZeemanStrength(i, zeeman_polarization, iz) : 1;
     const Complex LM = Complex(1 + X.G, -X.Y);
-    Calculator ls = line_shape_selection(band.LineShapeType(), band.F0(i), X, DC, dfdH * H);
+    Calculator ls = line_shape_selection(band.LineShapeType(), band.F0(i), X, DC, dfdH * H, band.Mirroring() == Absorption::MirroringType::Manual);
     Calculator ls_mirr = mirror_line_shape_selection(band.Mirroring(), band.LineShapeType(), band.F0(i), X, DC, dfdH * H);
     
     if (do_cutoff) {
@@ -2939,7 +2941,7 @@ void cutoff_loop_sparse_triple(ComputeData &com,
     const Numeric dfdH = do_zeeman ? band.ZeemanSplitting(i, zeeman_polarization, iz) : 0;
     const Numeric Sz = do_zeeman ? band.ZeemanStrength(i, zeeman_polarization, iz) : 1;
     const Complex LM = Complex(1 + X.G, -X.Y);
-    Calculator ls = line_shape_selection(band.LineShapeType(), band.F0(i), X, DC, dfdH * H);
+    Calculator ls = line_shape_selection(band.LineShapeType(), band.F0(i), X, DC, dfdH * H, band.Mirroring() == Absorption::MirroringType::Manual);
     Calculator ls_mirr = mirror_line_shape_selection(band.Mirroring(), band.LineShapeType(), band.F0(i), X, DC, dfdH * H);
     
     if (do_cutoff) {
@@ -3047,7 +3049,7 @@ void cutoff_loop(ComputeData &com,
     const Numeric dfdH = do_zeeman ? band.ZeemanSplitting(i, zeeman_polarization, iz) : 0;
     const Numeric Sz = do_zeeman ? band.ZeemanStrength(i, zeeman_polarization, iz) : 1;
     const Complex LM = Complex(1 + X.G, -X.Y);
-    Calculator ls = line_shape_selection(band.LineShapeType(), band.F0(i), X, DC, dfdH * H);
+    Calculator ls = line_shape_selection(band.LineShapeType(), band.F0(i), X, DC, dfdH * H, band.Mirroring() == Absorption::MirroringType::Manual);
     Calculator ls_mirr = mirror_line_shape_selection(band.Mirroring(), band.LineShapeType(), band.F0(i), X, DC, dfdH * H);
     
     if (do_cutoff) {

--- a/src/m_absorptionlines.cc
+++ b/src/m_absorptionlines.cc
@@ -1458,6 +1458,39 @@ void abs_lines_per_speciesSetMirroringForSpecies(
   }
 }
 
+/* Workspace method: Doxygen documentation will be auto-generated */
+void abs_linesMakeManualMirroring(ArrayOfAbsorptionLines& abs_lines,
+                                  const Verbosity&) 
+{
+  const ArrayOfAbsorptionLines abs_lines_copy = abs_lines;
+  for (AbsorptionLines band: abs_lines_copy) {
+    band.Mirroring(Absorption::MirroringType::Manual);
+    
+    //! Don't allow running this function twice
+    ARTS_USER_ERROR_IF(
+      std::find_if(abs_lines_copy.cbegin(), abs_lines_copy.cend(),
+                   [&band](const AbsorptionLines& li){
+                     return band.Match(li);
+                   }) not_eq abs_lines_copy.cend(),
+      "Dual bands with same setup is not allowed for mirroring of band:\n",
+      band, '\n')
+    
+    for (auto& line: band.AllLines()) {
+      line.F0() *= -1;
+    }
+    
+    abs_lines.emplace_back(std::move(band));
+  }
+}
+
+/* Workspace method: Doxygen documentation will be auto-generated */
+void abs_lines_per_speciesMakeManualMirroring(ArrayOfArrayOfAbsorptionLines& abs_lines_per_species,
+                                              const Verbosity& verbosity) 
+{
+  for (auto& abs_lines: abs_lines_per_species) abs_linesMakeManualMirroring(abs_lines, verbosity);
+}
+
+
 /////////////////////////////////////////////////////////
 ///////////////////////////////// Change Population Style
 /////////////////////////////////////////////////////////

--- a/src/m_checked.cc
+++ b/src/m_checked.cc
@@ -888,10 +888,24 @@ void lbl_checkedCalc(Index& lbl_checked,
   for (auto& lines: abs_lines_per_species) {
     for (auto& band: lines) {
       
+      // Mirroring checks
+      for (auto& line: band.AllLines()) {
+        if (band.Mirroring() == Absorption::MirroringType::Manual) {
+          ARTS_USER_ERROR_IF(line.F0() >= 0,
+                             "Must have negative frequency, finds " , line.F0())
+        } else {
+          ARTS_USER_ERROR_IF(line.F0() <= 0,
+                             "Must have positive frequency, finds " , line.F0())
+        }
+      }
+      
       // Cutoff checks
       switch (band.Cutoff()) {
         case Absorption::CutoffType::None: break;
         case Absorption::CutoffType::ByLine: {
+          ARTS_USER_ERROR_IF (not (band.Mirroring() == Absorption::MirroringType::None or
+                                   band.Mirroring() == Absorption::MirroringType::Manual),
+                              "Cutoff only possible with symmetric mirroring types")
           ARTS_USER_ERROR_IF(Absorption::relaxationtype_relmat(band.Population()),
                              "Cannot have relaxation matrix line mixing with cutoff calculations")
           ARTS_USER_ERROR_IF (not (band.LineShapeType() == LineShape::Type::DP or

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -863,6 +863,35 @@ void define_md_data_raw() {
                       "The species tag from *abs_species* to change")));
 
   md_data_raw.push_back(
+      create_mdrecord(NAME("abs_linesMakeManualMirroring"),
+               DESCRIPTION("Makes a copy of all lines at negative frequency setting them.\n"
+                           "to manual mirroring mode\n"),
+               AUTHORS("Richard Larsson"),
+               OUT("abs_lines"),
+               GOUT(),
+               GOUT_TYPE(),
+               GOUT_DESC(),
+               IN("abs_lines"),
+               GIN(),
+               GIN_TYPE(),
+               GIN_DEFAULT(),
+               GIN_DESC()));
+
+  md_data_raw.push_back(
+      create_mdrecord(NAME("abs_lines_per_speciesMakeManualMirroring"),
+               DESCRIPTION("See *abs_linesMakeManualMirroring*\n"),
+               AUTHORS("Richard Larsson"),
+               OUT("abs_lines_per_species"),
+               GOUT(),
+               GOUT_TYPE(),
+               GOUT_DESC(),
+               IN("abs_lines_per_species"),
+               GIN(),
+               GIN_TYPE(),
+               GIN_DEFAULT(),
+               GIN_DESC()));
+
+  md_data_raw.push_back(
       create_mdrecord(NAME("abs_linesSetPopulation"),
                DESCRIPTION("Sets population type for all lines.\n"
                            "\n"


### PR DESCRIPTION
Manual mirroring now behaves the same as in older versions before the line shape shifts.  I managed to mess up the direction of the shifts because those weren't required to be mirrored in old ARTS.

After creating `abs_lines`, running the new `abs_linesMakeManualMirroring` once should be enough to copy the old behavior of running `abs_lines_per_speciesAddMirrorLines`.  Perhaps some names should be updated.

@stuartfox , can you check that this works for you?  I ran your two tests `test_v2.3.1277.arts `and `test_v2.5.arts` with your default settings and with the two function calls above to check the difference and the versions seem to be close enough now.