### PR TITLE
Use int64_t for Index

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,13 +100,6 @@ if (ENABLE_FORTRAN)
     message (FATAL_ERROR "Unsupported Fortran compiler. Must be gfortran or ifort.")
   endif (FORTRAN_COMPILER MATCHES "gfortran.*")
 
-  INCLUDE (CheckTypeSize)
-  CHECK_TYPE_SIZE (long SIZEOF_LONG)
-  if (NOT SIZEOF_LONG EQUAL 8)
-    message (FATAL_ERROR "Fortran interface only works on 64-bit with long size of 8 bytes.\n"
-      "Size of long on this system: ${SIZEOF_LONG} bytes")
-  endif (NOT SIZEOF_LONG EQUAL 8)
-
 endif (ENABLE_FORTRAN)
 
 if (NOT CMAKE_BUILD_TYPE)
@@ -128,7 +121,7 @@ if (NOT NUMERIC)
 endif (NOT NUMERIC)
 
 if (NOT INDEX)
-  set (INDEX long)
+  set (INDEX std::int64_t)
 endif (NOT INDEX)
 
 add_definitions (-DHAVE_CONFIG_H)

--- a/src/bifstream.cc
+++ b/src/bifstream.cc
@@ -82,8 +82,8 @@ bifstream& operator>>(bifstream& bif, float& n) {
   return (bif);
 }
 
