### PR TITLE
Require cmake 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-if (ENABLE_CXX20)
-  cmake_minimum_required (VERSION 3.12)
-else ()
-  cmake_minimum_required (VERSION 3.9)
-endif ()
+cmake_minimum_required (VERSION 3.12)
 
 project (ARTS C CXX)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Building ARTS
 Build Prerequisites:
 
 - gcc/g++ >=8 (or llvm/clang >=10) older versions might work, but are untested
-- cmake (>=3.9)
+- cmake (>=3.12)
 - zlib
 - openblas
 - netcdf (optional)


### PR DESCRIPTION
Needed for the JOIN string command. Found by Patrick.