### PR TITLE
Reorder scalar

### DIFF
--- a/src/python_interface/py_matpack.cpp
+++ b/src/python_interface/py_matpack.cpp
@@ -10,7 +10,7 @@
 #include "py_macros.h"
 
 namespace Python {
-using Scalar = std::variant<Index, Numeric>;
+using Scalar = std::variant<Numeric, Index>;
 
 template <typename T>
 void test_correct_size(const std::vector<T>& x) {


### PR DESCRIPTION
This should fix the output of:

```python
import pyarts; import numpy
x = pyarts.arts.Vector(numpy.array([1.1,1.9],dtype="float32"))
print(x)
```

to be

```1.1 1.9```

instead of

```1 1```

It achieves this by selecting `Numeric` instead of `Index` first as the option to convert the `float32` into.  Note that on newer versions of python (perhaps not released versions, I don't know), the conversion should work since conversion from `float32` to `int` is deprecated (python 3.9.12).  But better safe than sorry in the future, it is better if we first try to convert to `Numeric`.