### PR TITLE
Bug fix to MT-CKD v3.2 H2O foreign continuum

### DIFF
--- a/src/legacy_continua.cc
+++ b/src/legacy_continua.cc
@@ -6485,8 +6485,8 @@ void PWR98H2OAbsModel(MatrixView pxsec,
     Numeric pvap = Pa_to_hPa * abs_p[i] * vmr[i];
     // dry air partial pressure [hPa]
     Numeric pda = (Pa_to_hPa * abs_p[i]) - pvap;
-    // Rosenkranz number density  (Rosenkranz H2O mass density in [g/mï¿½])
-    // [g/mï¿½]    =  [g*K / Pa*mï¿½]  *  [Pa/K]
+    // Rosenkranz number density  (Rosenkranz H2O mass density in [g/m³])
+    // [g/m³]    =  [g*K / Pa*m³]  *  [Pa/K]
     // rho       =   (M_H2O / R)   *  (P_H2O / T)
     // rho       =      2.1667     *  abs_p * vmr / abs_t
     // den       = 3.335e16 * rho
@@ -6666,7 +6666,7 @@ void CP98H2OAbsModel(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of the
                             H2O-H2O continuum [1/m]
-   \param    Cin            constant absorption strength     [1/m / (Hz*Pa)ï¿½]
+   \param    Cin            constant absorption strength     [1/m / (Hz*Pa)²]
    \param    xin            temperature exponent of (300/T)  [1]
    \param    model          allows user defined input parameter set
                             (C and x)<br> or choice of
@@ -6699,16 +6699,16 @@ void Standard_H2O_self_continuum(MatrixView pxsec,
 
   // --------- STANDARD MODEL PARAMETERS ---------------------------------------------------
   // standard values for the Rosenkranz model (Radio Science, 33(4), 919, 1998):
-  const Numeric Cs_PWR = 1.796e-33;  //  [1/m / (Hzï¿½*Paï¿½)]
+  const Numeric Cs_PWR = 1.796e-33;  //  [1/m / (Hz²*Pa²)]
   const Numeric xs_PWR = 4.5;        //  [1]
   // standard values for the Cruz-Pol model (Radio Science, 33(5), 1319, 1998):
-  const Numeric Cs_CP = 1.851e-33;  //  [1/m / (Hzï¿½*Paï¿½)]
+  const Numeric Cs_CP = 1.851e-33;  //  [1/m / (Hz²*Pa²)]
   const Numeric xs_CP = 7.5;        //  [1]
   // standard values for the MPM89 model (Int. J. Inf. and Millim. Waves, 10(6), 1989, 631):
-  const Numeric Cs_MPM89 = 1.500e-33;  //  [1/m / (Hzï¿½*Paï¿½)]
+  const Numeric Cs_MPM89 = 1.500e-33;  //  [1/m / (Hz²*Pa²)]
   const Numeric xs_MPM89 = 7.5;        //  [1]
   // standard values for the MPM87 model (Radio Science, 20(5), 1985, 1069):
-  const Numeric Cs_MPM87 = 1.500e-33;  //  [1/m / (Hzï¿½*Paï¿½)]
+  const Numeric Cs_MPM87 = 1.500e-33;  //  [1/m / (Hz²*Pa²)]
   const Numeric xs_MPM87 = 7.5;        //  [1]
   // ---------------------------------------------------------------------------------------
 
@@ -6774,7 +6774,7 @@ void Standard_H2O_self_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of the
                             H2O-dry air continuum [1/m]
-   \param    Cin            constant absorption strength [1/m / (Hz*Pa)ï¿½]
+   \param    Cin            constant absorption strength [1/m / (Hz*Pa)²]
    \param    xin            temperature exponent         [1]
    \param    model          allows user defined input parameter set
                             (C and x)<br> or choice of
@@ -6808,16 +6808,16 @@ void Standard_H2O_foreign_continuum(MatrixView pxsec,
 
   // --------- STANDARD MODEL PARAMETERS ---------------------------------------------------
   // standard values for the Rosenkranz model (Radio Science, 33(4), 919, 1998):
-  const Numeric Cf_PWR = 5.43e-35;  //  [1/m / (Hzï¿½*Paï¿½)]
+  const Numeric Cf_PWR = 5.43e-35;  //  [1/m / (Hz²*Pa²)]
   const Numeric xf_PWR = 0.0;       //  [1]
   // standard values for the Cruz-Pol model (Radio Science, 33(5), 1319, 1998):
-  const Numeric Cf_CP = 5.85e-35;  //  [1/m / (Hzï¿½*Paï¿½)]
+  const Numeric Cf_CP = 5.85e-35;  //  [1/m / (Hz²*Pa²)]
   const Numeric xf_CP = 0.0;       //  [1]
   // standard values for the MPM89 model (Int. J. Inf. and Millim. Waves, 10(6), 1989, 631):
-  const Numeric Cf_MPM89 = 4.74e-35;  //  [1/m / (Hzï¿½*Paï¿½)]
+  const Numeric Cf_MPM89 = 4.74e-35;  //  [1/m / (Hz²*Pa²)]
   const Numeric xf_MPM89 = 0.0;       //  [1]
   // standard values for the MPM87 model (Radio Science, 20(5), 1985, 1069):
-  const Numeric Cf_MPM87 = 4.74e-35;  //  [1/m / (Hzï¿½*Paï¿½)]
+  const Numeric Cf_MPM87 = 4.74e-35;  //  [1/m / (Hz²*Pa²)]
   const Numeric xf_MPM87 = 0.0;       //  [1]
   // ---------------------------------------------------------------------------------------
 
@@ -6886,7 +6886,7 @@ void Standard_H2O_foreign_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             the H2O-dry air continuum [1/m]
-   \param    Cin            constant absorption strength [1/m / (Hz*Pa)ï¿½]
+   \param    Cin            constant absorption strength [1/m / (Hz*Pa)²]
    \param    xin            temperature exponent         [1]
    \param    model          allows user defined input parameter set
                             (C and x)<br> or choice of
@@ -6922,7 +6922,7 @@ void MaTipping_H2O_foreign_continuum(MatrixView pxsec,
   // the Cf value is originally given in dB/km/kPa^2/GHz^2.0389. the conversion factor is
   // then 1.0283E-28 to get arts units. Additionally the Cf value is divided by 1.08 to
   // get the Cf for air.
-  const Numeric Cf_MaTipping = 1.8590e-35;  //  [1/m / (Hzï¿½*Paï¿½)]
+  const Numeric Cf_MaTipping = 1.8590e-35;  //  [1/m / (Hz²*Pa²)]
   const Numeric xf_MaTipping = 4.6019;      //  [1]
   // ---------------------------------------------------------------------------------------
 
@@ -9093,12 +9093,12 @@ void CKD_mt_320_self_h2o(MatrixView pxsec,
 
   int I1 = (int)((V1C - SL296_ckd_mt_320_v1) / SL296_ckd_mt_320_dv);
   if (V1C < SL296_ckd_mt_320_v1) I1 = -1;
-  V1C = SL296_ckd_mt_320_v1 + (SL296_ckd_mt_320_dv * (Numeric)(I1-1));
+  V1C = SL296_ckd_mt_320_v1 + (SL296_ckd_mt_320_dv * (Numeric)I1);
 
   int I2 = (int)((V2C - SL296_ckd_mt_320_v1) / SL296_ckd_mt_320_dv);
 
   int NPTC = I2 - I1 + 3;
-  if (NPTC > SL296_ckd_mt_320_npt) NPTC = SL296_ckd_mt_320_npt + 4;
+  if (NPTC > SL296_ckd_mt_320_npt) NPTC = SL296_ckd_mt_320_npt + 1;
 
   V2C = V1C + SL296_ckd_mt_320_dv * (Numeric)(NPTC - 1);
 
@@ -9116,7 +9116,7 @@ void CKD_mt_320_self_h2o(MatrixView pxsec,
   Vector SH2OT1(NPTC + addF77fields, 0.);  // [cm^3/molecules]
 
   for (Index J = 1; J <= NPTC; ++J) {
-    Index I = I1 + (J - 1);
+    Index I = I1 + J;
     if ((I > 0) && (I <= SL296_ckd_mt_320_npt)) {
       SH2OT0[J] = SL296_ckd_mt_320[I];  // at T=296 K
       SH2OT1[J] = SL260_ckd_mt_320[I];  // at T=260 K
@@ -9332,12 +9332,12 @@ void CKD_mt_320_foreign_h2o(MatrixView pxsec,
 
   int I1 = (int)((V1C - FH2O_ckd_mt_320_v1) / FH2O_ckd_mt_320_dv);
   if (V1C < FH2O_ckd_mt_320_v1) I1 = -1;
-  V1C = FH2O_ckd_mt_320_v1 + (FH2O_ckd_mt_320_dv * (Numeric)(I1 - 1));
+  V1C = FH2O_ckd_mt_320_v1 + (FH2O_ckd_mt_320_dv * (Numeric)I1);
 
   int I2 = (int)((V2C - FH2O_ckd_mt_320_v1) / FH2O_ckd_mt_320_dv);
 
   int NPTC = I2 - I1 + 3;
-  if (NPTC > FH2O_ckd_mt_320_npt) NPTC = FH2O_ckd_mt_320_npt + 4;
+  if (NPTC > FH2O_ckd_mt_320_npt) NPTC = FH2O_ckd_mt_320_npt + 1;
 
   V2C = V1C + FH2O_ckd_mt_320_dv * (Numeric)(NPTC - 1);
 
@@ -9354,7 +9354,7 @@ void CKD_mt_320_foreign_h2o(MatrixView pxsec,
   Vector FH2OT0(NPTC + addF77fields, 0.);  // [cm^3/molecules]
 
   for (Index J = 1; J <= NPTC; ++J) {
-    Index I = I1 + (J - 1);
+    Index I = I1 + J;
     if ((I > 0) && (I <= FH2O_ckd_mt_320_npt)) {
       FH2OT0[J] = FH2O_ckd_mt_320[I];
     }
@@ -9390,8 +9390,7 @@ void CKD_mt_320_foreign_h2o(MatrixView pxsec,
       {
         // Scaling factor below 600cm-1 based on RHUBC-II campaign
         JFAC = (int)((VJ + 10e0) / 10e0 + 0.00001e0);
-        FSCAL = XFAC_RHU[JFAC + 1]; // +1 needed as XFAC_RHU is indexed from 0 in C
-                                    // code, FORTRAN code has DIMENSION -1, 61
+        FSCAL = XFAC_RHU[JFAC];
       } else  // same as from version 2.4 apart from the 630e0 in the VF2 equation
       {
         Numeric VDELSQ1 = pow((VJ - 255.67e0), 2e0);
@@ -11858,7 +11857,7 @@ void CKD24_H20(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             N2-continuum according to Rosenkranz, 1993 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
    \param    model          allows user defined input parameter set
                             (Cin and xTin)<br> or choice of
                             pre-defined parameters of specific models (see note below).
@@ -11938,7 +11937,7 @@ void Pardo_ATM_H2O_ForeignContinuum(MatrixView pxsec,
       // specific N2 but mainly caused by N2. Therefore the N2 vmr must be
       // canceled out here which is later in abs_coefCalc multiplied
       // (calculation: abs = vmr * pxsec):
-      pxsec(s, i) += C *  // strength [1/(m*Hzï¿½Paï¿½)]
+      pxsec(s, i) += C *  // strength [1/(m*Hz²Pa²)]
                      pow((f_grid[s] / (Numeric)2.25e11),
                          (Numeric)2.) *  // quadratic f dependence [1]
                      pow(((Numeric)300.0 / abs_t[i]),
@@ -12937,7 +12936,7 @@ void MPM92O2AbsModel(MatrixView pxsec,
   // Coefficients are from Liebe et al., AGARD CP-May93, Paper 3/1-10
   //         0           1            2       3        4      5      6
   //         f0          a1           a2      a3       a4     a5     a6
-  //        [GHz]     [kHz/hPa]      [1]   [MHz/hPa]  [1]    [10ï¿½/hPa]
+  //        [GHz]     [kHz/hPa]      [1]   [MHz/hPa]  [1]    [10³/hPa]
   const Numeric mpm92[44][7] = {
       {50.474238, 0.094, 9.694, 0.850, 0.0, 0.210, 0.685},     // 0
       {50.987749, 0.246, 8.694, 0.870, 0.0, 0.190, 0.680},     // 1
@@ -13208,7 +13207,7 @@ void TRE05O2AbsModel(MatrixView pxsec,
   // Coefficients are from Liebe et al., AGARD CP-May93, Paper 3/1-10
   //         0             1           2         3         4      5        6
   //         f0           a1           a2       a3        a4      a5       a6
-  //        [GHz]      [kHz/hPa]      [1]    [MHz/hPa]    [1]       [10ï¿½/hPa]
+  //        [GHz]      [kHz/hPa]      [1]    [MHz/hPa]    [1]       [10³/hPa]
   const Numeric tre05[44][7] = {
       {50.474214, 0.975 / 10, 9.651, 0.669, 0.0, 0.2566, 0.685},     // 37-
       {50.987745, 2.529 / 10, 8.653, 0.717, 0.0, 0.2246, 0.680},     // 35-
@@ -13474,7 +13473,7 @@ void MPM93O2AbsModel(MatrixView pxsec,
   // Coefficients are from Liebe et al., AGARD CP-May93, Paper 3/1-10
   //         0             1           2         3         4      5        6
   //         f0           a1           a2       a3        a4      a5       a6
-  //        [GHz]      [kHz/hPa]      [1]    [MHz/hPa]    [1]       [10ï¿½/hPa]
+  //        [GHz]      [kHz/hPa]      [1]    [MHz/hPa]    [1]       [10³/hPa]
   const Numeric mpm93[44][7] = {
       {50.474238, 0.094, 9.694, 0.890, 0.0, 0.240, 0.790},     // 0
       {50.987749, 0.246, 8.694, 0.910, 0.0, 0.220, 0.780},     // 1
@@ -13783,7 +13782,7 @@ void PWR93O2AbsModel(MatrixView pxsec,
       52.5424,  66.8368,  52.0214,  67.3696,  51.5034, 67.9009, 368.4984,
       424.7632, 487.2494, 715.3931, 773.8397, 834.1458};
 
-  // line strength at T=300K in [cmï¿½ * Hz]
+  // line strength at T=300K in [cm² * Hz]
   const Numeric S93[n_lines] = {
       0.2936E-14, 0.8079E-15, 0.2480E-14, 0.2228E-14, 0.3351E-14, 0.3292E-14,
       0.3721E-14, 0.3891E-14, 0.3640E-14, 0.4005E-14, 0.3227E-14, 0.3715E-14,
@@ -14201,7 +14200,7 @@ void MPM93_O2_continuum(MatrixView pxsec,
 
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             O2-continuum according to Rosenkranz 1993 [1/m]
-   \param    S0in           line strength [Kï¿½/(Hz*Pa*m)]
+   \param    S0in           line strength [K²/(Hz*Pa*m)]
    \param    G0in           line width [Hz/Pa]
    \param    XS0in          line strength temperature exponent  [1]
    \param    XG0in          line widths temperature exponent    [1]
@@ -14245,7 +14244,7 @@ void Rosenkranz_O2_continuum(MatrixView pxsec,
   // P. W. Rosenkranz, Chapter 2, in M. A. Janssen,
   // Atmospheric Remote Sensing by Microwave Radiometry, John Wiley & Sons, Inc., 1993
   // ftp://mesa.mit.edu/phil/lbl_rt
-  const Numeric S0_PWR93 = 1.11e-14;  // [Kï¿½/(Hz*Pa*m)] line strength
+  const Numeric S0_PWR93 = 1.11e-14;  // [K²/(Hz*Pa*m)] line strength
   const Numeric G0_PWR93 = 5600.000;  // line width [Hz/Pa]
   const Numeric XS0_PWR93 = 2.000;    // temperature dependence of line strength
   const Numeric XG0_PWR93 = 0.800;    // temperature dependence of line width
@@ -14647,7 +14646,7 @@ void MPM93_N2_continuum(MatrixView pxsec,
   const Numeric xf_MPM93 = 1.500;  // frequency exponent [1]
   const Numeric gxf_MPM93 =
       9.000 * xf_MPM93;  // needed for the unit conversion of G_MPM93
-  const Numeric S_MPM93 = 2.296e-31;  // line strength  [1/Paï¿½ * 1/Hz]
+  const Numeric S_MPM93 = 2.296e-31;  // line strength  [1/Pa² * 1/Hz]
   const Numeric G_MPM93 =
       1.930e-5 *
       pow((Numeric)10.000, -gxf_MPM93);  // frequency factor [1/Hz^xf]
@@ -14688,7 +14687,7 @@ void MPM93_N2_continuum(MatrixView pxsec,
        << " xf = " << xf << "\n";
 
   // unit conversion internally:
-  //const Numeric S0unitconv = 1.000e+13;  // x [1/(hPaï¿½*GHz)] => y [1/(paï¿½*Hz)]
+  //const Numeric S0unitconv = 1.000e+13;  // x [1/(hPa²*GHz)] => y [1/(pa²*Hz)]
   //const Numeric G0unitconv = pow(10.000, gxf);
 
   const Index n_p = abs_p.nelem();   // Number of pressure levels
@@ -14729,7 +14728,7 @@ void MPM93_N2_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             N2-continuum according to Rosenkranz, 1993 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
    \param    model          allows user defined input parameter set
                             (Cin and xTin)<br> or choice of
                             pre-defined parameters of specific models (see note below).
@@ -14809,13 +14808,13 @@ void Pardo_ATM_N2_dry_continuum(MatrixView pxsec,
         // specific N2 but mainly caused by N2. Therefore the N2 vmr must be
         // canceled out here which is later in abs_coefCalc multiplied
         // (calculation: abs = vmr * pxsec):
-        pxsec(s, i) += C *  // strength [1/(m*Hzï¿½Paï¿½)]
+        pxsec(s, i) += C *  // strength [1/(m*Hz²Pa²)]
                        pow((f_grid[s] / (Numeric)2.25e11),
-                           (Numeric)2.) *  // quadratic f dependence [Hzï¿½]
+                           (Numeric)2.) *  // quadratic f dependence [Hz²]
                        pow(((Numeric)300.0 / abs_t[i]),
                            (Numeric)3.5) *  // free T dependence      [1]
                        pow((pd / (Numeric)1.01300e5),
-                           (Numeric)2.) /  // quadratic p dependence [Paï¿½]
+                           (Numeric)2.) /  // quadratic p dependence [Pa²]
                        vmr[i];             // cancel the vmr dependency
       }
     }
@@ -14827,7 +14826,7 @@ void Pardo_ATM_N2_dry_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             N2-continuum according to Rosenkranz, 1993 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
    \param    xin            temperature exponent of N2-continuum [1]
    \param    model          allows user defined input parameter set
                             (Cin and xTin)<br> or choice of
@@ -14864,7 +14863,7 @@ void Rosenkranz_N2_self_continuum(MatrixView pxsec,
   // --------- STANDARD MODEL PARAMETERS ---------------------------------------------------
   // standard values for the Rosenkranz model (Chapter 2, pp 74, in M. A. Janssen,
   // "Atmospheric Remote Sensing by Microwave Radiometry", John Wiley & Sons, Inc., 1993
-  const Numeric C_PWR = 1.05e-38;  // [1/(Paï¿½*Hzï¿½*m)]
+  const Numeric C_PWR = 1.05e-38;  // [1/(Pa²*Hz²*m)]
   const Numeric x_PWR = 3.55;      // [1]
   // ---------------------------------------------------------------------------------------
 
@@ -14905,10 +14904,10 @@ void Rosenkranz_N2_self_continuum(MatrixView pxsec,
       // The second vmr of N2 will be multiplied at the stage of absorption
       // calculation: abs = vmr * pxsec.
       pxsec(s, i) +=
-          C *                                  // strength [1/(m*Hzï¿½Paï¿½)]
-          pow(f_grid[s], (Numeric)2.) *        // quadratic f dependence [Hzï¿½]
+          C *                                  // strength [1/(m*Hz²Pa²)]
+          pow(f_grid[s], (Numeric)2.) *        // quadratic f dependence [Hz²]
           pow((Numeric)300.0 / abs_t[i], x) *  // free T dependence      [1]
-          pow(abs_p[i], (Numeric)2.) *         // quadratic p dependence [Paï¿½]
+          pow(abs_p[i], (Numeric)2.) *         // quadratic p dependence [Pa²]
           vmr[i];                              // second N2-VMR at the stage
                                                // of absorption calculation
     }
@@ -14924,7 +14923,7 @@ void Rosenkranz_N2_self_continuum(MatrixView pxsec,
 
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             N2-continuum according to Rosenkranz, 1993 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
    \param    xfin           continuum frequency exponent [1]
    \param    xtin           continuum strength temperature exponent [1]
    \param    xpin           continuum strength pressure exponent [1]
@@ -14965,7 +14964,7 @@ void Standard_N2_self_continuum(MatrixView pxsec,
   // --------- STANDARD MODEL PARAMETERS ---------------------------------------------------
   // standard values for the Rosenkranz model, Chapter 2, pp 74, in M. A. Janssen,
   // "Atmospheric Remote Sensing by Microwave Radiometry", John Wiley & Sons, Inc., 1993
-  const Numeric C_GM = 1.05e-38;  // [1/(Paï¿½*Hzï¿½*m)]
+  const Numeric C_GM = 1.05e-38;  // [1/(Pa²*Hz²*m)]
   const Numeric xf_GM = 2.00;     // [1]
   const Numeric xt_GM = 3.55;     // [1]
   const Numeric xp_GM = 2.00;     // [1]
@@ -15016,7 +15015,7 @@ void Standard_N2_self_continuum(MatrixView pxsec,
       // The second N2-VMR will be multiplied at the stage of absorption
       // calculation: abs = vmr * pxsec.
       pxsec(s, i) +=
-          C *                                      // strength [1/(m*Hzï¿½Paï¿½)]
+          C *                                      // strength [1/(m*Hz²Pa²)]
           pow(((Numeric)300.00 / abs_t[i]), xt) *  // T dependence        [1]
           pow(f_grid[s], xf) *                     // f dependence    [Hz^xt]
           pow(abs_p[i], xp) *                      // p dependence    [Pa^xp]
@@ -15035,7 +15034,7 @@ void Standard_N2_self_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             CO2-CO2-continuum according to Rosenkranz, 1993 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
    \param    xin            continuum temperature exponent [1]
    \param    model          allows user defined input parameter set
                             (Cin and xin)<br> or choice of
@@ -15072,7 +15071,7 @@ void Rosenkranz_CO2_self_continuum(MatrixView pxsec,
   // --------- STANDARD MODEL PARAMETERS ---------------------------------------------------
   // P. W. Rosenkranz Chapter 2, pp 74, in M. A. Janssen,
   // "Atmospheric Remote Sensing by Microwave Radiometry", John Wiley & Sons, Inc., 1993
-  const Numeric C_PWR = 7.43e-37;  // [ 1/(Paï¿½*Hzï¿½*m) ]
+  const Numeric C_PWR = 7.43e-37;  // [ 1/(Pa²*Hz²*m) ]
   const Numeric x_PWR = 5.08;      // [ 1 ]
   // ---------------------------------------------------------------------------------------
 
@@ -15129,7 +15128,7 @@ void Rosenkranz_CO2_self_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             CO2-N2-continuum according to Rosenkranz, 1993 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
    \param    xin            continuum temperature exponent [1]
    \param    model          allows user defined input parameter set
                             (Cin and xin)<br> or choice of
@@ -15167,7 +15166,7 @@ void Rosenkranz_CO2_foreign_continuum(MatrixView pxsec,
 
   // --------- STANDARD MODEL PARAMETERS ---------------------------------------------------
   // "Atmospheric Remote Sensing by Microwave Radiometry", John Wiley & Sons, Inc., 1993
-  const Numeric C_PWR = 2.71e-37;  // default: 2.71*10^-37 1/(Paï¿½*Hzï¿½*m)
+  const Numeric C_PWR = 2.71e-37;  // default: 2.71*10^-37 1/(Pa²*Hz²*m)
   const Numeric x_PWR = 4.7;       // default: 4.7
   // ---------------------------------------------------------------------------------------
 
@@ -15224,7 +15223,7 @@ void Rosenkranz_CO2_foreign_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             CO2-CO2-continuum according to Ho et al 1966 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
    \param    xin            continuum temperature exponent [1]
    \param    model          allows user defined input parameter set
                             (Cin and xin)<br> or choice of
@@ -15259,7 +15258,7 @@ void Ho66_CO2_self_continuum(MatrixView pxsec,
 
   // --------- STANDARD MODEL PARAMETERS --------------------------------------
   // Values (after conversion for C) from abstract of Ho66:
-  const Numeric C_Ho66 = 1.70e-36;  // [ 1/(Paï¿½*Hzï¿½*m) ]
+  const Numeric C_Ho66 = 1.70e-36;  // [ 1/(Pa²*Hz²*m) ]
   const Numeric x_Ho66 = 5;         // [ 1 ]
   // --------------------------------------------------------------------------
 
@@ -15316,7 +15315,7 @@ void Ho66_CO2_self_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             CO2-CO2-continuum according to Ho et al 1966 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
    \param    xin            continuum temperature exponent [1]
    \param    model          allows user defined input parameter set
                             (Cin and xin)<br> or choice of
@@ -15353,7 +15352,7 @@ void Ho66_CO2_foreign_continuum(MatrixView pxsec,
 
   // --------- STANDARD MODEL PARAMETERS --------------------------------------
   // Values (after conversion for C) from abstract of Ho66:
-  const Numeric C_Ho66 = 4.23e-37;  // [ 1/(Paï¿½*Hzï¿½*m) ]
+  const Numeric C_Ho66 = 4.23e-37;  // [ 1/(Pa²*Hz²*m) ]
   const Numeric x_Ho66 = 5;         // [ 1 ]
   // --------------------------------------------------------------------------
 
@@ -15423,7 +15422,7 @@ void Ho66_CO2_foreign_continuum(MatrixView pxsec,
    \param    f_grid         predefined frequency grid       [Hz]
    \param    abs_p          predefined pressure grid        [Pa]
    \param    abs_t          predefined temperature grid     [K]
-   \param    vmr            suspended water droplet density profile [kg/mï¿½]
+   \param    vmr            suspended water droplet density profile [kg/m³]
                             (valid range (Tab.1 of reference): 0-0.005)
 
    \note     Except for  model 'user' the input parameters CCin, CGin, and CEin
@@ -15500,7 +15499,7 @@ void MPM93WaterDropletAbs(
 
   // Loop pressure/temperature:
   for (Index i = 0; i < n_p; ++i) {
-    // Check limits of suspended water droplet density ("vmr") [kg/mï¿½]
+    // Check limits of suspended water droplet density ("vmr") [kg/m³]
     if ((vmr[i] < low_lim_den) || (vmr[i] > high_lim_den)) {
       ostringstream os;
       os << "ERROR in MPM93WaterDropletAbs:\n"
@@ -15546,10 +15545,10 @@ void MPM93WaterDropletAbs(
                               (pow((f_grid[s] * Hz_to_GHz), (Numeric)2.) +
                                pow(gamma2, (Numeric)2.))));
         // the imaginary part of the complex refractivity of suspended liquid water particle [ppm]
-        // In MPM93 w is in g/mï¿½ and m is in g/cmï¿½. Because of the units used in arts,
+        // In MPM93 w is in g/m³ and m is in g/cm³. Because of the units used in arts,
         // a factor of 1.000e6 must be multiplied with the ratio (w/m):
-        // MPM93: (w/m)_MPM93  in   (g/mï¿½)/(g/cmï¿½)
-        // arts:  (w/m)_arts   in  (kg/mï¿½)/(kg/mï¿½)
+        // MPM93: (w/m)_MPM93  in   (g/m³)/(g/cm³)
+        // arts:  (w/m)_arts   in  (kg/m³)/(kg/m³)
         // =====> (w/m)_MPM93   =   1.0e6 * (w/m)_arts
         // the factor of 1.0e6 is included below in pxsec calculation.
         Numeric ImNw = 1.500 / m *
@@ -15578,7 +15577,7 @@ void MPM93WaterDropletAbs(
    \param    f_grid         predefined frequency grid       [Hz]
    \param    abs_p          predefined pressure grid        [Pa]
    \param    abs_t          predefined temperature grid     [K]
-   \param    vmr            suspended water droplet density profile [kg/mï¿½]
+   \param    vmr            suspended water droplet density profile [kg/m³]
                             (valid range (Tab.1 of MPM93): 0-0.005)
 
    \note     Allowed models: 'ELL07'.
@@ -15664,7 +15663,7 @@ void ELL07WaterDropletAbs(
 
   // Loop pressure/temperature:
   for (Index i = 0; i < n_p; ++i) {
-    // Check limits of suspended water droplet density ("vmr") [kg/mï¿½]
+    // Check limits of suspended water droplet density ("vmr") [kg/m³]
     if ((vmr[i] < low_lim_den) || (vmr[i] > high_lim_den)) {
       ostringstream os;
       os << "ERROR in ELL07WaterDropletAbs:\n"
@@ -15761,10 +15760,10 @@ void ELL07WaterDropletAbs(
                                     (Numeric)2.)));
 
         // the imaginary part of the complex refractivity of suspended liquid water particle [ppm]
-        // In MPM93 w is in g/mï¿½ and m is in g/cmï¿½. Because of the units used in arts,
+        // In MPM93 w is in g/m³ and m is in g/cm³. Because of the units used in arts,
         // a factor of 1.000e6 must be multiplied with the ratio (w/m):
-        // MPM93: (w/m)_MPM93  in   (g/mï¿½)/(g/cmï¿½)
-        // arts:  (w/m)_arts   in  (kg/mï¿½)/(kg/mï¿½)
+        // MPM93: (w/m)_MPM93  in   (g/m³)/(g/cm³)
+        // arts:  (w/m)_arts   in  (kg/m³)/(kg/m³)
         // =====> (w/m)_MPM93   =   1.0e6 * (w/m)_arts
         // the factor of 1.0e6 is included below in pxsec calculation.
         Numeric ImNw = 1.500 / m *
@@ -15799,7 +15798,7 @@ void ELL07WaterDropletAbs(
    \param    f_grid         predefined frequency grid       [Hz]
    \param    abs_p          predefined pressure grid        [Pa]
    \param    abs_t          predefined temperature grid     [K]
-   \param    vmr            suspended water droplet density profile [kg/mï¿½]
+   \param    vmr            suspended water droplet density profile [kg/m³]
                             (valid range (Tab.1 of reference): 0-0.001)
 
    \note     Except for  model 'user' the input parameters CCin, CAin, and CBin
@@ -15827,7 +15826,7 @@ void MPM93IceCrystalAbs(
     ConstVectorView abs_p,   // pressure vector
     ConstVectorView abs_t,   // temperature vector
     ConstVectorView vmr,     // suspended ice particle density vector,
-                             // valid range: 0-1.0e-3 kg/mï¿½
+                             // valid range: 0-1.0e-3 kg/m³
     const Verbosity &) {
   // --------- STANDARD MODEL PARAMETERS ------------------------------------------------
   // standard values for the MPM93 model (J. Liebe and G. A. Hufford and M. G. Cotton,
@@ -15858,11 +15857,11 @@ void MPM93IceCrystalAbs(
   }
 
   const Numeric m =
-      0.916e3;  // specific weight of ice particles,  fixed value:   0.916e3 kg/mï¿½
+      0.916e3;  // specific weight of ice particles,  fixed value:   0.916e3 kg/m³
   const Numeric low_lim_den =
       -LIQUID_AND_ICE_TREAT_AS_ZERO;  // lower limit of suspended droplet particle density vector [kg/m3]
   const Numeric high_lim_den =
-      1.00e-3;  // lower limit of suspended ice particle density vector [kg/mï¿½]
+      1.00e-3;  // lower limit of suspended ice particle density vector [kg/m³]
 
   const Index n_p = abs_p.nelem();   // Number of pressure levels
   const Index n_f = f_grid.nelem();  // Number of frequencies
@@ -15878,7 +15877,7 @@ void MPM93IceCrystalAbs(
 
   // Loop pressure/temperature:
   for (Index i = 0; i < n_p; ++i) {
-    // Check limits of suspended water droplet density ("vmr") [kg/mï¿½]
+    // Check limits of suspended water droplet density ("vmr") [kg/m³]
     if ((vmr[i] < low_lim_den) || (vmr[i] > high_lim_den)) {
       ostringstream os;
       os << "ERROR in MPM93IceCrystalAbs:\n"
@@ -15910,10 +15909,10 @@ void MPM93IceCrystalAbs(
         Numeric Imepsilon =
             ((ai / (f_grid[s] * Hz_to_GHz)) + (bi * (f_grid[s] * Hz_to_GHz)));
         // the imaginary part of the complex refractivity of suspended ice particles.
-        // In MPM93 w is in g/mï¿½ and m is in g/cmï¿½. Because of the units used in arts,
+        // In MPM93 w is in g/m³ and m is in g/cm³. Because of the units used in arts,
         // a factor of 1.000e6 must be multiplied with the ratio (w/m):
-        // MPM93: (w/m)_MPM93  in   (g/mï¿½)/(g/cmï¿½)
-        // arts:  (w/m)_arts   in  (kg/mï¿½)/(kg/mï¿½)
+        // MPM93: (w/m)_MPM93  in   (g/m³)/(g/cm³)
+        // arts:  (w/m)_arts   in  (kg/m³)/(kg/m³)
         // =====> (w/m)_MPM93   =   1.0e6 * (w/m)_arts
         // the factor of 1.0e6 is included below in pxsec calculation.
         Numeric ImNw = 1.500 / m *
@@ -16179,7 +16178,7 @@ void MPM93RainExt(MatrixView pxsec,
    \param    f                     frequency position of calculation [Hz]
 
    \note     This function calculates the line shape function of Van Vleck and Weisskopf
-             with the factor (f/fl)ï¿½. for the MPM pseudo continuum line.
+             with the factor (f/fl)¹. for the MPM pseudo continuum line.
 
    \remark   Reference: H. J. Liebe and G. A. Hufford and M. G. Cotton,<br>
              <i>Propagation modeling of moist air and suspended water/ice
@@ -16196,7 +16195,7 @@ Numeric MPMLineShapeFunction(const Numeric gamma,
                              const Numeric f) {
   /*
     this routine calculates the line shape function of Van Vleck and Weisskopf
-    with the factor (f/f_o)ï¿½. for the MPM pseudo continuum line.
+    with the factor (f/f_o)¹. for the MPM pseudo continuum line.
 
     creation  TKS, 4.11.00
 
@@ -16398,7 +16397,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum coefficient (C_s)  [1/m / (Hzï¿½*Paï¿½)]
+    //     parameters[0] : continuum coefficient (C_s)  [1/m / (Hz²*Pa²)]
     //     parameters[1] : temperature exponent  (x_s)  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -16454,7 +16453,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  a) output
     //     pxsec          : [1/m],
     //  b) input
-    //     parameters[0] : [1/m / (Hzï¿½*Paï¿½)]
+    //     parameters[0] : [1/m / (Hz²*Pa²)]
     //     parameters[1] : [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -16510,7 +16509,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  a) output
     //     pxsec          : [1/m],
     //  b) input
-    //     parameters[0] : [1/m / (Hzï¿½*Paï¿½)]
+    //     parameters[0] : [1/m / (Hz²*Pa²)]
     //     parameters[1] : [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -17979,7 +17978,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum coefficient (C)    [1/m / (Hzï¿½*Paï¿½)]
+    //     parameters[0] : continuum coefficient (C)    [1/m / (Hz²*Pa²)]
     //     parameters[1] : temperature exponent  (x_s)  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -18062,7 +18061,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum coefficient (C) [Kï¿½/(Hz*Pa*m)]
+    //     parameters[0] : continuum coefficient (C) [K²/(Hz*Pa*m)]
     //     parameters[1] : temperature exponent  (x) [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -18929,7 +18928,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : strength parameter   [1/m * 1/(Hzï¿½*Paï¿½)]
+    //     parameters[0] : strength parameter   [1/m * 1/(Hz²*Pa²)]
     //     parameters[1] : broadening parameter [1]
     //     parameters[2] : temperature exponent [1]
     //     parameters[3] : frequency exponent   [1]
@@ -19039,7 +19038,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  a) output
     //     pxsec          : [1/m],
     //  b) input
-    //     parameters[0] : continuum strength coefficient  [1/m * 1/(Hz*Pa)ï¿½]
+    //     parameters[0] : continuum strength coefficient  [1/m * 1/(Hz*Pa)²]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
     //     abs_t         : [K]
@@ -19114,7 +19113,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  a) output
     //     pxsec          : [1/m],
     //  b) input
-    //     parameters[0] : continuum strength coefficient  [1/m * 1/(Hz*Pa)ï¿½]
+    //     parameters[0] : continuum strength coefficient  [1/m * 1/(Hz*Pa)²]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19172,7 +19171,7 @@ void xsec_continuum_tag(MatrixView xsec,
     // OUTPUT
     //     pxsec          : [1/m],
     // INPUT
-    //     parameters[0] : continuum coefficient (C)  [1/m * 1/(Hz*Pa)ï¿½]
+    //     parameters[0] : continuum coefficient (C)  [1/m * 1/(Hz*Pa)²]
     //     parameters[1] : frequency exponent    (xf) [1]
     //     parameters[2] : temperature exponent  (xt) [1]
     //     parameters[3] : pressure exponent     (xp) [1]
@@ -19534,7 +19533,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19593,7 +19592,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19652,7 +19651,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19712,7 +19711,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19773,7 +19772,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19851,7 +19850,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19911,7 +19910,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -20003,7 +20002,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //     vmr           : [1]
     //
     // liquid water droplet parameters:
-    // suspended water droplet density   range: 0-5 g/mï¿½
+    // suspended water droplet density   range: 0-5 g/m³
     //
     // valid atmospheric condition:
     // temperature      : 210 to 373 K
@@ -20101,7 +20100,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //     vmr           : [1]
     //
     // liquid water droplet parameters:
-    // suspended water droplet density   range: 0-5 g/mï¿½
+    // suspended water droplet density   range: 0-5 g/m³
     //
     // valid atmospheric condition:
     // temperature      : 210 to 373 K
@@ -20179,8 +20178,8 @@ void xsec_continuum_tag(MatrixView xsec,
     //     vmr           : [1]
     //
     // ice crystal parameters:
-    // suspended water droplet density   range: 0-10 g/mï¿½
-    // specific droplet weight           value:    1 g/cmï¿½
+    // suspended water droplet density   range: 0-10 g/m³
+    // specific droplet weight           value:    1 g/cm³
     //
     // valid atmospheric condition:
     // temperature      : 233 to 323 K

--- a/src/legacy_continua.cc
+++ b/src/legacy_continua.cc
@@ -9093,12 +9093,12 @@ void CKD_mt_320_self_h2o(MatrixView pxsec,
 
   int I1 = (int)((V1C - SL296_ckd_mt_320_v1) / SL296_ckd_mt_320_dv);
   if (V1C < SL296_ckd_mt_320_v1) I1 = -1;
-  V1C = SL296_ckd_mt_320_v1 + (SL296_ckd_mt_320_dv * (Numeric)I1);
+  V1C = SL296_ckd_mt_320_v1 + (SL296_ckd_mt_320_dv * (Numeric)(I1 - 1));
 
   int I2 = (int)((V2C - SL296_ckd_mt_320_v1) / SL296_ckd_mt_320_dv);
 
   int NPTC = I2 - I1 + 3;
-  if (NPTC > SL296_ckd_mt_320_npt) NPTC = SL296_ckd_mt_320_npt + 1;
+  if (NPTC > SL296_ckd_mt_320_npt) NPTC = SL296_ckd_mt_320_npt + 4;
 
   V2C = V1C + SL296_ckd_mt_320_dv * (Numeric)(NPTC - 1);
 
@@ -9116,7 +9116,7 @@ void CKD_mt_320_self_h2o(MatrixView pxsec,
   Vector SH2OT1(NPTC + addF77fields, 0.);  // [cm^3/molecules]
 
   for (Index J = 1; J <= NPTC; ++J) {
-    Index I = I1 + J;
+    Index I = I1 + (J - 1);
     if ((I > 0) && (I <= SL296_ckd_mt_320_npt)) {
       SH2OT0[J] = SL296_ckd_mt_320[I];  // at T=296 K
       SH2OT1[J] = SL260_ckd_mt_320[I];  // at T=260 K
@@ -9332,12 +9332,12 @@ void CKD_mt_320_foreign_h2o(MatrixView pxsec,
 
   int I1 = (int)((V1C - FH2O_ckd_mt_320_v1) / FH2O_ckd_mt_320_dv);
   if (V1C < FH2O_ckd_mt_320_v1) I1 = -1;
-  V1C = FH2O_ckd_mt_320_v1 + (FH2O_ckd_mt_320_dv * (Numeric)I1);
+  V1C = FH2O_ckd_mt_320_v1 + (FH2O_ckd_mt_320_dv * (Numeric)(I1 - 1));
 
   int I2 = (int)((V2C - FH2O_ckd_mt_320_v1) / FH2O_ckd_mt_320_dv);
 
   int NPTC = I2 - I1 + 3;
-  if (NPTC > FH2O_ckd_mt_320_npt) NPTC = FH2O_ckd_mt_320_npt + 1;
+  if (NPTC > FH2O_ckd_mt_320_npt) NPTC = FH2O_ckd_mt_320_npt + 4;
 
   V2C = V1C + FH2O_ckd_mt_320_dv * (Numeric)(NPTC - 1);
 
@@ -9354,7 +9354,7 @@ void CKD_mt_320_foreign_h2o(MatrixView pxsec,
   Vector FH2OT0(NPTC + addF77fields, 0.);  // [cm^3/molecules]
 
   for (Index J = 1; J <= NPTC; ++J) {
-    Index I = I1 + J;
+    Index I = I1 + (J - 1);
     if ((I > 0) && (I <= FH2O_ckd_mt_320_npt)) {
       FH2OT0[J] = FH2O_ckd_mt_320[I];
     }
@@ -9390,7 +9390,9 @@ void CKD_mt_320_foreign_h2o(MatrixView pxsec,
       {
         // Scaling factor below 600cm-1 based on RHUBC-II campaign
         JFAC = (int)((VJ + 10e0) / 10e0 + 0.00001e0);
-        FSCAL = XFAC_RHU[JFAC];
+        FSCAL = XFAC_RHU[JFAC + 1]; // +1 needed as XFAC_RHU is indexed
+                                    // from 0 in C code, but FORTRAN code
+                                    // declares DIMENSION -1, 61
       } else  // same as from version 2.4 apart from the 630e0 in the VF2 equation
       {
         Numeric VDELSQ1 = pow((VJ - 255.67e0), 2e0);

--- a/src/legacy_continua.cc
+++ b/src/legacy_continua.cc
@@ -6485,8 +6485,8 @@ void PWR98H2OAbsModel(MatrixView pxsec,
     Numeric pvap = Pa_to_hPa * abs_p[i] * vmr[i];
     // dry air partial pressure [hPa]
     Numeric pda = (Pa_to_hPa * abs_p[i]) - pvap;
-    // Rosenkranz number density  (Rosenkranz H2O mass density in [g/m³])
-    // [g/m³]    =  [g*K / Pa*m³]  *  [Pa/K]
+    // Rosenkranz number density  (Rosenkranz H2O mass density in [g/mï¿½])
+    // [g/mï¿½]    =  [g*K / Pa*mï¿½]  *  [Pa/K]
     // rho       =   (M_H2O / R)   *  (P_H2O / T)
     // rho       =      2.1667     *  abs_p * vmr / abs_t
     // den       = 3.335e16 * rho
@@ -6666,7 +6666,7 @@ void CP98H2OAbsModel(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of the
                             H2O-H2O continuum [1/m]
-   \param    Cin            constant absorption strength     [1/m / (Hz*Pa)²]
+   \param    Cin            constant absorption strength     [1/m / (Hz*Pa)ï¿½]
    \param    xin            temperature exponent of (300/T)  [1]
    \param    model          allows user defined input parameter set
                             (C and x)<br> or choice of
@@ -6699,16 +6699,16 @@ void Standard_H2O_self_continuum(MatrixView pxsec,
 
   // --------- STANDARD MODEL PARAMETERS ---------------------------------------------------
   // standard values for the Rosenkranz model (Radio Science, 33(4), 919, 1998):
-  const Numeric Cs_PWR = 1.796e-33;  //  [1/m / (Hz²*Pa²)]
+  const Numeric Cs_PWR = 1.796e-33;  //  [1/m / (Hzï¿½*Paï¿½)]
   const Numeric xs_PWR = 4.5;        //  [1]
   // standard values for the Cruz-Pol model (Radio Science, 33(5), 1319, 1998):
-  const Numeric Cs_CP = 1.851e-33;  //  [1/m / (Hz²*Pa²)]
+  const Numeric Cs_CP = 1.851e-33;  //  [1/m / (Hzï¿½*Paï¿½)]
   const Numeric xs_CP = 7.5;        //  [1]
   // standard values for the MPM89 model (Int. J. Inf. and Millim. Waves, 10(6), 1989, 631):
-  const Numeric Cs_MPM89 = 1.500e-33;  //  [1/m / (Hz²*Pa²)]
+  const Numeric Cs_MPM89 = 1.500e-33;  //  [1/m / (Hzï¿½*Paï¿½)]
   const Numeric xs_MPM89 = 7.5;        //  [1]
   // standard values for the MPM87 model (Radio Science, 20(5), 1985, 1069):
-  const Numeric Cs_MPM87 = 1.500e-33;  //  [1/m / (Hz²*Pa²)]
+  const Numeric Cs_MPM87 = 1.500e-33;  //  [1/m / (Hzï¿½*Paï¿½)]
   const Numeric xs_MPM87 = 7.5;        //  [1]
   // ---------------------------------------------------------------------------------------
 
@@ -6774,7 +6774,7 @@ void Standard_H2O_self_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of the
                             H2O-dry air continuum [1/m]
-   \param    Cin            constant absorption strength [1/m / (Hz*Pa)²]
+   \param    Cin            constant absorption strength [1/m / (Hz*Pa)ï¿½]
    \param    xin            temperature exponent         [1]
    \param    model          allows user defined input parameter set
                             (C and x)<br> or choice of
@@ -6808,16 +6808,16 @@ void Standard_H2O_foreign_continuum(MatrixView pxsec,
 
   // --------- STANDARD MODEL PARAMETERS ---------------------------------------------------
   // standard values for the Rosenkranz model (Radio Science, 33(4), 919, 1998):
-  const Numeric Cf_PWR = 5.43e-35;  //  [1/m / (Hz²*Pa²)]
+  const Numeric Cf_PWR = 5.43e-35;  //  [1/m / (Hzï¿½*Paï¿½)]
   const Numeric xf_PWR = 0.0;       //  [1]
   // standard values for the Cruz-Pol model (Radio Science, 33(5), 1319, 1998):
-  const Numeric Cf_CP = 5.85e-35;  //  [1/m / (Hz²*Pa²)]
+  const Numeric Cf_CP = 5.85e-35;  //  [1/m / (Hzï¿½*Paï¿½)]
   const Numeric xf_CP = 0.0;       //  [1]
   // standard values for the MPM89 model (Int. J. Inf. and Millim. Waves, 10(6), 1989, 631):
-  const Numeric Cf_MPM89 = 4.74e-35;  //  [1/m / (Hz²*Pa²)]
+  const Numeric Cf_MPM89 = 4.74e-35;  //  [1/m / (Hzï¿½*Paï¿½)]
   const Numeric xf_MPM89 = 0.0;       //  [1]
   // standard values for the MPM87 model (Radio Science, 20(5), 1985, 1069):
-  const Numeric Cf_MPM87 = 4.74e-35;  //  [1/m / (Hz²*Pa²)]
+  const Numeric Cf_MPM87 = 4.74e-35;  //  [1/m / (Hzï¿½*Paï¿½)]
   const Numeric xf_MPM87 = 0.0;       //  [1]
   // ---------------------------------------------------------------------------------------
 
@@ -6886,7 +6886,7 @@ void Standard_H2O_foreign_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             the H2O-dry air continuum [1/m]
-   \param    Cin            constant absorption strength [1/m / (Hz*Pa)²]
+   \param    Cin            constant absorption strength [1/m / (Hz*Pa)ï¿½]
    \param    xin            temperature exponent         [1]
    \param    model          allows user defined input parameter set
                             (C and x)<br> or choice of
@@ -6922,7 +6922,7 @@ void MaTipping_H2O_foreign_continuum(MatrixView pxsec,
   // the Cf value is originally given in dB/km/kPa^2/GHz^2.0389. the conversion factor is
   // then 1.0283E-28 to get arts units. Additionally the Cf value is divided by 1.08 to
   // get the Cf for air.
-  const Numeric Cf_MaTipping = 1.8590e-35;  //  [1/m / (Hz²*Pa²)]
+  const Numeric Cf_MaTipping = 1.8590e-35;  //  [1/m / (Hzï¿½*Paï¿½)]
   const Numeric xf_MaTipping = 4.6019;      //  [1]
   // ---------------------------------------------------------------------------------------
 
@@ -9093,12 +9093,12 @@ void CKD_mt_320_self_h2o(MatrixView pxsec,
 
   int I1 = (int)((V1C - SL296_ckd_mt_320_v1) / SL296_ckd_mt_320_dv);
   if (V1C < SL296_ckd_mt_320_v1) I1 = -1;
-  V1C = SL296_ckd_mt_320_v1 + (SL296_ckd_mt_320_dv * (Numeric)I1);
+  V1C = SL296_ckd_mt_320_v1 + (SL296_ckd_mt_320_dv * (Numeric)(I1-1));
 
   int I2 = (int)((V2C - SL296_ckd_mt_320_v1) / SL296_ckd_mt_320_dv);
 
   int NPTC = I2 - I1 + 3;
-  if (NPTC > SL296_ckd_mt_320_npt) NPTC = SL296_ckd_mt_320_npt + 1;
+  if (NPTC > SL296_ckd_mt_320_npt) NPTC = SL296_ckd_mt_320_npt + 4;
 
   V2C = V1C + SL296_ckd_mt_320_dv * (Numeric)(NPTC - 1);
 
@@ -9116,7 +9116,7 @@ void CKD_mt_320_self_h2o(MatrixView pxsec,
   Vector SH2OT1(NPTC + addF77fields, 0.);  // [cm^3/molecules]
 
   for (Index J = 1; J <= NPTC; ++J) {
-    Index I = I1 + J;
+    Index I = I1 + (J - 1);
     if ((I > 0) && (I <= SL296_ckd_mt_320_npt)) {
       SH2OT0[J] = SL296_ckd_mt_320[I];  // at T=296 K
       SH2OT1[J] = SL260_ckd_mt_320[I];  // at T=260 K
@@ -9332,12 +9332,12 @@ void CKD_mt_320_foreign_h2o(MatrixView pxsec,
 
   int I1 = (int)((V1C - FH2O_ckd_mt_320_v1) / FH2O_ckd_mt_320_dv);
   if (V1C < FH2O_ckd_mt_320_v1) I1 = -1;
-  V1C = FH2O_ckd_mt_320_v1 + (FH2O_ckd_mt_320_dv * (Numeric)I1);
+  V1C = FH2O_ckd_mt_320_v1 + (FH2O_ckd_mt_320_dv * (Numeric)(I1 - 1));
 
   int I2 = (int)((V2C - FH2O_ckd_mt_320_v1) / FH2O_ckd_mt_320_dv);
 
   int NPTC = I2 - I1 + 3;
-  if (NPTC > FH2O_ckd_mt_320_npt) NPTC = FH2O_ckd_mt_320_npt + 1;
+  if (NPTC > FH2O_ckd_mt_320_npt) NPTC = FH2O_ckd_mt_320_npt + 4;
 
   V2C = V1C + FH2O_ckd_mt_320_dv * (Numeric)(NPTC - 1);
 
@@ -9354,7 +9354,7 @@ void CKD_mt_320_foreign_h2o(MatrixView pxsec,
   Vector FH2OT0(NPTC + addF77fields, 0.);  // [cm^3/molecules]
 
   for (Index J = 1; J <= NPTC; ++J) {
-    Index I = I1 + J;
+    Index I = I1 + (J - 1);
     if ((I > 0) && (I <= FH2O_ckd_mt_320_npt)) {
       FH2OT0[J] = FH2O_ckd_mt_320[I];
     }
@@ -9390,7 +9390,8 @@ void CKD_mt_320_foreign_h2o(MatrixView pxsec,
       {
         // Scaling factor below 600cm-1 based on RHUBC-II campaign
         JFAC = (int)((VJ + 10e0) / 10e0 + 0.00001e0);
-        FSCAL = XFAC_RHU[JFAC];
+        FSCAL = XFAC_RHU[JFAC + 1]; // +1 needed as XFAC_RHU is indexed from 0 in C
+                                    // code, FORTRAN code has DIMENSION -1, 61
       } else  // same as from version 2.4 apart from the 630e0 in the VF2 equation
       {
         Numeric VDELSQ1 = pow((VJ - 255.67e0), 2e0);
@@ -11857,7 +11858,7 @@ void CKD24_H20(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             N2-continuum according to Rosenkranz, 1993 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
    \param    model          allows user defined input parameter set
                             (Cin and xTin)<br> or choice of
                             pre-defined parameters of specific models (see note below).
@@ -11937,7 +11938,7 @@ void Pardo_ATM_H2O_ForeignContinuum(MatrixView pxsec,
       // specific N2 but mainly caused by N2. Therefore the N2 vmr must be
       // canceled out here which is later in abs_coefCalc multiplied
       // (calculation: abs = vmr * pxsec):
-      pxsec(s, i) += C *  // strength [1/(m*Hz²Pa²)]
+      pxsec(s, i) += C *  // strength [1/(m*Hzï¿½Paï¿½)]
                      pow((f_grid[s] / (Numeric)2.25e11),
                          (Numeric)2.) *  // quadratic f dependence [1]
                      pow(((Numeric)300.0 / abs_t[i]),
@@ -12936,7 +12937,7 @@ void MPM92O2AbsModel(MatrixView pxsec,
   // Coefficients are from Liebe et al., AGARD CP-May93, Paper 3/1-10
   //         0           1            2       3        4      5      6
   //         f0          a1           a2      a3       a4     a5     a6
-  //        [GHz]     [kHz/hPa]      [1]   [MHz/hPa]  [1]    [10³/hPa]
+  //        [GHz]     [kHz/hPa]      [1]   [MHz/hPa]  [1]    [10ï¿½/hPa]
   const Numeric mpm92[44][7] = {
       {50.474238, 0.094, 9.694, 0.850, 0.0, 0.210, 0.685},     // 0
       {50.987749, 0.246, 8.694, 0.870, 0.0, 0.190, 0.680},     // 1
@@ -13207,7 +13208,7 @@ void TRE05O2AbsModel(MatrixView pxsec,
   // Coefficients are from Liebe et al., AGARD CP-May93, Paper 3/1-10
   //         0             1           2         3         4      5        6
   //         f0           a1           a2       a3        a4      a5       a6
-  //        [GHz]      [kHz/hPa]      [1]    [MHz/hPa]    [1]       [10³/hPa]
+  //        [GHz]      [kHz/hPa]      [1]    [MHz/hPa]    [1]       [10ï¿½/hPa]
   const Numeric tre05[44][7] = {
       {50.474214, 0.975 / 10, 9.651, 0.669, 0.0, 0.2566, 0.685},     // 37-
       {50.987745, 2.529 / 10, 8.653, 0.717, 0.0, 0.2246, 0.680},     // 35-
@@ -13473,7 +13474,7 @@ void MPM93O2AbsModel(MatrixView pxsec,
   // Coefficients are from Liebe et al., AGARD CP-May93, Paper 3/1-10
   //         0             1           2         3         4      5        6
   //         f0           a1           a2       a3        a4      a5       a6
-  //        [GHz]      [kHz/hPa]      [1]    [MHz/hPa]    [1]       [10³/hPa]
+  //        [GHz]      [kHz/hPa]      [1]    [MHz/hPa]    [1]       [10ï¿½/hPa]
   const Numeric mpm93[44][7] = {
       {50.474238, 0.094, 9.694, 0.890, 0.0, 0.240, 0.790},     // 0
       {50.987749, 0.246, 8.694, 0.910, 0.0, 0.220, 0.780},     // 1
@@ -13782,7 +13783,7 @@ void PWR93O2AbsModel(MatrixView pxsec,
       52.5424,  66.8368,  52.0214,  67.3696,  51.5034, 67.9009, 368.4984,
       424.7632, 487.2494, 715.3931, 773.8397, 834.1458};
 
-  // line strength at T=300K in [cm² * Hz]
+  // line strength at T=300K in [cmï¿½ * Hz]
   const Numeric S93[n_lines] = {
       0.2936E-14, 0.8079E-15, 0.2480E-14, 0.2228E-14, 0.3351E-14, 0.3292E-14,
       0.3721E-14, 0.3891E-14, 0.3640E-14, 0.4005E-14, 0.3227E-14, 0.3715E-14,
@@ -14200,7 +14201,7 @@ void MPM93_O2_continuum(MatrixView pxsec,
 
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             O2-continuum according to Rosenkranz 1993 [1/m]
-   \param    S0in           line strength [K²/(Hz*Pa*m)]
+   \param    S0in           line strength [Kï¿½/(Hz*Pa*m)]
    \param    G0in           line width [Hz/Pa]
    \param    XS0in          line strength temperature exponent  [1]
    \param    XG0in          line widths temperature exponent    [1]
@@ -14244,7 +14245,7 @@ void Rosenkranz_O2_continuum(MatrixView pxsec,
   // P. W. Rosenkranz, Chapter 2, in M. A. Janssen,
   // Atmospheric Remote Sensing by Microwave Radiometry, John Wiley & Sons, Inc., 1993
   // ftp://mesa.mit.edu/phil/lbl_rt
-  const Numeric S0_PWR93 = 1.11e-14;  // [K²/(Hz*Pa*m)] line strength
+  const Numeric S0_PWR93 = 1.11e-14;  // [Kï¿½/(Hz*Pa*m)] line strength
   const Numeric G0_PWR93 = 5600.000;  // line width [Hz/Pa]
   const Numeric XS0_PWR93 = 2.000;    // temperature dependence of line strength
   const Numeric XG0_PWR93 = 0.800;    // temperature dependence of line width
@@ -14646,7 +14647,7 @@ void MPM93_N2_continuum(MatrixView pxsec,
   const Numeric xf_MPM93 = 1.500;  // frequency exponent [1]
   const Numeric gxf_MPM93 =
       9.000 * xf_MPM93;  // needed for the unit conversion of G_MPM93
-  const Numeric S_MPM93 = 2.296e-31;  // line strength  [1/Pa² * 1/Hz]
+  const Numeric S_MPM93 = 2.296e-31;  // line strength  [1/Paï¿½ * 1/Hz]
   const Numeric G_MPM93 =
       1.930e-5 *
       pow((Numeric)10.000, -gxf_MPM93);  // frequency factor [1/Hz^xf]
@@ -14687,7 +14688,7 @@ void MPM93_N2_continuum(MatrixView pxsec,
        << " xf = " << xf << "\n";
 
   // unit conversion internally:
-  //const Numeric S0unitconv = 1.000e+13;  // x [1/(hPa²*GHz)] => y [1/(pa²*Hz)]
+  //const Numeric S0unitconv = 1.000e+13;  // x [1/(hPaï¿½*GHz)] => y [1/(paï¿½*Hz)]
   //const Numeric G0unitconv = pow(10.000, gxf);
 
   const Index n_p = abs_p.nelem();   // Number of pressure levels
@@ -14728,7 +14729,7 @@ void MPM93_N2_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             N2-continuum according to Rosenkranz, 1993 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
    \param    model          allows user defined input parameter set
                             (Cin and xTin)<br> or choice of
                             pre-defined parameters of specific models (see note below).
@@ -14808,13 +14809,13 @@ void Pardo_ATM_N2_dry_continuum(MatrixView pxsec,
         // specific N2 but mainly caused by N2. Therefore the N2 vmr must be
         // canceled out here which is later in abs_coefCalc multiplied
         // (calculation: abs = vmr * pxsec):
-        pxsec(s, i) += C *  // strength [1/(m*Hz²Pa²)]
+        pxsec(s, i) += C *  // strength [1/(m*Hzï¿½Paï¿½)]
                        pow((f_grid[s] / (Numeric)2.25e11),
-                           (Numeric)2.) *  // quadratic f dependence [Hz²]
+                           (Numeric)2.) *  // quadratic f dependence [Hzï¿½]
                        pow(((Numeric)300.0 / abs_t[i]),
                            (Numeric)3.5) *  // free T dependence      [1]
                        pow((pd / (Numeric)1.01300e5),
-                           (Numeric)2.) /  // quadratic p dependence [Pa²]
+                           (Numeric)2.) /  // quadratic p dependence [Paï¿½]
                        vmr[i];             // cancel the vmr dependency
       }
     }
@@ -14826,7 +14827,7 @@ void Pardo_ATM_N2_dry_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             N2-continuum according to Rosenkranz, 1993 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
    \param    xin            temperature exponent of N2-continuum [1]
    \param    model          allows user defined input parameter set
                             (Cin and xTin)<br> or choice of
@@ -14863,7 +14864,7 @@ void Rosenkranz_N2_self_continuum(MatrixView pxsec,
   // --------- STANDARD MODEL PARAMETERS ---------------------------------------------------
   // standard values for the Rosenkranz model (Chapter 2, pp 74, in M. A. Janssen,
   // "Atmospheric Remote Sensing by Microwave Radiometry", John Wiley & Sons, Inc., 1993
-  const Numeric C_PWR = 1.05e-38;  // [1/(Pa²*Hz²*m)]
+  const Numeric C_PWR = 1.05e-38;  // [1/(Paï¿½*Hzï¿½*m)]
   const Numeric x_PWR = 3.55;      // [1]
   // ---------------------------------------------------------------------------------------
 
@@ -14904,10 +14905,10 @@ void Rosenkranz_N2_self_continuum(MatrixView pxsec,
       // The second vmr of N2 will be multiplied at the stage of absorption
       // calculation: abs = vmr * pxsec.
       pxsec(s, i) +=
-          C *                                  // strength [1/(m*Hz²Pa²)]
-          pow(f_grid[s], (Numeric)2.) *        // quadratic f dependence [Hz²]
+          C *                                  // strength [1/(m*Hzï¿½Paï¿½)]
+          pow(f_grid[s], (Numeric)2.) *        // quadratic f dependence [Hzï¿½]
           pow((Numeric)300.0 / abs_t[i], x) *  // free T dependence      [1]
-          pow(abs_p[i], (Numeric)2.) *         // quadratic p dependence [Pa²]
+          pow(abs_p[i], (Numeric)2.) *         // quadratic p dependence [Paï¿½]
           vmr[i];                              // second N2-VMR at the stage
                                                // of absorption calculation
     }
@@ -14923,7 +14924,7 @@ void Rosenkranz_N2_self_continuum(MatrixView pxsec,
 
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             N2-continuum according to Rosenkranz, 1993 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
    \param    xfin           continuum frequency exponent [1]
    \param    xtin           continuum strength temperature exponent [1]
    \param    xpin           continuum strength pressure exponent [1]
@@ -14964,7 +14965,7 @@ void Standard_N2_self_continuum(MatrixView pxsec,
   // --------- STANDARD MODEL PARAMETERS ---------------------------------------------------
   // standard values for the Rosenkranz model, Chapter 2, pp 74, in M. A. Janssen,
   // "Atmospheric Remote Sensing by Microwave Radiometry", John Wiley & Sons, Inc., 1993
-  const Numeric C_GM = 1.05e-38;  // [1/(Pa²*Hz²*m)]
+  const Numeric C_GM = 1.05e-38;  // [1/(Paï¿½*Hzï¿½*m)]
   const Numeric xf_GM = 2.00;     // [1]
   const Numeric xt_GM = 3.55;     // [1]
   const Numeric xp_GM = 2.00;     // [1]
@@ -15015,7 +15016,7 @@ void Standard_N2_self_continuum(MatrixView pxsec,
       // The second N2-VMR will be multiplied at the stage of absorption
       // calculation: abs = vmr * pxsec.
       pxsec(s, i) +=
-          C *                                      // strength [1/(m*Hz²Pa²)]
+          C *                                      // strength [1/(m*Hzï¿½Paï¿½)]
           pow(((Numeric)300.00 / abs_t[i]), xt) *  // T dependence        [1]
           pow(f_grid[s], xf) *                     // f dependence    [Hz^xt]
           pow(abs_p[i], xp) *                      // p dependence    [Pa^xp]
@@ -15034,7 +15035,7 @@ void Standard_N2_self_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             CO2-CO2-continuum according to Rosenkranz, 1993 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
    \param    xin            continuum temperature exponent [1]
    \param    model          allows user defined input parameter set
                             (Cin and xin)<br> or choice of
@@ -15071,7 +15072,7 @@ void Rosenkranz_CO2_self_continuum(MatrixView pxsec,
   // --------- STANDARD MODEL PARAMETERS ---------------------------------------------------
   // P. W. Rosenkranz Chapter 2, pp 74, in M. A. Janssen,
   // "Atmospheric Remote Sensing by Microwave Radiometry", John Wiley & Sons, Inc., 1993
-  const Numeric C_PWR = 7.43e-37;  // [ 1/(Pa²*Hz²*m) ]
+  const Numeric C_PWR = 7.43e-37;  // [ 1/(Paï¿½*Hzï¿½*m) ]
   const Numeric x_PWR = 5.08;      // [ 1 ]
   // ---------------------------------------------------------------------------------------
 
@@ -15128,7 +15129,7 @@ void Rosenkranz_CO2_self_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             CO2-N2-continuum according to Rosenkranz, 1993 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
    \param    xin            continuum temperature exponent [1]
    \param    model          allows user defined input parameter set
                             (Cin and xin)<br> or choice of
@@ -15166,7 +15167,7 @@ void Rosenkranz_CO2_foreign_continuum(MatrixView pxsec,
 
   // --------- STANDARD MODEL PARAMETERS ---------------------------------------------------
   // "Atmospheric Remote Sensing by Microwave Radiometry", John Wiley & Sons, Inc., 1993
-  const Numeric C_PWR = 2.71e-37;  // default: 2.71*10^-37 1/(Pa²*Hz²*m)
+  const Numeric C_PWR = 2.71e-37;  // default: 2.71*10^-37 1/(Paï¿½*Hzï¿½*m)
   const Numeric x_PWR = 4.7;       // default: 4.7
   // ---------------------------------------------------------------------------------------
 
@@ -15223,7 +15224,7 @@ void Rosenkranz_CO2_foreign_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             CO2-CO2-continuum according to Ho et al 1966 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
    \param    xin            continuum temperature exponent [1]
    \param    model          allows user defined input parameter set
                             (Cin and xin)<br> or choice of
@@ -15258,7 +15259,7 @@ void Ho66_CO2_self_continuum(MatrixView pxsec,
 
   // --------- STANDARD MODEL PARAMETERS --------------------------------------
   // Values (after conversion for C) from abstract of Ho66:
-  const Numeric C_Ho66 = 1.70e-36;  // [ 1/(Pa²*Hz²*m) ]
+  const Numeric C_Ho66 = 1.70e-36;  // [ 1/(Paï¿½*Hzï¿½*m) ]
   const Numeric x_Ho66 = 5;         // [ 1 ]
   // --------------------------------------------------------------------------
 
@@ -15315,7 +15316,7 @@ void Ho66_CO2_self_continuum(MatrixView pxsec,
 /*!
    \param[out] pxsec        cross section (absorption/volume mixing ratio) of
                             CO2-CO2-continuum according to Ho et al 1966 [1/m]
-   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)²]
+   \param    Cin            continuum strength [1/m * 1/(Hz*Pa)ï¿½]
    \param    xin            continuum temperature exponent [1]
    \param    model          allows user defined input parameter set
                             (Cin and xin)<br> or choice of
@@ -15352,7 +15353,7 @@ void Ho66_CO2_foreign_continuum(MatrixView pxsec,
 
   // --------- STANDARD MODEL PARAMETERS --------------------------------------
   // Values (after conversion for C) from abstract of Ho66:
-  const Numeric C_Ho66 = 4.23e-37;  // [ 1/(Pa²*Hz²*m) ]
+  const Numeric C_Ho66 = 4.23e-37;  // [ 1/(Paï¿½*Hzï¿½*m) ]
   const Numeric x_Ho66 = 5;         // [ 1 ]
   // --------------------------------------------------------------------------
 
@@ -15422,7 +15423,7 @@ void Ho66_CO2_foreign_continuum(MatrixView pxsec,
    \param    f_grid         predefined frequency grid       [Hz]
    \param    abs_p          predefined pressure grid        [Pa]
    \param    abs_t          predefined temperature grid     [K]
-   \param    vmr            suspended water droplet density profile [kg/m³]
+   \param    vmr            suspended water droplet density profile [kg/mï¿½]
                             (valid range (Tab.1 of reference): 0-0.005)
 
    \note     Except for  model 'user' the input parameters CCin, CGin, and CEin
@@ -15499,7 +15500,7 @@ void MPM93WaterDropletAbs(
 
   // Loop pressure/temperature:
   for (Index i = 0; i < n_p; ++i) {
-    // Check limits of suspended water droplet density ("vmr") [kg/m³]
+    // Check limits of suspended water droplet density ("vmr") [kg/mï¿½]
     if ((vmr[i] < low_lim_den) || (vmr[i] > high_lim_den)) {
       ostringstream os;
       os << "ERROR in MPM93WaterDropletAbs:\n"
@@ -15545,10 +15546,10 @@ void MPM93WaterDropletAbs(
                               (pow((f_grid[s] * Hz_to_GHz), (Numeric)2.) +
                                pow(gamma2, (Numeric)2.))));
         // the imaginary part of the complex refractivity of suspended liquid water particle [ppm]
-        // In MPM93 w is in g/m³ and m is in g/cm³. Because of the units used in arts,
+        // In MPM93 w is in g/mï¿½ and m is in g/cmï¿½. Because of the units used in arts,
         // a factor of 1.000e6 must be multiplied with the ratio (w/m):
-        // MPM93: (w/m)_MPM93  in   (g/m³)/(g/cm³)
-        // arts:  (w/m)_arts   in  (kg/m³)/(kg/m³)
+        // MPM93: (w/m)_MPM93  in   (g/mï¿½)/(g/cmï¿½)
+        // arts:  (w/m)_arts   in  (kg/mï¿½)/(kg/mï¿½)
         // =====> (w/m)_MPM93   =   1.0e6 * (w/m)_arts
         // the factor of 1.0e6 is included below in pxsec calculation.
         Numeric ImNw = 1.500 / m *
@@ -15577,7 +15578,7 @@ void MPM93WaterDropletAbs(
    \param    f_grid         predefined frequency grid       [Hz]
    \param    abs_p          predefined pressure grid        [Pa]
    \param    abs_t          predefined temperature grid     [K]
-   \param    vmr            suspended water droplet density profile [kg/m³]
+   \param    vmr            suspended water droplet density profile [kg/mï¿½]
                             (valid range (Tab.1 of MPM93): 0-0.005)
 
    \note     Allowed models: 'ELL07'.
@@ -15663,7 +15664,7 @@ void ELL07WaterDropletAbs(
 
   // Loop pressure/temperature:
   for (Index i = 0; i < n_p; ++i) {
-    // Check limits of suspended water droplet density ("vmr") [kg/m³]
+    // Check limits of suspended water droplet density ("vmr") [kg/mï¿½]
     if ((vmr[i] < low_lim_den) || (vmr[i] > high_lim_den)) {
       ostringstream os;
       os << "ERROR in ELL07WaterDropletAbs:\n"
@@ -15760,10 +15761,10 @@ void ELL07WaterDropletAbs(
                                     (Numeric)2.)));
 
         // the imaginary part of the complex refractivity of suspended liquid water particle [ppm]
-        // In MPM93 w is in g/m³ and m is in g/cm³. Because of the units used in arts,
+        // In MPM93 w is in g/mï¿½ and m is in g/cmï¿½. Because of the units used in arts,
         // a factor of 1.000e6 must be multiplied with the ratio (w/m):
-        // MPM93: (w/m)_MPM93  in   (g/m³)/(g/cm³)
-        // arts:  (w/m)_arts   in  (kg/m³)/(kg/m³)
+        // MPM93: (w/m)_MPM93  in   (g/mï¿½)/(g/cmï¿½)
+        // arts:  (w/m)_arts   in  (kg/mï¿½)/(kg/mï¿½)
         // =====> (w/m)_MPM93   =   1.0e6 * (w/m)_arts
         // the factor of 1.0e6 is included below in pxsec calculation.
         Numeric ImNw = 1.500 / m *
@@ -15798,7 +15799,7 @@ void ELL07WaterDropletAbs(
    \param    f_grid         predefined frequency grid       [Hz]
    \param    abs_p          predefined pressure grid        [Pa]
    \param    abs_t          predefined temperature grid     [K]
-   \param    vmr            suspended water droplet density profile [kg/m³]
+   \param    vmr            suspended water droplet density profile [kg/mï¿½]
                             (valid range (Tab.1 of reference): 0-0.001)
 
    \note     Except for  model 'user' the input parameters CCin, CAin, and CBin
@@ -15826,7 +15827,7 @@ void MPM93IceCrystalAbs(
     ConstVectorView abs_p,   // pressure vector
     ConstVectorView abs_t,   // temperature vector
     ConstVectorView vmr,     // suspended ice particle density vector,
-                             // valid range: 0-1.0e-3 kg/m³
+                             // valid range: 0-1.0e-3 kg/mï¿½
     const Verbosity &) {
   // --------- STANDARD MODEL PARAMETERS ------------------------------------------------
   // standard values for the MPM93 model (J. Liebe and G. A. Hufford and M. G. Cotton,
@@ -15857,11 +15858,11 @@ void MPM93IceCrystalAbs(
   }
 
   const Numeric m =
-      0.916e3;  // specific weight of ice particles,  fixed value:   0.916e3 kg/m³
+      0.916e3;  // specific weight of ice particles,  fixed value:   0.916e3 kg/mï¿½
   const Numeric low_lim_den =
       -LIQUID_AND_ICE_TREAT_AS_ZERO;  // lower limit of suspended droplet particle density vector [kg/m3]
   const Numeric high_lim_den =
-      1.00e-3;  // lower limit of suspended ice particle density vector [kg/m³]
+      1.00e-3;  // lower limit of suspended ice particle density vector [kg/mï¿½]
 
   const Index n_p = abs_p.nelem();   // Number of pressure levels
   const Index n_f = f_grid.nelem();  // Number of frequencies
@@ -15877,7 +15878,7 @@ void MPM93IceCrystalAbs(
 
   // Loop pressure/temperature:
   for (Index i = 0; i < n_p; ++i) {
-    // Check limits of suspended water droplet density ("vmr") [kg/m³]
+    // Check limits of suspended water droplet density ("vmr") [kg/mï¿½]
     if ((vmr[i] < low_lim_den) || (vmr[i] > high_lim_den)) {
       ostringstream os;
       os << "ERROR in MPM93IceCrystalAbs:\n"
@@ -15909,10 +15910,10 @@ void MPM93IceCrystalAbs(
         Numeric Imepsilon =
             ((ai / (f_grid[s] * Hz_to_GHz)) + (bi * (f_grid[s] * Hz_to_GHz)));
         // the imaginary part of the complex refractivity of suspended ice particles.
-        // In MPM93 w is in g/m³ and m is in g/cm³. Because of the units used in arts,
+        // In MPM93 w is in g/mï¿½ and m is in g/cmï¿½. Because of the units used in arts,
         // a factor of 1.000e6 must be multiplied with the ratio (w/m):
-        // MPM93: (w/m)_MPM93  in   (g/m³)/(g/cm³)
-        // arts:  (w/m)_arts   in  (kg/m³)/(kg/m³)
+        // MPM93: (w/m)_MPM93  in   (g/mï¿½)/(g/cmï¿½)
+        // arts:  (w/m)_arts   in  (kg/mï¿½)/(kg/mï¿½)
         // =====> (w/m)_MPM93   =   1.0e6 * (w/m)_arts
         // the factor of 1.0e6 is included below in pxsec calculation.
         Numeric ImNw = 1.500 / m *
@@ -16178,7 +16179,7 @@ void MPM93RainExt(MatrixView pxsec,
    \param    f                     frequency position of calculation [Hz]
 
    \note     This function calculates the line shape function of Van Vleck and Weisskopf
-             with the factor (f/fl)¹. for the MPM pseudo continuum line.
+             with the factor (f/fl)ï¿½. for the MPM pseudo continuum line.
 
    \remark   Reference: H. J. Liebe and G. A. Hufford and M. G. Cotton,<br>
              <i>Propagation modeling of moist air and suspended water/ice
@@ -16195,7 +16196,7 @@ Numeric MPMLineShapeFunction(const Numeric gamma,
                              const Numeric f) {
   /*
     this routine calculates the line shape function of Van Vleck and Weisskopf
-    with the factor (f/f_o)¹. for the MPM pseudo continuum line.
+    with the factor (f/f_o)ï¿½. for the MPM pseudo continuum line.
 
     creation  TKS, 4.11.00
 
@@ -16397,7 +16398,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum coefficient (C_s)  [1/m / (Hz²*Pa²)]
+    //     parameters[0] : continuum coefficient (C_s)  [1/m / (Hzï¿½*Paï¿½)]
     //     parameters[1] : temperature exponent  (x_s)  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -16453,7 +16454,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  a) output
     //     pxsec          : [1/m],
     //  b) input
-    //     parameters[0] : [1/m / (Hz²*Pa²)]
+    //     parameters[0] : [1/m / (Hzï¿½*Paï¿½)]
     //     parameters[1] : [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -16509,7 +16510,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  a) output
     //     pxsec          : [1/m],
     //  b) input
-    //     parameters[0] : [1/m / (Hz²*Pa²)]
+    //     parameters[0] : [1/m / (Hzï¿½*Paï¿½)]
     //     parameters[1] : [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -17978,7 +17979,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum coefficient (C)    [1/m / (Hz²*Pa²)]
+    //     parameters[0] : continuum coefficient (C)    [1/m / (Hzï¿½*Paï¿½)]
     //     parameters[1] : temperature exponent  (x_s)  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -18061,7 +18062,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum coefficient (C) [K²/(Hz*Pa*m)]
+    //     parameters[0] : continuum coefficient (C) [Kï¿½/(Hz*Pa*m)]
     //     parameters[1] : temperature exponent  (x) [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -18928,7 +18929,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : strength parameter   [1/m * 1/(Hz²*Pa²)]
+    //     parameters[0] : strength parameter   [1/m * 1/(Hzï¿½*Paï¿½)]
     //     parameters[1] : broadening parameter [1]
     //     parameters[2] : temperature exponent [1]
     //     parameters[3] : frequency exponent   [1]
@@ -19038,7 +19039,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  a) output
     //     pxsec          : [1/m],
     //  b) input
-    //     parameters[0] : continuum strength coefficient  [1/m * 1/(Hz*Pa)²]
+    //     parameters[0] : continuum strength coefficient  [1/m * 1/(Hz*Pa)ï¿½]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
     //     abs_t         : [K]
@@ -19113,7 +19114,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  a) output
     //     pxsec          : [1/m],
     //  b) input
-    //     parameters[0] : continuum strength coefficient  [1/m * 1/(Hz*Pa)²]
+    //     parameters[0] : continuum strength coefficient  [1/m * 1/(Hz*Pa)ï¿½]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19171,7 +19172,7 @@ void xsec_continuum_tag(MatrixView xsec,
     // OUTPUT
     //     pxsec          : [1/m],
     // INPUT
-    //     parameters[0] : continuum coefficient (C)  [1/m * 1/(Hz*Pa)²]
+    //     parameters[0] : continuum coefficient (C)  [1/m * 1/(Hz*Pa)ï¿½]
     //     parameters[1] : frequency exponent    (xf) [1]
     //     parameters[2] : temperature exponent  (xt) [1]
     //     parameters[3] : pressure exponent     (xp) [1]
@@ -19533,7 +19534,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19592,7 +19593,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19651,7 +19652,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19711,7 +19712,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19772,7 +19773,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19850,7 +19851,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -19910,7 +19911,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //  OUTPUT
     //     pxsec          : [1/m],
     //  INPUT
-    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)²]
+    //     parameters[0] : continuum strength coefficient [1/m * 1/(Hz*Pa)ï¿½]
     //     parameters[1] : continuum temperature exponent  [1]
     //     f_grid        : [Hz]
     //     abs_p         : [Pa]
@@ -20002,7 +20003,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //     vmr           : [1]
     //
     // liquid water droplet parameters:
-    // suspended water droplet density   range: 0-5 g/m³
+    // suspended water droplet density   range: 0-5 g/mï¿½
     //
     // valid atmospheric condition:
     // temperature      : 210 to 373 K
@@ -20100,7 +20101,7 @@ void xsec_continuum_tag(MatrixView xsec,
     //     vmr           : [1]
     //
     // liquid water droplet parameters:
-    // suspended water droplet density   range: 0-5 g/m³
+    // suspended water droplet density   range: 0-5 g/mï¿½
     //
     // valid atmospheric condition:
     // temperature      : 210 to 373 K
@@ -20178,8 +20179,8 @@ void xsec_continuum_tag(MatrixView xsec,
     //     vmr           : [1]
     //
     // ice crystal parameters:
-    // suspended water droplet density   range: 0-10 g/m³
-    // specific droplet weight           value:    1 g/cm³
+    // suspended water droplet density   range: 0-10 g/mï¿½
+    // specific droplet weight           value:    1 g/cmï¿½
     //
     // valid atmospheric condition:
     // temperature      : 233 to 323 K


### PR DESCRIPTION
There is currently an error in the indexing for the correction factor XFAC_RHU in the H2O Foreign continuum MT-CKD v3.2 implementation in ARTS. This is because the C++ code closely follows the FORTRAN code from AER, but there is a difference between how the arrays are dimensioned between the two codes. The AER FORTRAN code declares XFAC_RHU to have dimension -1, 61 whereas the C++ code uses the default dimensions 0 to 62. Since the two codes extract the same index J from the array there is an unwanted offset in the C++ version.

This PR corrects this error. It also changes some of the indexing in the MTCKD v3.2 H2O self and foreign continua (sections SL260/296 and FR296) to match the conventions used by the AER code more closely, although this has no impact on the results.

The revised code gives a closer match to the foreign continuum absorption between ARTS and the official AER code.