### PR TITLE
Hydrotables and faster DISORT

### DIFF
--- a/src/disort.cc
+++ b/src/disort.cc
@@ -747,6 +747,7 @@ void run_cdisort(Workspace& ws,
                  ConstVectorView za_grid,
                  const Index& nstreams,
                  const Index& Npfct,
+                 const Index& only_tro,
                  const Index& quiet,
                  const Verbosity& verbosity) {
   // Create an atmosphere starting at z_surface
@@ -827,23 +828,6 @@ void run_cdisort(Workspace& ws,
   // Since we have no solar source there is no angular dependance
   ds.phi[0] = 0.;
 
-  for (Index i = 0; i <= ds.nlyr; i++) ds.temper[i] = t[ds.nlyr - i];
-
-  Matrix ext_bulk_gas(nf, ds.nlyr + 1);
-  get_gasoptprop(ws, ext_bulk_gas, propmat_clearsky_agenda, t, vmr, p, f_grid);
-  Matrix ext_bulk_par(nf, ds.nlyr + 1), abs_bulk_par(nf, ds.nlyr + 1);
-  get_paroptprop(
-      ext_bulk_par, abs_bulk_par, scat_data, pnd, t, p, cboxlims, f_grid);
-
-  // Optical depth of layers
-  Matrix dtauc(nf, ds.nlyr);
-  // Single scattering albedo of layers
-  Matrix ssalb(nf, ds.nlyr);
-  get_dtauc_ssalb(dtauc, ssalb, ext_bulk_gas, ext_bulk_par, abs_bulk_par, z);
-
-  // Transform to mu, starting with negative values
-  for (Index i = 0; i < ds.numu; i++) ds.umu[i] = -cos(za_grid[i] * PI / 180);
-
   //upper boundary conditions:
   // DISORT offers isotropic incoming radiance or emissivity-scaled planck
   // emission. Both are applied additively.
@@ -864,13 +848,64 @@ void run_cdisort(Workspace& ws,
   ds.bc.btemp = surface_skin_t;
   ds.bc.temis = 1.;
 
-  Vector pfct_angs;
-  get_angs(pfct_angs, scat_data, Npfct);
-  Index nang = pfct_angs.nelem();
+  
+  for (Index i = 0; i <= ds.nlyr; i++) ds.temper[i] = t[ds.nlyr - i];
 
+  // Absorption species
+  Matrix ext_bulk_gas(nf, ds.nlyr + 1);
+  get_gasoptprop(ws, ext_bulk_gas, propmat_clearsky_agenda, t, vmr, p, f_grid);
+
+  // Get particle bulk properties
+  Index nang;
+  Vector pfct_angs;
+  Matrix ext_bulk_par(nf, ds.nlyr + 1), abs_bulk_par(nf, ds.nlyr + 1);
   Index nf_ssd = scat_data[0][0].f_grid.nelem();
-  Tensor3 pha_bulk_par(nf_ssd, ds.nlyr + 1, nang);
-  get_parZ(pha_bulk_par, scat_data, pnd, t, pfct_angs, cboxlims);
+  Tensor3 pha_bulk_par;
+  if (only_tro && Npfct > 3) {
+    nang = Npfct;
+    nlinspace(pfct_angs, 0, 180, nang);
+
+    pha_bulk_par.resize(nf_ssd, ds.nlyr + 1, nang);
+    
+    ext_bulk_par = 0.0;
+    abs_bulk_par = 0.0;
+    pha_bulk_par = 0.0;
+
+    for (Index iss=0; iss < scat_data.nelem(); iss++)
+      ext_abs_pfun_from_tro(ext_bulk_par,
+                            abs_bulk_par,
+                            pha_bulk_par,
+                            scat_data[iss],
+                            pnd,
+                            cboxlims,
+                            t,
+                            pfct_angs);
+  } else {
+    get_angs(pfct_angs, scat_data, Npfct);
+    nang = pfct_angs.nelem();
+    
+    pha_bulk_par.resize(nf_ssd, ds.nlyr + 1, nang);
+  
+    get_paroptprop(ext_bulk_par,
+                   abs_bulk_par,
+                   scat_data,
+                   pnd,
+                   t,
+                   p,
+                   cboxlims,
+                   f_grid);
+    get_parZ(pha_bulk_par, scat_data, pnd, t, pfct_angs, cboxlims);
+  }
+  
+  // Optical depth of layers
+  Matrix dtauc(nf, ds.nlyr);
+  // Single scattering albedo of layers
+  Matrix ssalb(nf, ds.nlyr);
+  get_dtauc_ssalb(dtauc, ssalb, ext_bulk_gas, ext_bulk_par, abs_bulk_par, z);
+
+  // Transform to mu, starting with negative values
+  for (Index i = 0; i < ds.numu; i++) ds.umu[i] = -cos(za_grid[i] * PI / 180);
+
   Tensor3 pfct_bulk_par(nf_ssd, ds.nlyr, nang);
   get_pfct(pfct_bulk_par, pha_bulk_par, ext_bulk_par, abs_bulk_par, cboxlims);
 

--- a/src/disort.cc
+++ b/src/disort.cc
@@ -864,7 +864,6 @@ void run_cdisort(Workspace& ws,
   Tensor3 pha_bulk_par;
 
   if (only_tro && Npfct > 3) {
-    cout << "new\n";
     nang = Npfct;
     nlinspace(pfct_angs, 0, 180, nang);
 
@@ -882,6 +881,7 @@ void run_cdisort(Workspace& ws,
                             abs_bulk_par,
                             pha_bulk_par,
                             scat_data[iss],
+                            iss,
                             pnd(Range(iflat,nse),joker),
                             cboxlims,
                             t,

--- a/src/disort.cc
+++ b/src/disort.cc
@@ -750,6 +750,7 @@ void run_cdisort(Workspace& ws,
                  const Index& only_tro,
                  const Index& quiet,
                  const Verbosity& verbosity) {
+
   // Create an atmosphere starting at z_surface
   Vector p, z, t;
   Matrix vmr, pnd;
@@ -861,7 +862,9 @@ void run_cdisort(Workspace& ws,
   Matrix ext_bulk_par(nf, ds.nlyr + 1), abs_bulk_par(nf, ds.nlyr + 1);
   Index nf_ssd = scat_data[0][0].f_grid.nelem();
   Tensor3 pha_bulk_par;
+
   if (only_tro && Npfct > 3) {
+    cout << "new\n";
     nang = Npfct;
     nlinspace(pfct_angs, 0, 180, nang);
 
@@ -871,15 +874,20 @@ void run_cdisort(Workspace& ws,
     abs_bulk_par = 0.0;
     pha_bulk_par = 0.0;
 
-    for (Index iss=0; iss < scat_data.nelem(); iss++)
+    Index iflat = 0;
+    
+    for (Index iss=0; iss < scat_data.nelem(); iss++) {
+      const Index nse = scat_data[iss].nelem();
       ext_abs_pfun_from_tro(ext_bulk_par,
                             abs_bulk_par,
                             pha_bulk_par,
                             scat_data[iss],
-                            pnd,
+                            pnd(Range(iflat,nse),joker),
                             cboxlims,
                             t,
                             pfct_angs);
+      iflat += nse;
+    }
   } else {
     get_angs(pfct_angs, scat_data, Npfct);
     nang = pfct_angs.nelem();

--- a/src/disort.h
+++ b/src/disort.h
@@ -164,6 +164,7 @@ void run_cdisort(Workspace& ws,
                  ConstVectorView za_grid,
                  const Index& nstreams,
                  const Index& Npfct,
+                 const Index& only_tro,
                  const Index& quiet,
                  const Verbosity& verbosity);
 

--- a/src/m_disort.cc
+++ b/src/m_disort.cc
@@ -75,6 +75,7 @@ void DisortCalc(Workspace& ws,
                 const Vector& surface_scalar_reflectivity,
                 const Index& nstreams,
                 const Index& Npfct,
+                const Index& only_tro,
                 const Index& cdisort_quiet,
                 const Verbosity& verbosity) {
   // Don't do anything if there's no cloudbox defined.
@@ -122,6 +123,7 @@ void DisortCalc(Workspace& ws,
               za_grid,
               nstreams,
               Npfct,
+              only_tro,
               cdisort_quiet,
               verbosity);
 }
@@ -155,6 +157,7 @@ void DisortCalcWithARTSSurface(
     const Index& stokes_dim,
     const Index& nstreams,
     const Index& Npfct,
+    const Index& only_tro,
     const Index& cdisort_quiet,
     const Numeric& inc_angle,
     const Verbosity& verbosity) {
@@ -218,6 +221,7 @@ void DisortCalcWithARTSSurface(
               za_grid,
               nstreams,
               Npfct,
+              only_tro,
               cdisort_quiet,
               verbosity);
 }
@@ -303,6 +307,7 @@ void DisortCalcClearsky(Workspace& ws,
              surface_scalar_reflectivity,
              nstreams,
              181,
+             0,
              cdisort_quiet,
              verbosity);
 }

--- a/src/m_microphysics.cc
+++ b/src/m_microphysics.cc
@@ -82,8 +82,6 @@ void HydrotableCalc(Workspace& ws,
                     const Vector& wc_grid,                    
                     const Verbosity&)
 {
-  cout << "scat_data version\n";
-
   // Sizes
   const Index nss = scat_data.nelem(); 
   const Index nf = f_grid.nelem();
@@ -158,6 +156,7 @@ void HydrotableCalc(Workspace& ws,
                           abs,
                           pfun,
                           scat_data[iss],
+                          iss,
                           transpose(pnd_data),
                           cbox_limits,
                           T_grid,
@@ -171,150 +170,6 @@ void HydrotableCalc(Workspace& ws,
         hydrotable.data(2,iv,it,iw) = asymmetry_parameter(sa_grid,
                                                           pfun(iv,it,joker));
         hydrotable.data(3,iv,it,iw) = fourpi * pfun(iv,it,nsa-1);
-      }
-    }
-  }
-}
-
-
-/* Workspace method: Doxygen documentation will be auto-generated */
-void HydrotableCalc2(Workspace& ws,
-                    GriddedField4& hydrotable,
-                    const ArrayOfAgenda& pnd_agenda_array,
-                    const ArrayOfArrayOfString& pnd_agenda_array_input_names,
-                    const ArrayOfArrayOfSingleScatteringData& scat_data,
-                    const Index& scat_data_checked,
-                    const Vector& f_grid,
-                    const Index& iss,
-                    const Vector& T_grid,
-                    const Vector& wc_grid,                    
-                    const Verbosity&)
-{ 
-  cout << "disort version\n";
-
-  // Sizes
-  const Index nss = scat_data.nelem(); 
-  const Index nf = f_grid.nelem();
-  const Index nt = T_grid.nelem();
-  const Index nw = wc_grid.nelem();
-
-  ARTS_USER_ERROR_IF (pnd_agenda_array.nelem() != nss,
-        "*scat_data* and *pnd_agenda_array* are inconsistent "
-        "in size.");
-  ARTS_USER_ERROR_IF (pnd_agenda_array_input_names.nelem() != nss,
-        "*scat_data* and *pnd_agenda_array_input_names* are "
-        "inconsistent in size.");
-  ARTS_USER_ERROR_IF (pnd_agenda_array_input_names[iss].nelem() != 1,
-        "This method requires one-moment PSDs, but *pnd_agenda_array_input_names* "
-        "for the selected scattering species does not have length one.");
-  ARTS_USER_ERROR_IF (!scat_data_checked,
-                      "The scat_data must be flagged to have passed a "
-                      "consistency check (scat_data_checked=1).");
-
-  // Check that all is TRO and determine flat scattering element positions
-  Index ise0, nse, nsetot;
-  {    
-    bool all_totrand = true;
-    ArrayOfIndex ncumse(nss + 1);
-    ncumse[0] = 0;
-    for (Index i = 0; i < nss; i++) {
-      ncumse[i + 1] = ncumse[i] + scat_data[i].nelem();
-      for (Index i_se = 0; i_se < scat_data[i].nelem(); i_se++) {
-        if (scat_data[i][i_se].ptype != PTYPE_TOTAL_RND)
-          all_totrand = false;
-      }
-    }
-    ARTS_USER_ERROR_IF (!all_totrand,
-                        "This method demands that all scat_data are TRO");
-    ise0 = ncumse[iss];
-    nse = ncumse[iss+1] - ise0;
-    nsetot = ncumse[nss];
-  }
-  
-  // Allocate *hydrotable*
-  hydrotable.set_name("Table of particle optical properties");
-  hydrotable.data.resize(4, nf, nt, nw);
-  //
-  hydrotable.set_grid_name(0, "Quantity");
-  hydrotable.set_grid(0, {"Extinction [m-1]",
-                          "Single scattering albedo [-]",
-                          "Asymmetry parameter [-]",
-                          "Radar reflectivity [m2]"});
-  hydrotable.set_grid_name(1, "Frequency [Hz]");
-  hydrotable.set_grid(1, f_grid);
-  hydrotable.set_grid_name(2, "Temperature [K]");
-  hydrotable.set_grid(2, T_grid);
-  hydrotable.set_grid_name(3, "Particle content [kg/m3]");
-  hydrotable.set_grid(3, wc_grid);
-
-  // Phase matrix angles
-  Vector pfct_angs;
-  get_angs(pfct_angs, scat_data, -1);
-  Index nang = pfct_angs.nelem();
-  ARTS_USER_ERROR_IF (abs(pfct_angs[nang-1]-180.0)>1e-3,
-                      "scat_data must cover scattering angles up to 180 deg");
-  
-  // Local variables
-  Matrix pnd_data;
-  Tensor3 dpnd_data_dx;
-  Matrix pnd_agenda_input(nt, 1);
-  ArrayOfString dpnd_data_dx_names(0);
-  Matrix pnd_profiles(nsetot, nt, 0.0);
-  Matrix ext_bulk_par(nf, nt);
-  Matrix abs_bulk_par(nf, nt);
-  Vector p_grid_dummy(nt, 0.0);
-  ArrayOfIndex cloudbox_limits = {0, nt-1};
-  Tensor3 pha_bulk_par(nf, nt, nang);
-  const Numeric fourpi = 4.0 * PI;
-
-  // Loop and fill table
-  for (Index iw = 0; iw < nw; iw++) {
-    // Call pnd_agenda
-    pnd_agenda_input = wc_grid[iw];
-    pnd_agenda_arrayExecute(ws,
-                            pnd_data,
-                            dpnd_data_dx,
-                            iss,
-                            T_grid,
-                            pnd_agenda_input,
-                            pnd_agenda_array_input_names[iss],
-                            dpnd_data_dx_names,
-                            pnd_agenda_array);
-    
-    // Copy to variable covering all scattering elements 
-    for (Index ise = 0; ise < nse; ise++) {
-      pnd_profiles(ise0+ise,joker) = pnd_data(joker,ise);
-    }
-    
-    // We use methods from disort to calculate the opt props
-    get_paroptprop(ext_bulk_par,
-                   abs_bulk_par,
-                   scat_data,
-                   pnd_profiles,
-                   T_grid,
-                   p_grid_dummy,
-                   cloudbox_limits,
-                   f_grid);
-    get_parZ(pha_bulk_par,
-              scat_data,
-              pnd_profiles,
-              T_grid,
-              pfct_angs,
-              cloudbox_limits);
-    /*
-    WriteXML("ascii", pfct_angs, "theta.xml", 0, "Vector", "", "", verbosity);
-    WriteXML("ascii", pha_bulk_par, "pfun.xml", 0, "Tensor3", "", "", verbosity);
-    */
-
-    // Fill the hydrotable for present particle content
-    for (Index iv = 0; iv < nf; iv++) {
-      for (Index it = 0; it < nt; it++) {
-        hydrotable.data(0,iv,it,iw) = ext_bulk_par(iv,it);
-        hydrotable.data(1,iv,it,iw) = 1.0 - (abs_bulk_par(iv,it) /
-                                             ext_bulk_par(iv,it));
-        hydrotable.data(2,iv,it,iw) = asymmetry_parameter(pfct_angs,
-                                                          pha_bulk_par(iv,it,joker));
-        hydrotable.data(3,iv,it,iw) = fourpi * pha_bulk_par(iv,it,nang-1);
       }
     }
   }

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -5495,14 +5495,16 @@ void define_md_data_raw() {
          "z_surface",
          "surface_skin_t",
          "surface_scalar_reflectivity"),
-      GIN("nstreams", "Npfct", "quiet"),
-      GIN_TYPE("Index", "Index", "Index"),
-      GIN_DEFAULT("8", "181", "0"),
+      GIN("nstreams", "Npfct", "only_tro", "quiet"),
+      GIN_TYPE("Index", "Index", "Index", "Index"),
+      GIN_DEFAULT("8", "181", "0", "0"),
       GIN_DESC("Number of polar angle directions (streams) in DISORT "
                "solution (must be an even number).",
                "Number of angular grid points to calculate bulk phase"
                " function on (and derive Legendre polynomials from). If <0,"
                " the finest za_grid from scat_data will be used.",
+               "Set to 1 if the scattering data is just of TRO type. Has effect "
+               "only if Npfct > 3, but then leads to much faster calculatuions.",
                "Silence C Disort warnings.")));
 
   md_data_raw.push_back(create_mdrecord(
@@ -5539,14 +5541,16 @@ void define_md_data_raw() {
          "f_grid",
          "za_grid",
          "stokes_dim"),
-      GIN("nstreams", "Npfct", "quiet", "inc_angle"),
-      GIN_TYPE("Index", "Index", "Index", "Numeric"),
-      GIN_DEFAULT("8", "181", "0", "-1"),
+      GIN("nstreams", "Npfct", "quiet", "only_tro", "inc_angle"),
+      GIN_TYPE("Index", "Index", "Index", "Index", "Numeric"),
+      GIN_DEFAULT("8", "181", "0", "0", "-1"),
       GIN_DESC("Number of polar angle directions (streams) in DISORT "
                "solution (must be an even number).",
                "Number of angular grid points to calculate bulk phase"
                " function on (and derive Legendre polynomials from). If <0,"
                " the finest za_grid from scat_data will be used.",
+               "Set to 1 if the scattering data is just of TRO type. Has effect "
+               "only if Npfct > 3, but then leads to much faster calculatuions.",
                "Silence C Disort warnings.",
                "Incidence angle, see above.")));
 

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -5541,7 +5541,7 @@ void define_md_data_raw() {
          "f_grid",
          "za_grid",
          "stokes_dim"),
-      GIN("nstreams", "Npfct", "quiet", "only_tro", "inc_angle"),
+      GIN("nstreams", "Npfct", "only_tro", "quiet", "inc_angle"),
       GIN_TYPE("Index", "Index", "Index", "Index", "Numeric"),
       GIN_DEFAULT("8", "181", "0", "0", "-1"),
       GIN_DESC("Number of polar angle directions (streams) in DISORT "

--- a/src/optproperties.cc
+++ b/src/optproperties.cc
@@ -23,11 +23,11 @@
   \file   optproperties.cc
   \author Claudia Emde <claudia.emde@dlr.de>
   \date   Thu Mar  6 11:29:59 2003
-  
+
   \brief  This file contains definitions and functions related to the
           optical properties of particles.
-  
-  
+
+
  */
 
 /*===========================================================================
@@ -62,7 +62,7 @@ extern const Numeric PI;
 #define F44 pha_mat_int[5]
 
 //! one-line descript
-/*! 
+/*!
   Descript/Doc
 
   \param[out] name  desc.
@@ -81,7 +81,7 @@ void methodname(//Output
 */
 
 //! Scattering species bulk extinction and absorption.
-/*! 
+/*!
   Derives bulk properties from per-scat-species bulk properties.
 
   Ptype is defined by the most complex ptype of the individual scattering
@@ -122,7 +122,7 @@ void opt_prop_Bulk(    //Output
 }
 
 //! Scattering species bulk extinction and absorption.
-/*! 
+/*!
   Derives bulk properties separately per scattering species from (input)
   per-scattering-elements extinction and absorption given over frequency,
   temperature and propagation direction.
@@ -216,7 +216,7 @@ void opt_prop_ScatSpecBulk(   //Output
 }
 
 //! Extinction and absorption from all scattering elements.
-/*! 
+/*!
   Derives temperature and direction interpolated extinction matrices and
   absorption vectors for all scattering elements present in scat_data.
 
@@ -310,7 +310,7 @@ void opt_prop_NScatElems(            //Output
 }
 
 //! Determine T-interpol parameters for a specific scattering element.
-/*! 
+/*!
   Determine T-interpol order as well as interpol positions and weights (they
   are the same for all directions (and freqs), ie it is sufficient to
   calculate them once).
@@ -338,8 +338,8 @@ ArrayOfLagrangeInterpolation ssd_tinterp_parameters(  //Output
   const Index nTout = T_array.nelem();
 
   this_T_interp_order = -1;
-  
-  
+
+
   if (nTin > 1) {
     this_T_interp_order = min(t_interp_order, nTin - 1);
 
@@ -363,12 +363,12 @@ ArrayOfLagrangeInterpolation ssd_tinterp_parameters(  //Output
       } else
         t_ok[Tind] = 1.;
     }
-    
+
     if (any_T_exceed) {
       // Reserve output
       ArrayOfLagrangeInterpolation T_lag;
       T_lag.reserve(nTout);
-      
+
       bool grid_unchecked = true;
 
       for (Index iT = 0; iT < nTout; iT++) {
@@ -397,7 +397,7 @@ ArrayOfLagrangeInterpolation ssd_tinterp_parameters(  //Output
 }
 
 //! Preparing extinction and absorption from one scattering element.
-/*! 
+/*!
   Extracts and prepares extinction matrix and absorption vector data for one
   scattering element for one or all frequencies from the single scattering data.
   Includes interpolation in temperature and to propagation direction. Handles
@@ -482,7 +482,7 @@ void opt_prop_1ScatElem(  //Output
                                              T_array,
                                              t_interp_order);
   const auto T_itw_lag = interpweights(T_lag);
-  
+
   // Now loop over requested directions (and apply simultaneously for all freqs):
   // 1) extract/interpolate direction (but not for tot.random)
   // 2) apply T-interpol
@@ -517,7 +517,7 @@ void opt_prop_1ScatElem(  //Output
       Matrix abs_vec_tmp_ssd(nTout, ssd.abs_vec_data.ncols());
       for (Index find = 0; find < nf; find++) {
         for (Index nst = 0; nst < ext_mat_tmp_ssd.ncols(); nst++) {
-          reinterp(ext_mat_tmp_ssd(joker, nst), 
+          reinterp(ext_mat_tmp_ssd(joker, nst),
                    ssd.ext_mat_data(find + f_start, joker, 0, 0, nst),
                    T_itw_lag, T_lag);
         }
@@ -657,7 +657,7 @@ void opt_prop_1ScatElem(  //Output
 }
 
 //! Extinction matrix scat_data to stokes format conversion.
-/*! 
+/*!
   Converts extinction matrix from scat_data ptype-dependent compact format to
   Stokes-notation matrix.
 
@@ -705,7 +705,7 @@ void ext_mat_SSD2Stokes(  //Output
 }
 
 //! Absorption vector scat_data to stokes format conversion.
-/*! 
+/*!
   Converts absorption vector from scat_data ptype-dependent compact format to
   Stokes-notation matrix.
 
@@ -738,7 +738,7 @@ void abs_vec_SSD2Stokes(  //Output
 }
 
 //! Scattering species bulk phase matrix.
-/*! 
+/*!
   Derives bulk properties from per-scat-species bulk properties.
 
   Ptype is defined by the most complex ptype of the individual scattering
@@ -770,7 +770,7 @@ void pha_mat_Bulk(     //Output
 }
 
 //! Scattering species bulk phase matrices.
-/*! 
+/*!
   Derives bulk properties separately per scattering species from (input)
   per-scattering-elements phase matrices given over frequency, temperature and
   propagation direction.
@@ -850,7 +850,7 @@ void pha_mat_ScatSpecBulk(    //Output
 }
 
 //! Phase matrices from all scattering elements.
-/*! 
+/*!
   Derives temperature and direction interpolated phase matrices for all
   scattering elements present in scat_data.
 
@@ -942,7 +942,7 @@ void pha_mat_NScatElems(             //Output
 }
 
 //! Preparing phase matrix from one scattering element.
-/*! 
+/*!
   Extracts and prepares phase matrix data for one scattering element for one or
   all frequencies from the single scattering data. Includes interpolation in
   temperature as well as in incident and to propagation direction. Handles
@@ -1272,7 +1272,7 @@ void pha_mat_1ScatElem(   //Output
 }
 
 //! Preparing phase matrix fourier series components for one scattering element.
-/*! 
+/*!
   Calculates phase matrix fourier series components (currently only mode 0) for
   one scattering element for one or all frequencies from the single scattering
   data. Includes interpolation in temperature as well as in incident and
@@ -1528,9 +1528,9 @@ void FouComp_1ScatElem(       //Output
 }
 
 //! Transformation of absorption vector.
-/*! 
-  In the single scattering database the data of the absorption vector is 
-  stored in different coordinate systems, depending on the type (ptype) of 
+/*!
+  In the single scattering database the data of the absorption vector is
+  stored in different coordinate systems, depending on the type (ptype) of
   the scattering particle (scattering element).
 
   See AUG for information about the different classifications of the scattering
@@ -1545,9 +1545,9 @@ void FouComp_1ScatElem(       //Output
   \param ptype Type of scattering element.
   \param za_sca Zenith angle of scattered direction.
   \param aa_sca Azimuth angle of scattered direction.
-     
+
   \author Claudia Emde
-  \date   2003-05-24 
+  \date   2003-05-24
 */
 void abs_vecTransform(  //Output and Input
     StokesVector& abs_vec_lab,
@@ -1624,9 +1624,9 @@ void abs_vecTransform(  //Output and Input
 }
 
 //! Transformation of extinction matrix.
-/*! 
-  In the single scattering database the data of the extinction matrix is 
-  stored in different coordinate systems, depending on the type (ptype) of 
+/*!
+  In the single scattering database the data of the extinction matrix is
+  stored in different coordinate systems, depending on the type (ptype) of
   the scattering particle (scattering element).
 
   See AUG for information about the different classifications of the scattering
@@ -1643,7 +1643,7 @@ void abs_vecTransform(  //Output and Input
   \param aa_sca Azimuth angle of scattered direction.
 
   \author Claudia Emde
-  \date   2003-05-24 
+  \date   2003-05-24
 */
 void ext_matTransform(  //Output and Input
     PropagationMatrix& ext_mat_lab,
@@ -1736,9 +1736,9 @@ void ext_matTransform(  //Output and Input
 }
 
 //! Transformation of phase matrix.
-/*! 
-  In the single scattering database the data of the phase matrix is 
-  stored in different coordinate systems, depending on the type (ptype) of 
+/*!
+  In the single scattering database the data of the phase matrix is
+  stored in different coordinate systems, depending on the type (ptype) of
   the scattering particle (scattering element).
 
   See AUG for information about the different classifications of the scattering
@@ -1759,7 +1759,7 @@ void ext_matTransform(  //Output and Input
                                  within aa_grid.
   \param[in]     za_grid  Grid of zenith angles to extract pha_mat for.
   \param[in]     aa_grid  Grid of azimuth angles to extract pha_mat for.
-  
+
   \author Claudia Emde
   \date   2003-08-19
 */
@@ -2010,13 +2010,13 @@ void pha_matTransform(  //Output
 }
 
 //! Derive extinction matrix from absorption vector.
-/*! 
+/*!
   In case, when only absorption of a scattering element shall be considered, and
   the scattering is neglected, the extinction matrix is set from the absorption
   vector only.
 
   Extinction matrix is set the following way:
-  
+
   K11 = K22 = K33 = K44 = a1
   K12 = K21 = a2
   K13 = K31 = a3
@@ -2031,12 +2031,12 @@ void pha_matTransform(  //Output
 
   Output and Input:
   \param ext_mat     Extinction matrix.
-  Input: 
+  Input:
   \param abs_vec     Absorption vector.
   \param stokes_dim  as the WSV.
-  
+
   \author Jana Mendrok
-  \date   2013-04-30 
+  \date   2013-04-30
 */
 void ext_matFromabs_vec(  //Output
     MatrixView ext_mat,
@@ -2060,7 +2060,7 @@ void ext_matFromabs_vec(  //Output
 }
 
 //! Calculates the scattering angle.
-/*! 
+/*!
   The scattering angle is calculated from the angles defining
   the directions of the incoming and scattered radiation.
 
@@ -2068,8 +2068,8 @@ void ext_matFromabs_vec(  //Output
   \param[in]  aa_sca       Azimuth angle of scattered direction [deg].
   \param[in]  za_inc       Zenith angle of incoming direction [deg].
   \param[in]  aa_inc       Azimuth angle of incoming direction [deg].
-  \return Scattering angle [rad].   
-  
+  \return Scattering angle [rad].
+
   \author Jana Mendrok (moved out from interpolate_scat_angle by C.Emde)
   \date   2018-03-23
 */
@@ -2097,22 +2097,22 @@ Numeric scat_angle(const Numeric& za_sca,
     }
   } else {theta_rad =
       acos(Conversion::cosd(za_sca) * Conversion::cosd(za_inc) +
-           Conversion::sind(za_sca) * Conversion::sind(za_inc) * 
+           Conversion::sind(za_sca) * Conversion::sind(za_inc) *
            Conversion::cosd(aa_sca - aa_inc));
   }
   return theta_rad;
 }
 
 //! Interpolate data on the scattering angle.
-/*! 
-  This function is used for the transformation of the phase matrix 
+/*!
+  This function is used for the transformation of the phase matrix
   from scattering frame to the laboratory frame for randomly oriented
   scattering media (case PTYPE_TOTAL_RND).
 
   The scattering angle is calculated from the angles defining
   the directions of the incoming and scattered radiation.
   After that the data (which is stored in the data files as a function
-  of the scattering angle) is interpolated on the calculated 
+  of the scattering angle) is interpolated on the calculated
   scattering angle.
 
   \param[out] pha_mat_int  Interpolated phase matrix.
@@ -2123,7 +2123,7 @@ Numeric scat_angle(const Numeric& za_sca,
   \param[in]  aa_sca       Azimuth angle of scattered direction [rad].
   \param[in]  za_inc       Zenith angle of incoming direction [rad].
   \param[in]  aa_inc       Azimuth angle of incoming direction [rad].
-     
+
   \author Claudia Emde
   \date   2003-08-19
 */
@@ -2146,13 +2146,13 @@ void interpolate_scat_angle(  //Output:
 }
 
 //! Calculate phase matrix in laboratory coordinate system.
-/*! 
+/*!
   Transformation function for the phase matrix for the case of
   randomly oriented particles (case PTYPE_TOTAL_RND).
-  
-  Some of the formulas can be found in 
 
-  Mishchenkho: "Scattering, Absorption and Emission of Light 
+  Some of the formulas can be found in
+
+  Mishchenkho: "Scattering, Absorption and Emission of Light
   by Small Particles", Cambridge University Press, 2002
   Capter 4
 
@@ -2160,16 +2160,16 @@ void interpolate_scat_angle(  //Output:
 
   Output and Input:
   \param pha_mat_lab Phase matrix in laboratory frame.
-  Input: 
+  Input:
   \param pha_mat_int Interpolated phase matrix.
   \param za_sca Zenith angle of scattered direction.
   \param aa_sca Azimuth angle of scattered direction.
   \param za_inc Zenith angle of incoming direction.
   \param aa_inc Azimuth angle of incoming direction.
   \param theta_rad Scattering angle [rad].
-  
+
   \author Claudia Emde
-  \date   2003-05-13 
+  \date   2003-05-13
 */
 void pha_mat_labCalc(  //Output:
     MatrixView pha_mat_lab,
@@ -2304,14 +2304,14 @@ void pha_mat_labCalc(  //Output:
             "sampling will be rejected and replaced with a new one.");
 
       if (stokes_dim > 2) {
-        /*CPD: For skokes_dim > 2 some of the transformation formula 
+        /*CPD: For skokes_dim > 2 some of the transformation formula
             for each element have a different sign depending on whether or
-            not 0<aa_scat-aa_inc<180.  For details see pages 94 and 95 of 
-            Mishchenkos chapter in : 
-            Mishchenko, M. I., and L. D. Travis, 2003: Electromagnetic 
-            scattering by nonspherical particles. In Exploring the Atmosphere 
-            by Remote Sensing Techniques (R. Guzzi, Ed.), Springer-Verlag, 
-            Berlin, pp. 77-127. 
+            not 0<aa_scat-aa_inc<180.  For details see pages 94 and 95 of
+            Mishchenkos chapter in :
+            Mishchenko, M. I., and L. D. Travis, 2003: Electromagnetic
+            scattering by nonspherical particles. In Exploring the Atmosphere
+            by Remote Sensing Techniques (R. Guzzi, Ed.), Springer-Verlag,
+            Berlin, pp. 77-127.
             This is available at http://www.giss.nasa.gov/~crmim/publications/ */
         Numeric delta_aa = aa_sca - aa_inc + (aa_sca - aa_inc < -180) * 360 -
                            (aa_sca - aa_inc > 180) * 360;
@@ -2373,7 +2373,7 @@ ostream& operator<<(ostream& os, const ArrayOfScatteringMetaData& /*assd*/) {
   and absorption vector for use when these are important.
 
   Internal function to replace the old opt_prop_gas_agenda.
-  
+
   Output and Input:
   \param ext_mat Extinction matrix.
   \param abs_vec Absorption vector.
@@ -2435,7 +2435,7 @@ PType PTypeFromString(const String& ptype_string) {
 //! Convert ptype name to enum value
 /*!
  Returns the PType enum value for the given String.
- 
+
  This is the conversion for SingleScatteringData version 2.
 
  \param[in]  ptype_string  Particle type name
@@ -2655,7 +2655,7 @@ String PTypeToString(const ParticleSSDMethod& particle_ssdmethod) {
 /*!
  This function interpolates scat_data and sums up values to obtain the
  extinction, absorption and phase function for one scattering species, on the
- condition that scat_data only contains data of TRO-type and a 1D atmosphere is 
+ condition that scat_data only contains data of TRO-type and a 1D atmosphere is
  given.
 
  For flexibility, the quantities are added to ext, mat and pfun. This means
@@ -2689,10 +2689,12 @@ void ext_abs_pfun_from_tro(MatrixView ext,
                            ConstVectorView sa_grid)
 {
   // Sizes
-  const Index nse = scat_data.nelem(); 
+  const Index nse = scat_data.nelem();
   const Index nf = scat_data[0].f_grid.nelem();
   const Index nt = T_grid.nelem();
   const Index nsa = sa_grid.nelem();
+  const Index ncl = cloudbox_limits[1] - cloudbox_limits[0] + 1;
+  
 
   ARTS_ASSERT(ext.nrows() == nf);
   ARTS_ASSERT(ext.ncols() == nt);
@@ -2703,10 +2705,10 @@ void ext_abs_pfun_from_tro(MatrixView ext,
   ARTS_ASSERT(pfun.ncols() == nsa);
   ARTS_ASSERT(cloudbox_limits.nelem() == 2);
   ARTS_ASSERT(pnd_data.nrows() == nse);
-  ARTS_ASSERT(pnd_data.ncols() == cloudbox_limits[1]-cloudbox_limits[0]+1);
-  
-  // Check that all data is TRO 
-  {    
+  ARTS_ASSERT(pnd_data.ncols() == ncl);
+
+  // Check that all data is TRO
+  {
     bool all_totrand = true;
     for (Index ie = 0; ie < nse; ie++) {
       if (scat_data[ie].ptype != PTYPE_TOTAL_RND)
@@ -2715,42 +2717,45 @@ void ext_abs_pfun_from_tro(MatrixView ext,
     ARTS_USER_ERROR_IF (!all_totrand,
                         "This method demands that all scat_data are TRO");
   }
+
+  // Range for layers inside the cloudbox
+  const Index i0 = cloudbox_limits[0];
+  Range clevels = Range(i0, ncl);
   
   // Loop scattering elements
   for (Index ie = 0; ie < nse; ie++) {
-    
+    // Add any check that pnd_data(ie,:) > 0?
+
     // Temperature-only interpolation weights
-    ArrayOfGridPos gp_t(nt);
-    gridpos(gp_t, scat_data[ie].T_grid, T_grid);
-    Matrix itw1(nt, 2);
+    ArrayOfGridPos gp_t(ncl);
+    gridpos(gp_t, scat_data[ie].T_grid, T_grid[clevels]);
+    Matrix itw1(ncl, 2);
     interpweights(itw1, gp_t);
 
     // Temperature + scattering angle interpolation weights
     ArrayOfGridPos gp_sa(nsa);
     gridpos(gp_sa, scat_data[ie].za_grid, sa_grid);
-    Tensor3 itw2(nt, nsa, 4);
+    Tensor3 itw2(ncl, nsa, 4);
     interpweights(itw2, gp_t, gp_sa);
 
     // Loop frequencies
     for (Index iv = 0; iv < nf; iv++) {
       // Interpolate
-      Vector ext1(nt), abs1(nt);
-      Matrix pfu1(nt,nsa);
+      Vector ext1(ncl), abs1(ncl);
+      Matrix pfu1(ncl,nsa);
       interp(ext1, itw1, scat_data[ie].ext_mat_data(iv,joker,0,0,0), gp_t);
       interp(abs1, itw1, scat_data[ie].abs_vec_data(iv,joker,0,0,0), gp_t);
       interp(pfu1, itw2, scat_data[ie].pha_mat_data(iv,joker,joker,0,0,0,0),
              gp_t, gp_sa);
 
       // Add to container variables
-      for (Index it = 0; it < nt; it++) {
-        ext(iv,it) += pnd_data(ie,it) * ext1[it];
-        abs(iv,it) += pnd_data(ie,it) * abs1[it];
+      for (Index il = 0; il < ncl; il++) {
+        ext(iv,i0+il) += pnd_data(ie,il) * ext1[il];
+        abs(iv,i0+il) += pnd_data(ie,il) * abs1[il];
         for (Index ia = 0; ia < nsa; ia++) {
-          pfun(iv,it,ia) += pnd_data(ie,it) * pfu1(it,ia);
-        }          
+          pfun(iv,i0+il,ia) += pnd_data(ie,il) * pfu1(il,ia);
+        }
       }
     }
   }
 }
-
-

--- a/src/optproperties.h
+++ b/src/optproperties.h
@@ -327,10 +327,11 @@ ParticleSSDMethod ParticleSSDMethodFromString(
 String ParticleSSDMethodToString(
     const ParticleSSDMethod& particle_ssdmethod_type);
 
-void ext_abs_pfun_from_tro(MatrixView ext,
-                           MatrixView abs,
-                           Tensor3View pfun,
+void ext_abs_pfun_from_tro(MatrixView ext_data,
+                           MatrixView abs_data,
+                           Tensor3View pfun_data,
                            const ArrayOfSingleScatteringData& scat_data,
+                           const Index& iss,
                            ConstMatrixView pnd_data,
                            ArrayOfIndex& cloudbox_limits,
                            ConstVectorView T_grid,

--- a/src/optproperties.h
+++ b/src/optproperties.h
@@ -327,4 +327,13 @@ ParticleSSDMethod ParticleSSDMethodFromString(
 String ParticleSSDMethodToString(
     const ParticleSSDMethod& particle_ssdmethod_type);
 
+void ext_abs_pfun_from_tro(MatrixView ext,
+                           MatrixView abs,
+                           Tensor3View pfun,
+                           const ArrayOfSingleScatteringData& scat_data,
+                           ConstMatrixView pnd_data,
+                           ArrayOfIndex& cloudbox_limits,
+                           ConstVectorView T_grid,
+                           ConstVectorView sa_grid);
+
 #endif  //optproperties_h


### PR DESCRIPTION
This started by that I needed a method to generate lookup tables like the ones in RTTOV-SCATT. Produced tables compared to data generated by Vasilis. In the process also detected errors in a published figure! That is, method well tested.

When doing this I realised that the same code could be used to speed up DISORT for cases with just TRO scattering data. This implemented, and improvement about 25%. Results checked by comparison to old version.