-bifstream& operator>>(bifstream& bif, long& n) {
-  n = (long)bif.readInt(4);
+bifstream& operator>>(bifstream& bif, std::int64_t& n) {
+  n = static_cast<std::int64_t>(bif.readInt(4));
   return (bif);
 }
 

--- a/src/bifstream.h
+++ b/src/bifstream.h
@@ -83,7 +83,7 @@ bifstream& operator>>(bifstream& bif, double& n);
 
 bifstream& operator>>(bifstream& bif, float& n);
 
-bifstream& operator>>(bifstream& bif, long& n);
+bifstream& operator>>(bifstream& bif, std::int64_t& n);
 
 bifstream& operator>>(bifstream& bif, int& n);
 

--- a/src/binio.h
+++ b/src/binio.h
@@ -77,7 +77,7 @@ class binio {
   virtual std::streampos pos() = 0;
 
  protected:
-  using Int = long;
+  using Int = std::int64_t;
   using Float = double;
   using Byte = unsigned char;  // has to be unsigned!
 

--- a/src/bofstream.cc
+++ b/src/bofstream.cc
@@ -83,7 +83,7 @@ bofstream& operator<<(bofstream& bof, float n) {
   return (bof);
 }
 
-bofstream& operator<<(bofstream& bof, long n) {
+bofstream& operator<<(bofstream& bof, std::int64_t n) {
   bof.writeInt(n, 4);
   return (bof);
 }

--- a/src/bofstream.h
+++ b/src/bofstream.h
@@ -59,7 +59,7 @@ bofstream& operator<<(bofstream& bof, double n);
 
 bofstream& operator<<(bofstream& bof, float n);
 
-bofstream& operator<<(bofstream& bof, long n);
+bofstream& operator<<(bofstream& bof, std::int64_t n);
 
 bofstream& operator<<(bofstream& bof, int n);
 

--- a/src/disort.cc
+++ b/src/disort.cc
@@ -923,7 +923,7 @@ void run_cdisort(Workspace& ws,
   get_pmom(pmom, pfct_bulk_par, pfct_angs, Nlegendre);
 
   for (Index f_index = 0; f_index < f_grid.nelem(); f_index++) {
-    sprintf(ds.header, "ARTS Calc f_index = %ld", f_index);
+    sprintf(ds.header, "ARTS Calc f_index = %lld", f_index);
 
     std::memcpy(ds.dtauc,
                 dtauc(f_index, joker).get_c_array(),

--- a/src/gui/plot.cc
+++ b/src/gui/plot.cc
@@ -74,7 +74,7 @@ void plot(const ArrayOfVector& xdata, const ArrayOfVector& ydata) {
         ImGui::Text("Invalid sizes, xdata is %ld elements and ydata is %ld elements", xdata.size(), ydata.size());
       else {
         for (Index i=0; i<xdata.nelem(); i++) {
-          ImGui::Text("xdata[%ld] is %ld elements and ydata[%ld] is %ld elements", i, xdata[i].size(), i, ydata[i].size());
+          ImGui::Text("xdata[%lld] is %lld elements and ydata[%lld] is %lld elements", i, xdata[i].size(), i, ydata[i].size());
         }
       }
     }

--- a/src/gui/propmat.cc
+++ b/src/gui/propmat.cc
@@ -797,7 +797,7 @@ void propmat(PropmatClearsky::ResultsArray& res,
 
       // Display current frequency grid
       ImGui::Text(
-          "\tFrequency Grid:\n\t  Start: %g Hz%c\t\n\t  Stop: %g Hz%c\t\n\t  nelem: %ld%c\t",
+          "\tFrequency Grid:\n\t  Start: %g Hz%c\t\n\t  Stop: %g Hz%c\t\n\t  nelem: %lld%c\t",
           v.f_grid[0],
           v.f_grid[0] == f_grid[0] ? ' ' : '*',
           v.f_grid[v.f_grid.nelem() - 1],

--- a/src/linemixing_hitran.cc
+++ b/src/linemixing_hitran.cc
@@ -301,7 +301,7 @@ void readlines(CommonBlock& cmn, const String& basedir="data_new/")
         char iv11, iv12, iv21, iv22, il21, il22, iv31, iv32, ir1, fv11, fv12, fv21, fv22, fl21, fl22, fv31, fv32, fr1;
         
         sscanf(line.c_str(), 
-               "%c%c" "%1ld" "%12lf" "%10lf"
+               "%c%c" "%1lld" "%12lf" "%10lf"
                "%10lf" "%5lf" "%5lf" "%4lf"
                "%5lf" "%5lf" "%4lf" "%10lf"
                "%4lf" "%4lf" "%8lf" 
@@ -310,7 +310,7 @@ void readlines(CommonBlock& cmn, const String& basedir="data_new/")
                "%c%c%c%c%c%c"
                "%c%c" "%c%c" "%c%c" "%c%c" "%c"
                "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
-               "%c" "%3ld" "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
+               "%c" "%3lld" "%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c%c"
                "%5lf" "%5lf" "%4lf" "%5lf"
                "%20s" "%20s",
                &x,&x,
@@ -1783,15 +1783,15 @@ void detband(CommonBlock& cmn,
     Index isotr, lfr, lir, jmxp, jmxq, jmxr;
     char c11, c12, c21, c22, c31, c32, c41, c42, c51, c52, x;
     sscanf(line.c_str(), 
-           "%1ld"
-           "%c%c" "%1ld" "%c%c"
-           "%c%c" "%1ld" "%c%c"
+           "%1lld"
+           "%c%c" "%1lld" "%c%c"
+           "%c%c" "%1lld" "%c%c"
            "%c%c"
            "%12lf"
            "%c" "%12lf"
            "%c" "%12lf"
            "%c%c%c%c%c%c%c%c"
-           "%4ld" "%4ld" "%4ld",
+           "%4lld" "%4lld" "%4lld",
            &isotr,
            &c11, &c12, &lfr, &c21, &c22,
            &c31, &c32, &lir, &c41, &c42,
@@ -1814,7 +1814,7 @@ void detband(CommonBlock& cmn,
       cmn.Bands.lf[cmn.Bands.nBand] = lfr;
       
       char name[15];
-      sprintf(name, "S%ld%c%c%ld%c%c%c%c%ld%c%c%c%c", isotr, c11, c12, lfr, c21, c22, c31, c32, lir, c41, c42, c51, c52);
+      sprintf(name, "S%lld%c%c%lld%c%c%c%c%lld%c%c%c%c", isotr, c11, c12, lfr, c21, c22, c31, c32, lir, c41, c42, c51, c52);
       cmn.Bands.BandFile[cmn.Bands.nBand] = name;
       cmn.Bands.nBand++;
       ARTS_USER_ERROR_IF (cmn.Bands.nBand > parameters::nBmx,
@@ -1846,7 +1846,7 @@ void readw(CommonBlock& cmn, const String& basedir="data_new/")
         sscanf(line.c_str(), 
                "%20s" "%20s"
                "%14lf" "%14lf"
-               "%4ld" "%4ld" "%4ld" "%4ld",
+               "%4lld" "%4lld" "%4lld" "%4lld",
                sw0r, sb0r, &dmaxdt, &wtmax, &jic, &jfc, &jipc, &jfpc);
         String ssw0r = sw0r;
         std::replace(ssw0r.begin(), ssw0r.end(), 'D', 'E');

--- a/src/python_interface/py_matpack.cpp
+++ b/src/python_interface/py_matpack.cpp
@@ -134,12 +134,14 @@ via x.value)--");
           [](const Matrix& x) { return Matrix(transpose(x)); },
           "Non-trivial transpose")
       .def_buffer([](Matrix& x) -> py::buffer_info {
-        return py::buffer_info(x.get_c_array(),
-                               sizeof(Numeric),
-                               py::format_descriptor<Numeric>::format(),
-                               2,
-                               {x.nrows(), x.ncols()},
-                               {sizeof(Numeric) * x.ncols(), sizeof(Numeric)});
+        return py::buffer_info(
+            x.get_c_array(),
+            sizeof(Numeric),
+            py::format_descriptor<Numeric>::format(),
+            2,
+            {static_cast<ssize_t>(x.nrows()), static_cast<ssize_t>(x.ncols())},
+            {sizeof(Numeric) * static_cast<ssize_t>(x.ncols()),
+             sizeof(Numeric)});
       })
       .def_property("value",
                     py::cpp_function(
@@ -189,14 +191,17 @@ via x.value)--");
       .PythonInterfaceFileIO(Tensor3)
       .PythonInterfaceValueOperators
       .def_buffer([](Tensor3& x) -> py::buffer_info {
-        return py::buffer_info(x.get_c_array(),
-                               sizeof(Numeric),
-                               py::format_descriptor<Numeric>::format(),
-                               3,
-                               {x.npages(), x.nrows(), x.ncols()},
-                               {sizeof(Numeric) * x.nrows() * x.ncols(),
-                                sizeof(Numeric) * x.ncols(),
-                                sizeof(Numeric)});
+        return py::buffer_info(
+            x.get_c_array(),
+            sizeof(Numeric),
+            py::format_descriptor<Numeric>::format(),
+            3,
+            {static_cast<ssize_t>(x.npages()),
+             static_cast<ssize_t>(x.nrows()),
+             static_cast<ssize_t>(x.ncols())},
+            {sizeof(Numeric) * static_cast<ssize_t>(x.nrows() * x.ncols()),
+             sizeof(Numeric) * static_cast<ssize_t>(x.ncols()),
+             sizeof(Numeric)});
       })
       .def_property("value",
                     py::cpp_function(
@@ -255,10 +260,14 @@ via x.value)--");
             sizeof(Numeric),
             py::format_descriptor<Numeric>::format(),
             4,
-            {x.nbooks(), x.npages(), x.nrows(), x.ncols()},
-            {sizeof(Numeric) * x.npages() * x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.ncols(),
+            {static_cast<ssize_t>(x.nbooks()),
+             static_cast<ssize_t>(x.npages()),
+             static_cast<ssize_t>(x.nrows()),
+             static_cast<ssize_t>(x.ncols())},
+            {sizeof(Numeric) *
+                 static_cast<ssize_t>(x.npages() * x.ncols() * x.nrows()),
+             sizeof(Numeric) * static_cast<ssize_t>(x.ncols() * x.nrows()),
+             sizeof(Numeric) * static_cast<ssize_t>(x.ncols()),
              sizeof(Numeric)});
       })
       .def_property("value",
@@ -321,11 +330,17 @@ via x.value)--");
             sizeof(Numeric),
             py::format_descriptor<Numeric>::format(),
             5,
-            {x.nshelves(), x.nbooks(), x.npages(), x.nrows(), x.ncols()},
-            {sizeof(Numeric) * x.nbooks() * x.npages() * x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.npages() * x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.ncols(),
+            {static_cast<ssize_t>(x.nshelves()),
+             static_cast<ssize_t>(x.nbooks()),
+             static_cast<ssize_t>(x.npages()),
+             static_cast<ssize_t>(x.nrows()),
+             static_cast<ssize_t>(x.ncols())},
+            {sizeof(Numeric) * static_cast<ssize_t>(x.nbooks() * x.npages() *
+                                                    x.ncols() * x.nrows()),
+             sizeof(Numeric) *
+                 static_cast<ssize_t>(x.npages() * x.ncols() * x.nrows()),
+             sizeof(Numeric) * static_cast<ssize_t>(x.ncols() * x.nrows()),
+             sizeof(Numeric) * static_cast<ssize_t>(x.ncols()),
              sizeof(Numeric)});
       })
       .def_property("value",
@@ -392,18 +407,21 @@ via x.value)--");
             sizeof(Numeric),
             py::format_descriptor<Numeric>::format(),
             6,
-            {x.nvitrines(),
-             x.nshelves(),
-             x.nbooks(),
-             x.npages(),
-             x.nrows(),
-             x.ncols()},
-            {sizeof(Numeric) * x.nshelves() * x.nbooks() * x.npages() *
-                 x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.nbooks() * x.npages() * x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.npages() * x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.ncols(),
+            {static_cast<ssize_t>(x.nvitrines()),
+             static_cast<ssize_t>(x.nshelves()),
+             static_cast<ssize_t>(x.nbooks()),
+             static_cast<ssize_t>(x.npages()),
+             static_cast<ssize_t>(x.nrows()),
+             static_cast<ssize_t>(x.ncols())},
+            {sizeof(Numeric) *
+                 static_cast<ssize_t>(x.nshelves() * x.nbooks() * x.npages() *
+                                      x.ncols() * x.nrows()),
+             sizeof(Numeric) * static_cast<ssize_t>(x.nbooks() * x.npages() *
+                                                    x.ncols() * x.nrows()),
+             sizeof(Numeric) *
+                 static_cast<ssize_t>(x.npages() * x.ncols() * x.nrows()),
+             sizeof(Numeric) * static_cast<ssize_t>(x.ncols() * x.nrows()),
+             sizeof(Numeric) * static_cast<ssize_t>(x.ncols()),
              sizeof(Numeric)});
       })
       .def_property("value",
@@ -475,21 +493,25 @@ via x.value)--");
             sizeof(Numeric),
             py::format_descriptor<Numeric>::format(),
             7,
-            {x.nlibraries(),
-             x.nvitrines(),
-             x.nshelves(),
-             x.nbooks(),
-             x.npages(),
-             x.nrows(),
-             x.ncols()},
-            {sizeof(Numeric) * x.nvitrines() * x.nshelves() * x.nbooks() *
-                 x.npages() * x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.nshelves() * x.nbooks() * x.npages() *
-                 x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.nbooks() * x.npages() * x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.npages() * x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.ncols() * x.nrows(),
-             sizeof(Numeric) * x.ncols(),
+            {static_cast<ssize_t>(x.nlibraries()),
+             static_cast<ssize_t>(x.nvitrines()),
+             static_cast<ssize_t>(x.nshelves()),
+             static_cast<ssize_t>(x.nbooks()),
+             static_cast<ssize_t>(x.npages()),
+             static_cast<ssize_t>(x.nrows()),
+             static_cast<ssize_t>(x.ncols())},
+            {sizeof(Numeric) * static_cast<ssize_t>(
+                                   x.nvitrines() * x.nshelves() * x.nbooks() *
+                                   x.npages() * x.ncols() * x.nrows()),
+             sizeof(Numeric) *
+                 static_cast<ssize_t>(x.nshelves() * x.nbooks() * x.npages() *
+                                      x.ncols() * x.nrows()),
+             sizeof(Numeric) * static_cast<ssize_t>(x.nbooks() * x.npages() *
+                                                    x.ncols() * x.nrows()),
+             sizeof(Numeric) *
+                 static_cast<ssize_t>(x.npages() * x.ncols() * x.nrows()),
+             sizeof(Numeric) * static_cast<ssize_t>(x.ncols() * x.nrows()),
+             sizeof(Numeric) * static_cast<ssize_t>(x.ncols()),
              sizeof(Numeric)});
       })
       .def_property("value",

--- a/src/python_interface/py_rte.cpp
+++ b/src/python_interface/py_rte.cpp
@@ -32,14 +32,18 @@ void py_rte(py::module_& m) {
                                   ? t.T2.data()->data()
                                   : (t.stokes_dim == 3 ? t.T3.data()->data()
                                                        : t.T4.data()->data()));
-        return py::buffer_info(ptr,
-                               sizeof(Numeric),
-                               py::format_descriptor<Numeric>::format(),
-                               3,
-                               {t.Frequencies(), t.stokes_dim, t.stokes_dim},
-                               {sizeof(Numeric) * t.stokes_dim * t.stokes_dim,
-                                sizeof(Numeric) * t.stokes_dim,
-                                sizeof(Numeric)});
+        return py::buffer_info(
+            ptr,
+            sizeof(Numeric),
+            py::format_descriptor<Numeric>::format(),
+            3,
+            {static_cast<ssize_t>(t.Frequencies()),
+             static_cast<ssize_t>(t.stokes_dim),
+             static_cast<ssize_t>(t.stokes_dim)},
+            {sizeof(Numeric) *
+                 static_cast<ssize_t>(t.stokes_dim * t.stokes_dim),
+             sizeof(Numeric) * static_cast<ssize_t>(t.stokes_dim),
+             sizeof(Numeric)});
       })
       .def_property("value",
                     py::cpp_function(
@@ -49,7 +53,8 @@ void py_rte(py::module_& m) {
                         },
                         py::keep_alive<0, 1>()),
                     [](TransmissionMatrix& x, TransmissionMatrix& y) { x = y; })
-      .PythonInterfaceValueOperators.def(py::pickle(
+      .PythonInterfaceValueOperators
+      .def(py::pickle(
           [](const TransmissionMatrix& self) {
             return py::make_tuple(
                 self.stokes_dim, self.T1, self.T2, self.T3, self.T4);
@@ -94,7 +99,8 @@ void py_rte(py::module_& m) {
             py::format_descriptor<Numeric>::format(),
             2,
             {t.Frequencies(), t.stokes_dim},
-            {sizeof(Numeric) * t.stokes_dim, sizeof(Numeric)});
+            {sizeof(Numeric) * static_cast<ssize_t>(t.stokes_dim),
+             sizeof(Numeric)});
       })
       .def_property("value",
                     py::cpp_function(
@@ -104,7 +110,8 @@ void py_rte(py::module_& m) {
                         },
                         py::keep_alive<0, 1>()),
                     [](RadiationVector& x, RadiationVector& y) { x = y; })
-      .PythonInterfaceValueOperators.def(py::pickle(
+      .PythonInterfaceValueOperators
+      .def(py::pickle(
           [](const RadiationVector& self) {
             return py::make_tuple(
                 self.stokes_dim, self.R1, self.R2, self.R3, self.R4);


### PR DESCRIPTION
We need a guaranteed 64-bit type for Index, long is only 32-bit on some systems (e.g. Windows).