### PR TITLE
Faster binio reading

### DIFF
--- a/src/bofstream.h
+++ b/src/bofstream.h
@@ -45,13 +45,8 @@ class bofstream : public binostream, public ofstream {
 
   explicit bofstream(const char* name,
                      ios::openmode mode = ios::out | ios::trunc | ios::binary)
-      : ofstream(name, mode) {
-    // Set Little Endian mode, with IEEE-754 floats.
-    this->setFlag(binio::BigEndian, false);  // remove flag
-    this->setFlag(binio::FloatIEEE);         // set flag
-  }
+      : ofstream(name, mode) {}
 
-  virtual ~bofstream() {}
   void seek(long spos, Offset offs) override final;
   streampos pos() override final;
 

--- a/src/xml_io_general_types.cc
+++ b/src/xml_io_general_types.cc
@@ -120,17 +120,11 @@ void xml_read_from_stream(istream& is_xml,
   tag.get_attribute_value("ncols", ncols);
   matrix.resize(nrows, ncols);
 
-  for (Index r = 0; r < nrows; r++) {
-    for (Index c = 0; c < ncols; c++) {
-      if (pbifs) {
-        *pbifs >> matrix(r, c);
-        if (pbifs->fail()) {
-          ostringstream os;
-          os << " near "
-             << "\n  Row   : " << r << "\n  Column: " << c;
-          xml_data_parse_error(tag, os.str());
-        }
-      } else {
+  if (pbifs) {
+    pbifs->readDoubleArray(matrix.get_c_array(), nrows * ncols);
+  } else {
+    for (Index r = 0; r < nrows; r++) {
+      for (Index c = 0; c < ncols; c++) {
         is_xml >> double_imanip() >> matrix(r, c);
         if (is_xml.fail()) {
           ostringstream os;
@@ -338,16 +332,10 @@ void xml_read_from_stream(istream& is_xml,
   tag.read_from_stream(is_xml);
   tag.check_name("SparseData");
 
-  for (Index i = 0; i < nnz; i++) {
-    if (pbifs) {
-      *pbifs >> data[i];
-      if (pbifs->fail()) {
-        ostringstream os;
-        os << " near "
-           << "\n  Data element: " << i;
-        xml_data_parse_error(tag, os.str());
-      }
-    } else {
+  if (pbifs) {
+    pbifs->readDoubleArray(data.get_c_array(), nnz);
+  } else {
+    for (Index i = 0; i < nnz; i++) {
       is_xml >> double_imanip() >> data[i];
       if (is_xml.fail()) {
         ostringstream os;
@@ -572,19 +560,12 @@ void xml_read_from_stream(istream& is_xml,
   tag.get_attribute_value("ncols", ncols);
   tensor.resize(npages, nrows, ncols);
 
-  for (Index p = 0; p < npages; p++) {
-    for (Index r = 0; r < nrows; r++) {
-      for (Index c = 0; c < ncols; c++) {
-        if (pbifs) {
-          *pbifs >> tensor(p, r, c);
-          if (pbifs->fail()) {
-            ostringstream os;
-            os << " near "
-               << "\n  Page  : " << p << "\n  Row   : " << r
-               << "\n  Column: " << c;
-            xml_data_parse_error(tag, os.str());
-          }
-        } else {
+  if (pbifs) {
+    pbifs->readDoubleArray(tensor.get_c_array(), npages * nrows * ncols);
+  } else {
+    for (Index p = 0; p < npages; p++) {
+      for (Index r = 0; r < nrows; r++) {
+        for (Index c = 0; c < ncols; c++) {
           is_xml >> double_imanip() >> tensor(p, r, c);
           if (is_xml.fail()) {
             ostringstream os;
@@ -675,20 +656,14 @@ void xml_read_from_stream(istream& is_xml,
   tag.get_attribute_value("ncols", ncols);
   tensor = Tensor4(nbooks, npages, nrows, ncols);
 
-  for (Index b = 0; b < nbooks; b++) {
-    for (Index p = 0; p < npages; p++) {
-      for (Index r = 0; r < nrows; r++) {
-        for (Index c = 0; c < ncols; c++) {
-          if (pbifs) {
-            *pbifs >> tensor(b, p, r, c);
-            if (pbifs->fail()) {
-              ostringstream os;
-              os << " near "
-                 << "\n  Book  : " << b << "\n  Page  : " << p
-                 << "\n  Row   : " << r << "\n  Column: " << c;
-              xml_data_parse_error(tag, os.str());
-            }
-          } else {
+  if (pbifs) {
+    pbifs->readDoubleArray(tensor.get_c_array(),
+                           nbooks * npages * nrows * ncols);
+  } else {
+    for (Index b = 0; b < nbooks; b++) {
+      for (Index p = 0; p < npages; p++) {
+        for (Index r = 0; r < nrows; r++) {
+          for (Index c = 0; c < ncols; c++) {
             is_xml >> double_imanip() >> tensor(b, p, r, c);
             if (is_xml.fail()) {
               ostringstream os;
@@ -784,22 +759,15 @@ void xml_read_from_stream(istream& is_xml,
   tag.get_attribute_value("ncols", ncols);
   tensor.resize(nshelves, nbooks, npages, nrows, ncols);
 
-  for (Index s = 0; s < nshelves; s++) {
-    for (Index b = 0; b < nbooks; b++) {
-      for (Index p = 0; p < npages; p++) {
-        for (Index r = 0; r < nrows; r++) {
-          for (Index c = 0; c < ncols; c++) {
-            if (pbifs) {
-              *pbifs >> tensor(s, b, p, r, c);
-              if (pbifs->fail()) {
-                ostringstream os;
-                os << " near "
-                   << "\n  Shelf : " << s << "\n  Book  : " << b
-                   << "\n  Page  : " << p << "\n  Row   : " << r
-                   << "\n  Column: " << c;
-                xml_data_parse_error(tag, os.str());
-              }
-            } else {
+  if (pbifs) {
+    pbifs->readDoubleArray(tensor.get_c_array(),
+                           nshelves * nbooks * npages * nrows * ncols);
+  } else {
+    for (Index s = 0; s < nshelves; s++) {
+      for (Index b = 0; b < nbooks; b++) {
+        for (Index p = 0; p < npages; p++) {
+          for (Index r = 0; r < nrows; r++) {
+            for (Index c = 0; c < ncols; c++) {
               is_xml >> double_imanip() >> tensor(s, b, p, r, c);
               if (is_xml.fail()) {
                 ostringstream os;
@@ -901,23 +869,17 @@ void xml_read_from_stream(istream& is_xml,
   tag.get_attribute_value("ncols", ncols);
   tensor.resize(nvitrines, nshelves, nbooks, npages, nrows, ncols);
 
-  for (Index v = 0; v < nvitrines; v++) {
-    for (Index s = 0; s < nshelves; s++) {
-      for (Index b = 0; b < nbooks; b++) {
-        for (Index p = 0; p < npages; p++) {
-          for (Index r = 0; r < nrows; r++) {
-            for (Index c = 0; c < ncols; c++) {
-              if (pbifs) {
-                *pbifs >> tensor(v, s, b, p, r, c);
-                if (pbifs->fail()) {
-                  ostringstream os;
-                  os << " near "
-                     << "\n  Vitrine: " << v << "\n  Shelf  : " << s
-                     << "\n  Book   : " << b << "\n  Page   : " << p
-                     << "\n  Row    : " << r << "\n  Column : " << c;
-                  xml_data_parse_error(tag, os.str());
-                }
-              } else {
+  if (pbifs) {
+    pbifs->readDoubleArray(
+        tensor.get_c_array(),
+        nvitrines * nshelves * nbooks * npages * nrows * ncols);
+  } else {
+    for (Index v = 0; v < nvitrines; v++) {
+      for (Index s = 0; s < nshelves; s++) {
+        for (Index b = 0; b < nbooks; b++) {
+          for (Index p = 0; p < npages; p++) {
+            for (Index r = 0; r < nrows; r++) {
+              for (Index c = 0; c < ncols; c++) {
                 is_xml >> double_imanip() >> tensor(v, s, b, p, r, c);
                 if (is_xml.fail()) {
                   ostringstream os;
@@ -1024,25 +986,18 @@ void xml_read_from_stream(istream& is_xml,
   tag.get_attribute_value("ncols", ncols);
   tensor.resize(nlibraries, nvitrines, nshelves, nbooks, npages, nrows, ncols);
 
-  for (Index l = 0; l < nlibraries; l++) {
-    for (Index v = 0; v < nvitrines; v++) {
-      for (Index s = 0; s < nshelves; s++) {
-        for (Index b = 0; b < nbooks; b++) {
-          for (Index p = 0; p < npages; p++) {
-            for (Index r = 0; r < nrows; r++) {
-              for (Index c = 0; c < ncols; c++) {
-                if (pbifs) {
-                  *pbifs >> tensor(l, v, s, b, p, r, c);
-                  if (pbifs->fail()) {
-                    ostringstream os;
-                    os << " near "
-                       << "\n  Library: " << l << "\n  Vitrine: " << v
-                       << "\n  Shelf  : " << s << "\n  Book   : " << b
-                       << "\n  Page   : " << p << "\n  Row    : " << r
-                       << "\n  Column : " << c;
-                    xml_data_parse_error(tag, os.str());
-                  }
-                } else {
+  if (pbifs) {
+    pbifs->readDoubleArray(
+        tensor.get_c_array(),
+        nlibraries * nvitrines * nshelves * nbooks * npages * nrows * ncols);
+  } else {
+    for (Index l = 0; l < nlibraries; l++) {
+      for (Index v = 0; v < nvitrines; v++) {
+        for (Index s = 0; s < nshelves; s++) {
+          for (Index b = 0; b < nbooks; b++) {
+            for (Index p = 0; p < npages; p++) {
+              for (Index r = 0; r < nrows; r++) {
+                for (Index c = 0; c < ncols; c++) {
                   is_xml >> double_imanip() >> tensor(l, v, s, b, p, r, c);
                   if (is_xml.fail()) {
                     ostringstream os;
@@ -1146,16 +1101,10 @@ void xml_parse_from_stream(istream& is_xml,
   tag.get_attribute_value("nelem", nelem);
   vector.resize(nelem);
 
-  for (Index n = 0; n < nelem; n++) {
-    if (pbifs) {
-      *pbifs >> vector[n];
-      if (pbifs->fail()) {
-        ostringstream os;
-        os << " near "
-           << "\n  Element: " << n;
-        xml_data_parse_error(tag, os.str());
-      }
-    } else {
+  if (pbifs) {
+    pbifs->readDoubleArray(vector.get_c_array(), vector.nelem());
+  } else {
+    for (Index n = 0; n < nelem; n++) {
       is_xml >> double_imanip() >> vector[n];
       if (is_xml.fail()) {
         ostringstream os;


### PR DESCRIPTION
Add new function binistream::readDoubleArray to improve read
performance of binary xml files significantly (up to 20x depending
on disk speed, OS and compiler) by reading directly into the memory
of the matpack variable, bypassing the slow istream::read.

Here are two benchmarks on Linux (GCC x86_64) and on macOS (Clang arm64).
Case 1 is reading a 76MB Vector, case 2 a 760MB GriddedField3:

|                 | Case 1  | Case 2 |
|-----------------|---------|--------|
| Linux (master)  | 0.2287s | 2.479s |
| Linux (this PR) | 0.0123s | 0.165s |
| macOS (master)  | 0.1318s | 1.451s |
| macOS (this PR) | 0.0071s | 0.081s |

Both systems show a performance increase of around 15-18x.
Note that the files are cached in memory to benchmark
the actual code performance, not the performance of the disk.
However, all times for the "before" tests are still significantly slower
than the available bandwidth of the underlying SSD could offer.
