### PR TITLE
Add abs_lines_per_speciesMakeManualMirroringSpecies

### DIFF
--- a/src/m_absorptionlines.cc
+++ b/src/m_absorptionlines.cc
@@ -1498,7 +1498,8 @@ void abs_lines_per_speciesMakeManualMirroringSpecies(ArrayOfArrayOfAbsorptionLin
 {
   ARTS_USER_ERROR_IF(abs_species.size() not_eq abs_lines_per_species.size(),
     "Mismatch abs_species and abs_lines_per_species sizes [",
-    abs_species.size(), " vs ", abs_lines_per_species.size())
+    abs_species.size(), " vs ", abs_lines_per_species.size(),
+    ", respectively]")
   
   if (auto ind = std::distance(abs_species.cbegin(), std::find(abs_species.cbegin(), abs_species.cend(), species)); ind not_eq abs_species.nelem()) {
     abs_linesMakeManualMirroring(abs_lines_per_species[ind], verbosity);

--- a/src/m_absorptionlines.cc
+++ b/src/m_absorptionlines.cc
@@ -1490,6 +1490,23 @@ void abs_lines_per_speciesMakeManualMirroring(ArrayOfArrayOfAbsorptionLines& abs
   for (auto& abs_lines: abs_lines_per_species) abs_linesMakeManualMirroring(abs_lines, verbosity);
 }
 
+/* Workspace method: Doxygen documentation will be auto-generated */
+void abs_lines_per_speciesMakeManualMirroringSpecies(ArrayOfArrayOfAbsorptionLines& abs_lines_per_species,
+                                                     const ArrayOfArrayOfSpeciesTag& abs_species,
+                                                     const ArrayOfSpeciesTag& species,
+                                                     const Verbosity& verbosity) 
+{
+  ARTS_USER_ERROR_IF(abs_species.size() not_eq abs_lines_per_species.size(),
+    "Mismatch abs_species and abs_lines_per_species sizes [",
+    abs_species.size(), " vs ", abs_lines_per_species.size())
+  
+  if (auto ind = std::distance(abs_species.cbegin(), std::find(abs_species.cbegin(), abs_species.cend(), species)); ind not_eq abs_species.nelem()) {
+    abs_linesMakeManualMirroring(abs_lines_per_species[ind], verbosity);
+  } else {
+    ARTS_USER_ERROR("Cannot find species: ", species, "\nIn abs_species: [", abs_species, ']')
+  }
+}
+
 
 /////////////////////////////////////////////////////////
 ///////////////////////////////// Change Population Style

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -892,6 +892,20 @@ void define_md_data_raw() {
                GIN_DESC()));
 
   md_data_raw.push_back(
+      create_mdrecord(NAME("abs_lines_per_speciesMakeManualMirroringSpecies"),
+               DESCRIPTION("Calls *abs_linesMakeManualMirroring* for given species in *abs_species*\n"),
+               AUTHORS("Richard Larsson"),
+               OUT("abs_lines_per_species"),
+               GOUT(),
+               GOUT_TYPE(),
+               GOUT_DESC(),
+               IN("abs_lines_per_species", "abs_species"),
+               GIN("species"),
+               GIN_TYPE("ArrayOfSpeciesTag"),
+               GIN_DEFAULT(NODEF),
+               GIN_DESC("Species to mirror")));
+
+  md_data_raw.push_back(
       create_mdrecord(NAME("abs_linesSetPopulation"),
                DESCRIPTION("Sets population type for all lines.\n"
                            "\n"


### PR DESCRIPTION
@stuartfox After this merge, you will be able to do

```
abs_lines_per_speciesMakeManualMirroringSpecies(species="H2O")
```

The string input as a species must be the full string you use to define a species tag group.  So if your full definition is something like:

```
abs_speciesSet(species=["H2O,H2O-SelfContStandardType", "O3", "Some", "Other,Species"])
```

then you have to write something like:

```
abs_lines_per_speciesMakeManualMirroringSpecies(species="H2O,H2O-SelfContStandardType")
```

(Spaces are still optional)