### PR TITLE
Use reference types in firstprivate

### DIFF
--- a/src/m_abs_lookup.cc
+++ b/src/m_abs_lookup.cc
@@ -360,7 +360,7 @@ Your current lowest_vmr value is: )--", lowest_vmr)
     !arts_omp_in_parallel() &&                                        \
     these_t_pert_nelem >=                                             \
         arts_omp_get_max_threads()) private(this_t)                   \
-    firstprivate(ws, propmat_clearsky_agenda)
+    firstprivate(ws)
       for (Index j = 0; j < these_t_pert_nelem; ++j) {
         // Skip remaining iterations if an error occurred
         if (failed) continue;
@@ -2230,13 +2230,10 @@ void propmat_clearsky_fieldCalc(Workspace& ws,
 
   // Now we have to loop all points in the atmosphere:
   if (n_pressures)
-#pragma omp parallel for if (!arts_omp_in_parallel() &&                        \
-                             n_pressures >= arts_omp_get_max_threads())        \
-    firstprivate(ws, abs_agenda, this_f_grid) private(abs,                 \
-                                                          nlte,                \
-                                                          partial_abs,         \
-                                                          partial_nlte,        \
-                                                          a_vmr_list)
+#pragma omp parallel for if (!arts_omp_in_parallel() &&                 \
+                             n_pressures >= arts_omp_get_max_threads()) \
+    firstprivate(ws, this_f_grid) private(                              \
+        abs, nlte, partial_abs, partial_nlte, a_vmr_list)
     for (Index ipr = 0; ipr < n_pressures; ++ipr)  // Pressure:  ipr
     {
       // Skip remaining iterations if an error occurred

--- a/src/m_abs_lookup.cc
+++ b/src/m_abs_lookup.cc
@@ -266,11 +266,6 @@ Your current lowest_vmr value is: )--", lowest_vmr)
   String fail_msg;
   bool failed = false;
 
-  // We have to make a local copy of the Workspace and the agenda because
-  // only non-reference types can be declared firstprivate in OpenMP
-  Workspace l_ws(ws);
-  Agenda l_propmat_clearsky_agenda(propmat_clearsky_agenda);
-
   // Loop species:
   for (Index i = 0, spec = 0; i < n_species; ++i) {
     // Skipping Zeeman and free_electrons species.
@@ -365,7 +360,7 @@ Your current lowest_vmr value is: )--", lowest_vmr)
     !arts_omp_in_parallel() &&                                        \
     these_t_pert_nelem >=                                             \
         arts_omp_get_max_threads()) private(this_t)                   \
-    firstprivate(l_ws, l_propmat_clearsky_agenda)
+    firstprivate(ws, propmat_clearsky_agenda)
       for (Index j = 0; j < these_t_pert_nelem; ++j) {
         // Skip remaining iterations if an error occurred
         if (failed) continue;
@@ -401,7 +396,7 @@ Your current lowest_vmr value is: )--", lowest_vmr)
             for (auto& x : rtp_vmr) x = std::max(lowest_vmr, x);
 
             // Perform the propagation matrix computations
-            propmat_clearsky_agendaExecute(l_ws,
+            propmat_clearsky_agendaExecute(ws,
                                            K,
                                            S,
                                            dK,
@@ -415,7 +410,7 @@ Your current lowest_vmr value is: )--", lowest_vmr)
                                            this_t[p],
                                            {},
                                            rtp_vmr,
-                                           l_propmat_clearsky_agenda);
+                                           propmat_clearsky_agenda);
             K.Kjj() /= rtp_vmr[i] * number_density(abs_p[p], this_t[p]);
             abs_lookup.xsec(j, spec, Range(joker), p) = K.Kjj();
 
@@ -2227,11 +2222,6 @@ void propmat_clearsky_fieldCalc(Workspace& ws,
     rq.Target().perturbation = 0.001;
   }
 
-  // We have to make a local copy of the Workspace and the agendas because
-  // only non-reference types can be declared firstprivate in OpenMP
-  Workspace l_ws(ws);
-  Agenda l_abs_agenda(abs_agenda);
-
   String fail_msg;
   bool failed = false;
 
