### PR TITLE
Clean up compiler diagnostic flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,9 +77,6 @@ target_link_libraries (arts ${ALL_ARTS_LIBRARIES})
 
 install (TARGETS arts RUNTIME DESTINATION bin)
 
-# Reduce compile time for very large initialization functions
-set_source_files_properties (methods.cc PROPERTIES COMPILE_FLAGS "-O0")
-
 ########### next target ###############
 
 add_executable (make_workspace_memory_handler_cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,15 +77,8 @@ target_link_libraries (arts ${ALL_ARTS_LIBRARIES})
 
 install (TARGETS arts RUNTIME DESTINATION bin)
 
-set_source_files_properties (legacy_continua.cc PROPERTIES
-                             COMPILE_FLAGS "-fno-strict-aliasing")
-
 # Reduce compile time for very large initialization functions
 set_source_files_properties (methods.cc PROPERTIES COMPILE_FLAGS "-O0")
-
-# Silence invlib warning spam
-set_source_files_properties (m_oem.cc PROPERTIES
-                             COMPILE_FLAGS "-Wno-conversion")
 
 ########### next target ###############
 

--- a/src/legacy_continua.cc
+++ b/src/legacy_continua.cc
@@ -404,6 +404,8 @@
 #include "global_data.h"
 #include "matpackI.h"
 
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+
 // #################################################################################
 
 // global constants as defined in constants.cc

--- a/src/m_oem.cc
+++ b/src/m_oem.cc
@@ -53,6 +53,8 @@
 #include "surface.h"
 #include "check_input.h"
 
+#pragma GCC diagnostic ignored "-Wconversion"
+
 #ifdef OEM_SUPPORT
 #include "oem.h"
 #endif

--- a/src/matpackI.h
+++ b/src/matpackI.h
@@ -96,11 +96,17 @@
 #define matpackI_h
 
 #include <algorithm>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#if !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
+
 #include <Eigen/Dense>
+
 #pragma GCC diagnostic pop
 
 #include "array.h"

--- a/src/matpackII.h
+++ b/src/matpackII.h
@@ -47,8 +47,13 @@
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#if !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
+
 #include <Eigen/Core>
 #include <Eigen/SparseCore>
+
 #pragma GCC diagnostic pop
 
 #include "array.h"

--- a/src/transmissionmatrix.h
+++ b/src/transmissionmatrix.h
@@ -33,8 +33,13 @@
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma GCC diagnostic ignored "-Wconversion"
 #pragma GCC diagnostic ignored "-Wfloat-conversion"
+#if !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
+
 #include <Eigen/Dense>
 #include <Eigen/StdVector>
+
 #pragma GCC diagnostic pop
 
 #include "jacobian.h"


### PR DESCRIPTION
Use pragmas to disable diagnostics where necessary.

Remove `-O0` flag for `methods.cc`.