### PR TITLE
Add remove functions to make the line catalog smaller

### DIFF
--- a/src/m_absorptionlines.cc
+++ b/src/m_absorptionlines.cc
@@ -2522,7 +2522,7 @@ void remove_impl(ArrayOfAbsorptionLines& abs_lines,
       const bool all_upp = std::all_of(lines.begin(), lines.end(),
                                        [upper_frequency] (auto& line) {return line.F0() > upper_frequency;});
       const bool low_int = std::all_of(lines.begin(), lines.end(),
-                                       [lower_intensity] (auto& line) {return line.F0() < lower_intensity;});
+                                       [lower_intensity] (auto& line) {return line.I0() < lower_intensity;});
       if (all_low or all_upp or low_int) lines.resize(0);
     }
   }

--- a/src/m_absorptionlines.cc
+++ b/src/m_absorptionlines.cc
@@ -2485,3 +2485,91 @@ void abs_linesPrintDefinedQuantumNumbers(const ArrayOfAbsorptionLines& abs_lines
     out0 << QuantumNumberType(qn.first) << ':' << ' ' << qn.second << '\n';
   }
 }
+
+
+/////////////////////////////////////////////////////////
+//////////////////// Remove lines safely from the catalog
+/////////////////////////////////////////////////////////
+
+void remove_impl(ArrayOfAbsorptionLines& abs_lines,
+                 const ArrayOfSpeciesTag& species,
+                 const Numeric lower_frequency,
+                 const Numeric upper_frequency,
+                 const Numeric lower_intensity,
+                 const Index safe,
+                 const Verbosity& verbosity) {
+  const bool care_about_species = species.nelem();
+  
+  for (auto& band: abs_lines) {
+    if (care_about_species and species[0].Isotopologue() not_eq band.Isotopologue()) continue;
+    
+    auto& lines = band.AllLines();
+    
+    if (not safe) {
+      std::vector<std::size_t> rem;
+      for (std::size_t i=lines.size()-1; i<lines.size(); i--) {
+        auto& line = lines[i];
+        if (line.F0() < lower_frequency or
+            line.F0() > upper_frequency or
+            line.I0() < lower_intensity)
+          rem.push_back(i);
+      }
+      
+      for (auto i: rem) band.RemoveLine(i);
+    } else {
+      const bool all_low = std::all_of(lines.begin(), lines.end(),
+                                       [lower_frequency] (auto& line) {return line.F0() < lower_frequency;});
+      const bool all_upp = std::all_of(lines.begin(), lines.end(),
+                                       [upper_frequency] (auto& line) {return line.F0() > upper_frequency;});
+      const bool low_int = std::all_of(lines.begin(), lines.end(),
+                                       [lower_intensity] (auto& line) {return line.F0() < lower_intensity;});
+      if (all_low or all_upp or low_int) lines.resize(0);
+    }
+  }
+  
+  // Removes empty bands
+  abs_linesRemoveEmptyBands(abs_lines, verbosity);
+}
+
+void abs_linesRemoveLines(ArrayOfAbsorptionLines& abs_lines,
+                          const Numeric& lower_frequency,
+                          const Numeric& upper_frequency,
+                          const Numeric& lower_intensity,
+                          const Index& safe,
+                          const Verbosity& verbosity) {
+  remove_impl(abs_lines, {}, lower_frequency, upper_frequency, lower_intensity, safe, verbosity);
+}
+
+void abs_lines_per_speciesRemoveLines(ArrayOfArrayOfAbsorptionLines& abs_lines_per_species,
+                                      const Numeric& lower_frequency,
+                                      const Numeric& upper_frequency,
+                                      const Numeric& lower_intensity,
+                                      const Index& safe,
+                                      const Verbosity& verbosity) {
+  for (auto& abs_lines: abs_lines_per_species)
+    abs_linesRemoveLines(abs_lines, lower_frequency, upper_frequency, lower_intensity, safe, verbosity);
+}
+
+void abs_linesRemoveLinesFromSpecies(ArrayOfAbsorptionLines& abs_lines,
+                                     const ArrayOfSpeciesTag& species,
+                                     const Numeric& lower_frequency,
+                                     const Numeric& upper_frequency,
+                                     const Numeric& lower_intensity,
+                                     const Index& safe,
+                                     const Verbosity& verbosity) {
+  ARTS_USER_ERROR_IF(species.nelem() not_eq 1, "Must have a single species, got: ", species)
+  ARTS_USER_ERROR_IF(species[0].Isotopologue().joker(), "Cannot give joker species, got: ", species)
+  
+  remove_impl(abs_lines, species, lower_frequency, upper_frequency, lower_intensity, safe, verbosity);
+}
+
+void abs_lines_per_speciesRemoveLinesFromSpecies(ArrayOfArrayOfAbsorptionLines& abs_lines_per_species,
+                                                 const ArrayOfSpeciesTag& species,
+                                                 const Numeric& lower_frequency,
+                                                 const Numeric& upper_frequency,
+                                                 const Numeric& lower_intensity,
+                                                 const Index& safe,
+                                                 const Verbosity& verbosity) {
+  for (auto& abs_lines: abs_lines_per_species)
+    abs_linesRemoveLinesFromSpecies(abs_lines, species, lower_frequency, upper_frequency, lower_intensity, safe, verbosity);
+}

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -475,6 +475,89 @@ void define_md_data_raw() {
       GIN_DESC("Band ID")));
 
   md_data_raw.push_back(create_mdrecord(
+    NAME("abs_linesRemoveLines"),
+      DESCRIPTION("Remove lines *abs_lines* outside of specifications\n"
+        "\n"
+        "The specifications are:\n"
+        "\tThe lower frequency bound (all lines of this frequency or higher may be kept)\n"
+        "\tThe upper frequency bound (all lines of this frequency or lower may be kept)\n"
+        "\tThe lower intensity bound (all lines with lower intensity may be removed)\n"
+        "\n"
+        "If safe evaluates true, all lines in an absorption band must fail the above tests to be removed\n"
+      ),
+      AUTHORS("Richard Larsson"),
+      OUT("abs_lines"),
+      GOUT(),
+      GOUT_TYPE(),
+      GOUT_DESC(),
+      IN("abs_lines"),
+      GIN("lower_frequency", "upper_frequency", "lower_intensity", "safe"),
+      GIN_TYPE("Numeric", "Numeric", "Numeric", "Index"),
+      GIN_DEFAULT("-1e99", "1e99", "0", "1"),
+      GIN_DESC("The lower frequency bound",
+        "The upper frequency bound",
+        "The lower intensity bound",
+        "Remove only lines from a band if all lines of a band fail")));
+
+  md_data_raw.push_back(create_mdrecord(
+    NAME("abs_lines_per_speciesRemoveLines"),
+      DESCRIPTION("Repeats *abs_linesRemoveLines* for all inner arrays\n"
+      ),
+      AUTHORS("Richard Larsson"),
+      OUT("abs_lines_per_species"),
+      GOUT(),
+      GOUT_TYPE(),
+      GOUT_DESC(),
+      IN("abs_lines_per_species"),
+      GIN("lower_frequency", "upper_frequency", "lower_intensity", "safe"),
+      GIN_TYPE("Numeric", "Numeric", "Numeric", "Index"),
+      GIN_DEFAULT("-1e99", "1e99", "0", "1"),
+      GIN_DESC("The lower frequency bound",
+        "The upper frequency bound",
+        "The lower intensity bound",
+        "Remove only lines from a band if all lines of a band fail")));
+
+  md_data_raw.push_back(create_mdrecord(
+    NAME("abs_linesRemoveLinesFromSpecies"),
+      DESCRIPTION("As *abs_linesRemoveLines* but only for bands of the given species\n"
+      "\n"
+      "speices must be a single entry, and must specify the isotopologue\n"
+      ),
+      AUTHORS("Richard Larsson"),
+      OUT("abs_lines"),
+      GOUT(),
+      GOUT_TYPE(),
+      GOUT_DESC(),
+      IN("abs_lines"),
+      GIN("species", "lower_frequency", "upper_frequency", "lower_intensity", "safe"),
+      GIN_TYPE("ArrayOfSpeciesTag", "Numeric", "Numeric", "Numeric", "Index"),
+      GIN_DEFAULT(NODEF, "-1e99", "1e99", "0", "1"),
+      GIN_DESC("Species to be removed",
+        "The lower frequency bound",
+        "The upper frequency bound",
+        "The lower intensity bound",
+        "Remove only lines from a band if all lines of a band fail")));
+
+  md_data_raw.push_back(create_mdrecord(
+    NAME("abs_lines_per_speciesRemoveLinesFromSpecies"),
+      DESCRIPTION("Repeats *abs_linesRemoveLinesFromSpecies* for all inner arrays\n"
+      ),
+      AUTHORS("Richard Larsson"),
+      OUT("abs_lines_per_species"),
+      GOUT(),
+      GOUT_TYPE(),
+      GOUT_DESC(),
+      IN("abs_lines_per_species"),
+      GIN("species", "lower_frequency", "upper_frequency", "lower_intensity", "safe"),
+      GIN_TYPE("ArrayOfSpeciesTag", "Numeric", "Numeric", "Numeric", "Index"),
+      GIN_DEFAULT(NODEF, "-1e99", "1e99", "0", "1"),
+      GIN_DESC("Species to be removed",
+        "The lower frequency bound",
+        "The upper frequency bound",
+        "The lower intensity bound",
+        "Remove only lines from a band if all lines of a band fail")));
+
+  md_data_raw.push_back(create_mdrecord(
     NAME("abs_linesRemoveEmptyBands"),
       DESCRIPTION("Removes emtpy bands from *abs_lines*\n"),
       AUTHORS("Richard Larsson"),

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -521,7 +521,7 @@ void define_md_data_raw() {
     NAME("abs_linesRemoveLinesFromSpecies"),
       DESCRIPTION("As *abs_linesRemoveLines* but only for bands of the given species\n"
       "\n"
-      "speices must be a single entry, and must specify the isotopologue\n"
+      "species must be a single entry, and must specify the isotopologue\n"
       ),
       AUTHORS("Richard Larsson"),
       OUT("abs_lines"),


### PR DESCRIPTION
This allows removing lines from the catalog that are outside some frequency range or are just too weak to want considering.  There's a (default true) safe argument to not mess up line mixing and other stuff requiring the entire band.