@@ -2242,7 +2232,7 @@ void propmat_clearsky_fieldCalc(Workspace& ws,
   if (n_pressures)
 #pragma omp parallel for if (!arts_omp_in_parallel() &&                        \
                              n_pressures >= arts_omp_get_max_threads())        \
-    firstprivate(l_ws, l_abs_agenda, this_f_grid) private(abs,                 \
+    firstprivate(ws, abs_agenda, this_f_grid) private(abs,                 \
                                                           nlte,                \
                                                           partial_abs,         \
                                                           partial_nlte,        \
@@ -2291,7 +2281,7 @@ void propmat_clearsky_fieldCalc(Workspace& ws,
             // Execute agenda to calculate local absorption.
             // Agenda input:  f_index, a_pressure, a_temperature, a_vmr_list
             // Agenda output: abs, nlte
-            propmat_clearsky_agendaExecute(l_ws,
+            propmat_clearsky_agendaExecute(ws,
                                            abs,
                                            nlte,
                                            partial_abs,
@@ -2305,7 +2295,7 @@ void propmat_clearsky_fieldCalc(Workspace& ws,
                                            a_temperature,
                                            a_nlte_list,
                                            a_vmr_list,
-                                           l_abs_agenda);
+                                           abs_agenda);
             
             // Convert from derivative to absorption
             for (Index ispec=0; ispec<partial_abs.nelem(); ispec++) {

--- a/src/m_batch.cc
+++ b/src/m_batch.cc
@@ -121,8 +121,7 @@ void ybatchCalc(Workspace& ws,
 
   if (ybatch_n)
 #pragma omp parallel for schedule(dynamic) if (!arts_omp_in_parallel() && \
-                                               ybatch_n > 1)              \
-    firstprivate(ws, ybatch_calc_agenda)
+                                               ybatch_n > 1) firstprivate(ws)
     for (Index ybatch_index = first_ybatch_index; ybatch_index < ybatch_n;
          ybatch_index++) {
       Index l_job_counter;  // Thread-local copy of job counter.
@@ -683,8 +682,7 @@ void DOBatchCalc(Workspace& ws,
 
   if (ybatch_n)
 #pragma omp parallel for schedule(dynamic) if (!arts_omp_in_parallel() && \
-                                               ybatch_n > 1)              \
-    firstprivate(ws, dobatch_calc_agenda)
+                                               ybatch_n > 1) firstprivate(ws)
     for (Index ybatch_index = first_ybatch_index; ybatch_index < ybatch_n;
          ybatch_index++) {
       Index l_job_counter;  // Thread-local copy of job counter.

--- a/src/m_batch.cc
+++ b/src/m_batch.cc
@@ -117,17 +117,12 @@ void ybatchCalc(Workspace& ws,
     ybatch_jacobians[i].resize(0, 0);
   }
 
-  // We have to make a local copy of the Workspace and the agendas because
-  // only non-reference types can be declared firstprivate in OpenMP
-  Workspace l_ws(ws);
-  Agenda l_ybatch_calc_agenda(ybatch_calc_agenda);
-
   // Go through the batch:
 
   if (ybatch_n)
 #pragma omp parallel for schedule(dynamic) if (!arts_omp_in_parallel() && \
                                                ybatch_n > 1)              \
-    firstprivate(l_ws, l_ybatch_calc_agenda)
+    firstprivate(ws, ybatch_calc_agenda)
     for (Index ybatch_index = first_ybatch_index; ybatch_index < ybatch_n;
          ybatch_index++) {
       Index l_job_counter;  // Thread-local copy of job counter.
@@ -149,12 +144,12 @@ void ybatchCalc(Workspace& ws,
         ArrayOfVector y_aux;
         Matrix jacobian;
 
-        ybatch_calc_agendaExecute(l_ws,
+        ybatch_calc_agendaExecute(ws,
                                   y,
                                   y_aux,
                                   jacobian,
                                   ybatch_start + ybatch_index,
-                                  l_ybatch_calc_agenda);
+                                  ybatch_calc_agenda);
 
         if (y.nelem()) {
 #pragma omp critical(ybatchCalc_assign_y)
@@ -684,17 +679,12 @@ void DOBatchCalc(Workspace& ws,
   dobatch_irradiance_field.resize(ybatch_n);
   dobatch_spectral_irradiance_field.resize(ybatch_n);
 
-  // We have to make a local copy of the Workspace and the agendas because
-  // only non-reference types can be declared firstprivate in OpenMP
-  Workspace l_ws(ws);
-  Agenda l_dobatch_calc_agenda(dobatch_calc_agenda);
-
   // Go through the batch:
 
   if (ybatch_n)
 #pragma omp parallel for schedule(dynamic) if (!arts_omp_in_parallel() && \
                                                ybatch_n > 1)              \
-    firstprivate(l_ws, l_dobatch_calc_agenda)
+    firstprivate(ws, dobatch_calc_agenda)
     for (Index ybatch_index = first_ybatch_index; ybatch_index < ybatch_n;
          ybatch_index++) {
       Index l_job_counter;  // Thread-local copy of job counter.
@@ -717,13 +707,13 @@ void DOBatchCalc(Workspace& ws,
         Tensor4 irradiance_field;
         Tensor5 spectral_irradiance_field;
 
-        dobatch_calc_agendaExecute(l_ws,
+        dobatch_calc_agendaExecute(ws,
                                    cloudbox_field,
                                    radiance_field,
                                    irradiance_field,
                                    spectral_irradiance_field,
                                    ybatch_start + ybatch_index,
-                                   l_dobatch_calc_agenda);
+                                   dobatch_calc_agenda);
 
 #pragma omp critical(dobatchCalc_assign_cloudbox_field)
         dobatch_cloudbox_field[ybatch_index] = cloudbox_field;

--- a/src/m_cloudradar.cc
+++ b/src/m_cloudradar.cc
@@ -962,13 +962,11 @@ void particle_bulkpropRadarOnionPeeling(
   // relationship. 
   const Numeric extrap_fac = 100;
   
-  Workspace l_ws(ws);
-  Agenda l_propmat_clearsky_agenda(propmat_clearsky_agenda);
   ArrayOfString fail_msg;
 
   // Loop all profiles
 #pragma omp parallel for if (!arts_omp_in_parallel() && nlat + nlon > 2) \
-    firstprivate(l_ws, l_propmat_clearsky_agenda) collapse(2)
+    firstprivate(ws, propmat_clearsky_agenda) collapse(2)
   for (Index ilat = 0; ilat < nlat; ilat++) {
     for (Index ilon = 0; ilon < nlon; ilon++) {
       if (fail_msg.nelem() != 0) continue;
@@ -1059,7 +1057,7 @@ void particle_bulkpropRadarOnionPeeling(
                   ArrayOfStokesVector partial_nlte_dummy;
                   EnergyLevelMap rtp_nlte_local_dummy;
                   propmat_clearsky_agendaExecute(
-                      l_ws,
+                      ws,
                       propmat,
                       nlte_dummy,
                       partial_dummy,
@@ -1073,7 +1071,7 @@ void particle_bulkpropRadarOnionPeeling(
                       t_field(ip, ilat, ilon),
                       rtp_nlte_local_dummy,
                       vmr_field(joker, ip, ilat, ilon),
-                      l_propmat_clearsky_agenda);
+                      propmat_clearsky_agenda);
                   k_this = propmat.Kjj()[0];
                   // Optical thickness
                   Numeric tau =

--- a/src/m_cloudradar.cc
+++ b/src/m_cloudradar.cc
@@ -966,7 +966,7 @@ void particle_bulkpropRadarOnionPeeling(
 
   // Loop all profiles
 #pragma omp parallel for if (!arts_omp_in_parallel() && nlat + nlon > 2) \
-    firstprivate(ws, propmat_clearsky_agenda) collapse(2)
+    firstprivate(ws) collapse(2)
   for (Index ilat = 0; ilat < nlat; ilat++) {
     for (Index ilon = 0; ilon < nlon; ilon++) {
       if (fail_msg.nelem() != 0) continue;

--- a/src/m_doit.cc
+++ b/src/m_doit.cc
@@ -2809,8 +2809,7 @@ void DoitCalc(Workspace& ws,
     String fail_msg;
     bool failed = false;
 
-#pragma omp parallel for if (!arts_omp_in_parallel() && nf > 1) \
-    firstprivate(ws, doit_mono_agenda)
+#pragma omp parallel for if (!arts_omp_in_parallel() && nf > 1) firstprivate(ws)
     for (Index f_index = 0; f_index < nf; f_index++) {
       if (failed) {
         cloudbox_field(f_index, joker, joker, joker, joker, joker, joker) = NAN;

--- a/src/m_doit.cc
+++ b/src/m_doit.cc
@@ -2802,11 +2802,6 @@ void DoitCalc(Workspace& ws,
 
   //-------- end of checks ----------------------------------------
 
-  // We have to make a local copy of the Workspace and the agendas because
-  // only non-reference types can be declared firstprivate in OpenMP
-  Workspace l_ws(ws);
-  Agenda l_doit_mono_agenda(doit_mono_agenda);
-
   // OMP likes simple loop end conditions, so we make a local copy here:
   const Index nf = f_grid.nelem();
 
@@ -2815,7 +2810,7 @@ void DoitCalc(Workspace& ws,
     bool failed = false;
 
 #pragma omp parallel for if (!arts_omp_in_parallel() && nf > 1) \
-    firstprivate(l_ws, l_doit_mono_agenda)
+    firstprivate(ws, doit_mono_agenda)
     for (Index f_index = 0; f_index < nf; f_index++) {
       if (failed) {
         cloudbox_field(f_index, joker, joker, joker, joker, joker, joker) = NAN;
@@ -2829,11 +2824,11 @@ void DoitCalc(Workspace& ws,
 
         Tensor6 cloudbox_field_mono_local =
             cloudbox_field(f_index, joker, joker, joker, joker, joker, joker);
-        doit_mono_agendaExecute(l_ws,
+        doit_mono_agendaExecute(ws,
                                 cloudbox_field_mono_local,
                                 f_grid,
                                 f_index,
-                                l_doit_mono_agenda);
+                                doit_mono_agenda);
         cloudbox_field(f_index, joker, joker, joker, joker, joker, joker) =
             cloudbox_field_mono_local;
       } catch (const std::exception& e) {

--- a/src/m_fluxes.cc
+++ b/src/m_fluxes.cc
@@ -541,7 +541,6 @@ void spectral_radiance_fieldClearskyPlaneParallel(
   // Create one altitude just above TOA
   const Numeric z_space = z_field(nl - 1, 0, 0) + 10;
 
-  Workspace l_ws(ws);
   ArrayOfString fail_msg;
   bool failed = false;
 
@@ -561,7 +560,7 @@ void spectral_radiance_fieldClearskyPlaneParallel(
   //
   if (nza)
 #pragma omp parallel for if (!arts_omp_in_parallel() && nza > 1 && \
-                             use_parallel_za) firstprivate(l_ws)
+                             use_parallel_za) firstprivate(ws)
     for (Index i = 0; i < nza; i++) {
       if (failed) continue;
       try {
@@ -593,7 +592,7 @@ void spectral_radiance_fieldClearskyPlaneParallel(
         ARTS_ASSERT(ppath.gp_p[ppath.np - 1].idx == i0 ||
                ppath.gp_p[ppath.np - 1].idx == nl - 2);
 
-        iyEmissionStandard(l_ws,
+        iyEmissionStandard(ws,
                            iy,
                            iy_aux,
                            diy_dx,
@@ -797,7 +796,6 @@ void spectral_radiance_fieldExpandCloudboxField(
   // Create one altitude just above TOA
   const Numeric z_space = z_field(nl - 1, 0, 0) + 10;
 
-  Workspace l_ws(ws);
   ArrayOfString fail_msg;
   bool failed = false;
 
@@ -817,7 +815,7 @@ void spectral_radiance_fieldExpandCloudboxField(
   //
   if (nza)
 #pragma omp parallel for if (!arts_omp_in_parallel() && nza > 1 && \
-                             use_parallel_za) firstprivate(l_ws)
+                             use_parallel_za) firstprivate(ws)
     for (Index i = 0; i < nza; i++) {
       if (failed) continue;
       try {
@@ -849,7 +847,7 @@ void spectral_radiance_fieldExpandCloudboxField(
         ARTS_ASSERT(ppath.gp_p[ppath.np - 1].idx == i0 ||
                ppath.gp_p[ppath.np - 1].idx == nl - 2);
 
-        iyEmissionStandard(l_ws,
+        iyEmissionStandard(ws,
                            iy,
                            iy_aux,
                            diy_dx,

--- a/src/m_radiation_field.cc
+++ b/src/m_radiation_field.cc
@@ -171,18 +171,12 @@ void line_irradianceCalcForSingleSpeciesNonOverlappingLinesPseudo2D(
   for (Index i = 0; i < np; i++)
     line_radiance[i].resize(sorted_index[i].nelem(), nl);
 
-  Workspace l_ws(ws);
-  Agenda l_iy_main_agenda(iy_main_agenda);
-  Agenda l_iy_space_agenda(iy_space_agenda);
-  Agenda l_iy_surface_agenda(iy_surface_agenda);
-  Agenda l_iy_cloudbox_agenda(iy_cloudbox_agenda);
-
 #pragma omp parallel for if (not arts_omp_in_parallel())               \
-    schedule(guided) default(shared) firstprivate(l_ws,                \
-                                                  l_iy_main_agenda,    \
-                                                  l_iy_space_agenda,   \
-                                                  l_iy_surface_agenda, \
-                                                  l_iy_cloudbox_agenda,\
+    schedule(guided) default(shared) firstprivate(ws,                \
+                                                  iy_main_agenda,    \
+                                                  iy_space_agenda,   \
+                                                  iy_surface_agenda, \
+                                                  iy_cloudbox_agenda,\
                                                   il)
   for (Index i = 0; i < ppath_field.nelem(); i++) {
     const Ppath& path = ppath_field[i];
@@ -192,7 +186,7 @@ void line_irradianceCalcForSingleSpeciesNonOverlappingLinesPseudo2D(
     thread_local ArrayOfTransmissionMatrix lyr_tra;
     thread_local ArrayOfTransmissionMatrix tot_tra;
 
-    emission_from_propmat_field(l_ws,
+    emission_from_propmat_field(ws,
                                 lvl_rad,
                                 src_rad,
                                 lyr_tra,
@@ -204,10 +198,10 @@ void line_irradianceCalcForSingleSpeciesNonOverlappingLinesPseudo2D(
                                 t_field,
                                 nlte_field,
                                 path,
-                                l_iy_main_agenda,
-                                l_iy_space_agenda,
-                                l_iy_surface_agenda,
-                                l_iy_cloudbox_agenda,
+                                iy_main_agenda,
+                                iy_space_agenda,
+                                iy_surface_agenda,
+                                iy_cloudbox_agenda,
                                 surface_props_data,
                                 verbosity);
     

--- a/src/m_radiation_field.cc
+++ b/src/m_radiation_field.cc
@@ -171,13 +171,8 @@ void line_irradianceCalcForSingleSpeciesNonOverlappingLinesPseudo2D(
   for (Index i = 0; i < np; i++)
     line_radiance[i].resize(sorted_index[i].nelem(), nl);
 
-#pragma omp parallel for if (not arts_omp_in_parallel())               \
-    schedule(guided) default(shared) firstprivate(ws,                \
-                                                  iy_main_agenda,    \
-                                                  iy_space_agenda,   \
-                                                  iy_surface_agenda, \
-                                                  iy_cloudbox_agenda,\
-                                                  il)
+#pragma omp parallel for if (not arts_omp_in_parallel()) \
+    schedule(guided) default(shared) firstprivate(ws, il)
   for (Index i = 0; i < ppath_field.nelem(); i++) {
     const Ppath& path = ppath_field[i];
 

--- a/src/m_rte.cc
+++ b/src/m_rte.cc
@@ -897,7 +897,7 @@ void iyEmissionStandard(
 
     // Loop ppath points and determine radiative properties
 #pragma omp parallel for if (!arts_omp_in_parallel()) \
-    firstprivate(ws, propmat_clearsky_agenda, a, B, dB_dT, S, da_dx, dS_dx)
+    firstprivate(ws, a, B, dB_dT, S, da_dx, dS_dx)
     for (Index ip = 0; ip < np; ip++) {
       if (do_abort) continue;
       try {
@@ -1744,12 +1744,7 @@ void iyMC(Workspace& ws,
   bool failed = false;
 
   if (nf)
-#pragma omp parallel for if (!arts_omp_in_parallel() && nf > 1) \
-    firstprivate(ws,                                          \
-                 ppath_step_agenda,                           \
-                 iy_space_agenda,                             \
-                 propmat_clearsky_agenda,                     \
-                 surface_rtprop_agenda)
+#pragma omp parallel for if (!arts_omp_in_parallel() && nf > 1) firstprivate(ws)
     for (Index f_index = 0; f_index < nf; f_index++) {
       if (failed) continue;
 
@@ -1992,8 +1987,7 @@ void yCalc(Workspace& ws,
       (nf <= nmblock && nmblock >= nlos)) {
     out3 << "  Parallelizing mblock loop (" << nmblock << " iterations)\n";
 
-#pragma omp parallel for firstprivate( \
-    ws, jacobian_agenda, iy_main_agenda, geo_pos_agenda)
+#pragma omp parallel for firstprivate(ws)
     for (Index mblock_index = 0; mblock_index < nmblock; mblock_index++) {
       // Skip remaining iterations if an error occurred
       if (failed) continue;

--- a/src/m_rte.cc
+++ b/src/m_rte.cc
@@ -892,14 +892,12 @@ void iyEmissionStandard(
           })
     }
 
-    Agenda l_propmat_clearsky_agenda(propmat_clearsky_agenda);
-    Workspace l_ws(ws);
     ArrayOfString fail_msg;
     bool do_abort = false;
 
     // Loop ppath points and determine radiative properties
 #pragma omp parallel for if (!arts_omp_in_parallel()) \
-    firstprivate(l_ws, l_propmat_clearsky_agenda, a, B, dB_dT, S, da_dx, dS_dx)
+    firstprivate(ws, propmat_clearsky_agenda, a, B, dB_dT, S, da_dx, dS_dx)
     for (Index ip = 0; ip < np; ip++) {
       if (do_abort) continue;
       try {
@@ -907,13 +905,13 @@ void iyEmissionStandard(
             B, dB_dT, ppvar_f(joker, ip), ppvar_t[ip], temperature_jacobian);
 
         Index lte;
-        get_stepwise_clearsky_propmat(l_ws,
+        get_stepwise_clearsky_propmat(ws,
                                       K[ip],
                                       S,
                                       lte,
                                       dK_dx[ip],
                                       dS_dx,
-                                      l_propmat_clearsky_agenda,
+                                      propmat_clearsky_agenda,
                                       jacobian_quantities,
                                       ppvar_f(joker, ip),
                                       ppvar_mag(joker, ip),
@@ -1742,22 +1740,16 @@ void iyMC(Workspace& ws,
   pos(0, joker) = rte_pos;
   los(0, joker) = rte_los;
 
-  Workspace l_ws(ws);
-  Agenda l_ppath_step_agenda(ppath_step_agenda);
-  Agenda l_iy_space_agenda(iy_space_agenda);
-  Agenda l_propmat_clearsky_agenda(propmat_clearsky_agenda);
-  Agenda l_surface_rtprop_agenda(surface_rtprop_agenda);
-
   String fail_msg;
   bool failed = false;
 
   if (nf)
 #pragma omp parallel for if (!arts_omp_in_parallel() && nf > 1) \
-    firstprivate(l_ws,                                          \
-                 l_ppath_step_agenda,                           \
-                 l_iy_space_agenda,                             \
-                 l_propmat_clearsky_agenda,                     \
-                 l_surface_rtprop_agenda)
+    firstprivate(ws,                                          \
+                 ppath_step_agenda,                           \
+                 iy_space_agenda,                             \
+                 propmat_clearsky_agenda,                     \
+                 surface_rtprop_agenda)
     for (Index f_index = 0; f_index < nf; f_index++) {
       if (failed) continue;
 
@@ -1772,7 +1764,7 @@ void iyMC(Workspace& ws,
         Tensor3 mc_points;
         ArrayOfIndex mc_scat_order, mc_source_domain;
 
-        MCGeneral(l_ws,
+        MCGeneral(ws,
                   y,
                   mc_iteration_count,
                   mc_error,
@@ -1786,12 +1778,12 @@ void iyMC(Workspace& ws,
                   los,
                   stokes_dim,
                   atmosphere_dim,
-                  l_ppath_step_agenda,
+                  ppath_step_agenda,
                   ppath_lmax,
                   ppath_lraytrace,
-                  l_iy_space_agenda,
-                  l_surface_rtprop_agenda,
-                  l_propmat_clearsky_agenda,
+                  iy_space_agenda,
+                  surface_rtprop_agenda,
+                  propmat_clearsky_agenda,
                   p_grid,
                   lat_grid,
                   lon_grid,
@@ -2000,15 +1992,8 @@ void yCalc(Workspace& ws,
       (nf <= nmblock && nmblock >= nlos)) {
     out3 << "  Parallelizing mblock loop (" << nmblock << " iterations)\n";
 
-    // We have to make a local copy of the Workspace and the agendas because
-    // only non-reference types can be declared firstprivate in OpenMP
-    Workspace l_ws(ws);
-    Agenda l_jacobian_agenda(jacobian_agenda);
-    Agenda l_iy_main_agenda(iy_main_agenda);
-    Agenda l_geo_pos_agenda(geo_pos_agenda);
-
 #pragma omp parallel for firstprivate( \
-    l_ws, l_jacobian_agenda, l_iy_main_agenda, l_geo_pos_agenda)
+    ws, jacobian_agenda, iy_main_agenda, geo_pos_agenda)
     for (Index mblock_index = 0; mblock_index < nmblock; mblock_index++) {
       // Skip remaining iterations if an error occurred
       if (failed) continue;
@@ -2016,7 +2001,7 @@ void yCalc(Workspace& ws,
       yCalc_mblock_loop_body(failed,
                              fail_msg,
                              iyb_aux_array,
-                             l_ws,
+                             ws,
                              y,
                              y_f,
                              y_pol,
@@ -2038,9 +2023,9 @@ void yCalc(Workspace& ws,
                              sensor_response_pol,
                              sensor_response_dlos,
                              iy_unit,
-                             l_iy_main_agenda,
-                             l_geo_pos_agenda,
-                             l_jacobian_agenda,
+                             iy_main_agenda,
+                             geo_pos_agenda,
+                             jacobian_agenda,
                              jacobian_do,
                              jacobian_quantities,
                              jacobian_indices,

--- a/src/propmat_field.cc
+++ b/src/propmat_field.cc
@@ -72,7 +72,7 @@ void field_of_propagation(Workspace& ws,
       FieldOfStokesVector(nalt, nlat, nlon, StokesVector(nf, stokes_dim));
 
 #pragma omp parallel for if (not arts_omp_in_parallel()) schedule(guided) \
-    firstprivate(ws, propmat_clearsky_agenda)
+    firstprivate(ws)
   for (Index i = 0; i < nalt; i++) {
     for (Index j = 0; j < nlat; j++) {
       for (Index k = 0; k < nlon; k++) {

--- a/src/propmat_field.cc
+++ b/src/propmat_field.cc
@@ -71,23 +71,20 @@ void field_of_propagation(Workspace& ws,
   additional_source_field =
       FieldOfStokesVector(nalt, nlat, nlon, StokesVector(nf, stokes_dim));
 
-  Workspace l_ws(ws);
-  Agenda l_propmat_clearsky_agenda(propmat_clearsky_agenda);
-
 #pragma omp parallel for if (not arts_omp_in_parallel()) schedule(guided) \
-    firstprivate(l_ws, l_propmat_clearsky_agenda)
+    firstprivate(ws, propmat_clearsky_agenda)
   for (Index i = 0; i < nalt; i++) {
     for (Index j = 0; j < nlat; j++) {
       for (Index k = 0; k < nlon; k++) {
         thread_local Index itmp;
         get_stepwise_clearsky_propmat(
-            l_ws,
+            ws,
             propmat_field(i, j, k),
             additional_source_field(i, j, k),
             itmp,
             dK_dx,
             dS_dx,
-            l_propmat_clearsky_agenda,
+            propmat_clearsky_agenda,
             jacobian_quantities,
             f_grid,
             mag_field,

--- a/src/rte.cc
+++ b/src/rte.cc
@@ -1649,12 +1649,6 @@ void iyb_calc(Workspace& ws,
   // all outout
   ArrayOfArrayOfMatrix iy_aux_array(nlos);
 
-  // We have to make a local copy of the Workspace and the agendas because
-  // only non-reference types can be declared firstprivate in OpenMP
-  Workspace l_ws(ws);
-  Agenda l_iy_main_agenda(iy_main_agenda);
-  Agenda l_geo_pos_agenda(geo_pos_agenda);
-
   String fail_msg;
   bool failed = false;
   if (nlos >= arts_omp_get_max_threads() || nlos * 10 >= nf) {
@@ -1663,7 +1657,7 @@ void iyb_calc(Workspace& ws,
 
     // Start of actual calculations
 #pragma omp parallel for if (!arts_omp_in_parallel()) \
-    firstprivate(l_ws, l_iy_main_agenda, l_geo_pos_agenda)
+    firstprivate(ws, iy_main_agenda, geo_pos_agenda)
     for (Index ilos = 0; ilos < nlos; ilos++) {
       // Skip remaining iterations if an error occurred
       if (failed) continue;
@@ -1672,7 +1666,7 @@ void iyb_calc(Workspace& ws,
       iyb_calc_body(failed,
                     fail_msg,
                     iy_aux_array,
-                    l_ws,
+                    ws,
                     ppath,
                     iyb,
                     diyb_dx,
@@ -1686,7 +1680,7 @@ void iyb_calc(Workspace& ws,
                     transmitter_pos,
                     mblock_dlos_grid,
                     iy_unit,
-                    l_iy_main_agenda,
+                    iy_main_agenda,
                     j_analytical_do,
                     jacobian_quantities,
                     jacobian_indices,
@@ -1701,7 +1695,7 @@ void iyb_calc(Workspace& ws,
       // Note that this code is found in two places inside the function
       Vector geo_pos;
       try {
-        geo_pos_agendaExecute(l_ws, geo_pos, ppath, l_geo_pos_agenda);
+        geo_pos_agendaExecute(ws, geo_pos, ppath, geo_pos_agenda);
         if (geo_pos.nelem()) {
           ARTS_USER_ERROR_IF (geo_pos.nelem() != 5,
                 "Wrong size of *geo_pos* obtained from *geo_pos_agenda*.\n"
@@ -1729,7 +1723,7 @@ void iyb_calc(Workspace& ws,
       iyb_calc_body(failed,
                     fail_msg,
                     iy_aux_array,
-                    l_ws,
+                    ws,
                     ppath,
                     iyb,
                     diyb_dx,
@@ -1743,7 +1737,7 @@ void iyb_calc(Workspace& ws,
                     transmitter_pos,
                     mblock_dlos_grid,
                     iy_unit,
-                    l_iy_main_agenda,
+                    iy_main_agenda,
                     j_analytical_do,
                     jacobian_quantities,
                     jacobian_indices,
@@ -1758,7 +1752,7 @@ void iyb_calc(Workspace& ws,
       // Note that this code is found in two places inside the function
       Vector geo_pos;
       try {
-        geo_pos_agendaExecute(l_ws, geo_pos, ppath, l_geo_pos_agenda);
+        geo_pos_agendaExecute(ws, geo_pos, ppath, geo_pos_agenda);
         if (geo_pos.nelem()) {
           ARTS_USER_ERROR_IF (geo_pos.nelem() != 5,
                 "Wrong size of *geo_pos* obtained from *geo_pos_agenda*.\n"

--- a/src/rte.cc
+++ b/src/rte.cc
@@ -1656,8 +1656,7 @@ void iyb_calc(Workspace& ws,
          << " frequencies)\n";
 
     // Start of actual calculations
-#pragma omp parallel for if (!arts_omp_in_parallel()) \
-    firstprivate(ws, iy_main_agenda, geo_pos_agenda)
+#pragma omp parallel for if (!arts_omp_in_parallel()) firstprivate(ws)
     for (Index ilos = 0; ilos < nlos; ilos++) {
       // Skip remaining iterations if an error occurred
       if (failed) continue;


### PR DESCRIPTION
Older OpenMP versions didn't support reference types in firstprivate. Now we can avoid making an additional manual copy of the Workspace.

Also, agendas don't need to be firstprivate which saves some unnecessary copying.