### PR TITLE
Always overwrite the default value

### DIFF
--- a/python/test/workspace/test_agendas.py
+++ b/python/test/workspace/test_agendas.py
@@ -209,6 +209,29 @@ class TestAgendas:
         self.ws = pyarts.workspace.Workspace()
         with pytest.raises(Exception):
               self.ws.abs_xsec_agenda = abs_xsec_agenda
+              
+    def test_multiple_workspace_defaults(self):
+        """
+        Tests that we can reliably use multiple workspaces with default GINs
+        """
+        @pyarts.workspace.arts_agenda
+        def myagenda(ws):
+            """
+            A simple delayed agenda that has defaults
+            """
+            ws.WriteXML("ascii", [1,2,3])
+
+        def do_something():
+            """
+            A simple function that has its own workspace
+            """
+            ws = pyarts.workspace.Workspace()
+            ws.test_agenda = myagenda
+            ws.AgendaExecute(ws.test_agenda)
+        
+        # Call twice to test multiple defaults
+        do_something()
+        do_something()
 
 
 if __name__ == "__main__":

--- a/src/python_interface/gen_auto_py.cpp
+++ b/src/python_interface/gen_auto_py.cpp
@@ -1625,9 +1625,9 @@ void WorkspaceVariable::pop_workspace_level() { ws.pop_free(pos); }
 }
 
 Index create_workspace_gin_default_internal(Workspace& ws, const String& key) {
-  if (auto ptr = ws.WsvMap.find(key); ptr not_eq ws.WsvMap.end()) return ptr -> second;
+  auto ptr = ws.WsvMap.find(key);
   
-  Index pos=-1;
+  Index pos = ptr == ws.WsvMap.end() ? -1 : ptr -> second;
   )--";
 
   std::map<String, TypeVal> has;
@@ -1643,10 +1643,11 @@ Index create_workspace_gin_default_internal(Workspace& ws, const String& key) {
 
   for (auto& [key, items] : has) {
     os << "if (key == \"" << key << "\") {\n";
+    os << "    if (pos < 0) pos = ws.add_wsv_inplace(WsvRecord(\""
+       << key << R"(", "do not modify", )"
+       << arts.group.at(items.type) << "));\n";
     os << "    static_cast<" << items.type
-       << " &>(WorkspaceVariable{ws, pos = ws.add_wsv_inplace(WsvRecord(\""
-       << key << R"(", "A default GIN value; modify at own risk", )"
-       << arts.group.at(items.type) << "))}) = " << items.type << '('
+       << " &>(WorkspaceVariable{ws, pos}) = " << items.type << '('
        << items.val << ')';
     os << ";\n";
     os << "  } else ";


### PR DESCRIPTION
This is a workaround while we still have a static map for workspace variable names.