### PR TITLE
Add cmake option to enable IPO/LTO support

### DIFF
--- a/3rdparty/Faddeeva/CMakeLists.txt
+++ b/3rdparty/Faddeeva/CMakeLists.txt
@@ -1,1 +1,5 @@
 add_library (Faddeeva STATIC Faddeeva.cc)
+
+if (IPO_SUPPORTED)
+  set_property(TARGET Faddeeva PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()

--- a/3rdparty/wigner/fastwigxj/CMakeLists.txt
+++ b/3rdparty/wigner/fastwigxj/CMakeLists.txt
@@ -194,3 +194,8 @@ add_custom_target(fastwigxj_generate_tables
 )
 
 add_dependencies(fastwigxj fastwigxj_generate_tables)
+
+if (IPO_SUPPORTED)
+  set_property(TARGET fastwigxj PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+  set_property(TARGET hashing_fastwigxj PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()

--- a/3rdparty/wigner/wigxjpf/CMakeLists.txt
+++ b/3rdparty/wigner/wigxjpf/CMakeLists.txt
@@ -93,6 +93,10 @@ if (WIGXJPF_CPP_ERROR)
     target_link_libraries(wigxjpf PRIVATE wigxjpf_cpp_throw)
 
     target_compile_definitions(wigxjpf PUBLIC -DCPP_WIGXJPF_ERROR_HANDLING)
+
+    if (IPO_SUPPORTED)
+        set_property(TARGET wigxjpf_cpp_throw PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+    endif()
 endif()
 
 target_include_directories(wigxjpf
@@ -107,3 +111,7 @@ target_include_directories(wigxjpf
 set_target_properties(wigxjpf PROPERTIES COMPILE_FLAGS "-fPIC ${CMAKE_C_FLAGS}")
 
 target_compile_options(wigxjpf PRIVATE -Wno-shadow)
+
+if (IPO_SUPPORTED)
+  set_property(TARGET wigxjpf PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 if (ENABLE_IPO)
   include(CheckIPOSupported)
-  check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_ERROR)
+  check_ipo_supported(RESULT IPO_SUPPORTED LANGUAGES C CXX OUTPUT IPO_ERROR)
   if (NOT IPO_SUPPORTED)
     message(FATAL_ERROR "IPO / LTO not supported: ${IPO_ERROR}")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ option (ENABLE_CCACHE "Turn on CCACHE" ON)
 option (ENABLE_CXX20 "Turn on C++20 (experimental)" OFF)
 option (ENABLE_FORTRAN "Turn on Fortran code" OFF)
 option (ENABLE_GUI "Turn on Debug GUI" OFF)
+option (ENABLE_IPO "Turn on IPO (experimental)" OFF)
 option (ENABLE_MPI "Turn on MPI" OFF)
 option (ENABLE_NETCDF "Turn on NETCDF support" OFF)
 option (ENABLE_PCH "Turn on precomnpiled headers" OFF)
@@ -158,6 +159,16 @@ endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+if (ENABLE_IPO)
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_ERROR)
+  if (NOT IPO_SUPPORTED)
+    message(FATAL_ERROR "IPO / LTO not supported: ${IPO_ERROR}")
+  endif()
+else()
+  set(IPO_SUPPORTED OFF)
+endif()
 
 # Explicitly set C++ flags for Intel compiler because cmake
 # only supports it from version 3.6.0+. We don't want to
@@ -546,6 +557,12 @@ if (ENABLE_PCH)
   endif()
 else()
   message (STATUS "Precompiled headers disabled")
+endif()
+
+if (IPO_SUPPORTED)
+  message(STATUS "IPO / LTO enabled")
+else()
+  message(STATUS "IPO / LTO disabled")
 endif()
 
 add_subdirectory (src)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -39,6 +39,9 @@
 #cmakedefine ENABLE_TMATRIX
 #cmakedefine ENABLE_TMATRIX_QUAD
 
+/* Defined if IPO/LTO support is available and enabled */
+#cmakedefine IPO_SUPPORTED
+
 /* Define to compile with zlib support */
 #cmakedefine ENABLE_ZLIB
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -301,7 +301,6 @@ if (ENABLE_PCH)
   target_precompile_headers(artscore PRIVATE pch_artscore.h)
 endif()
 
-
 if (ENABLE_GUI)
   add_subdirectory(gui)
   
@@ -656,3 +655,15 @@ add_custom_target(check-pyversion
   COMMENT "Check Python version")
 ########################################################################################
 
+########### IPO / LTO support
+if (IPO_SUPPORTED)
+  set_property(TARGET arts PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+  set_property(TARGET artscore PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+  set_property(TARGET binio PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+  set_property(TARGET make_auto_md_cc PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+  set_property(TARGET make_auto_md_h PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+  set_property(TARGET matpack PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+  set_property(TARGET methods PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+  set_property(TARGET species PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+  set_property(TARGET xmliobase PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -13,3 +13,7 @@ target_include_directories(artsgui PUBLIC ${ARTS_SOURCE_DIR}/src
                                           ${ARTS_SOURCE_DIR}/3rdparty/gui/implot/
                                           ${ARTS_SOURCE_DIR}/3rdparty/gui/imgui-filebrowser/
                                           ${ARTS_SOURCE_DIR}/3rdparty/)
+
+if (IPO_SUPPORTED)
+  set_property(TARGET artsgui PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()

--- a/src/main.cc
+++ b/src/main.cc
@@ -732,6 +732,12 @@ int main(int argc, char** argv) {
 #else
                << "disabled" << endl
 #endif
+               << "   IPO/LTO support:      "
+#ifdef IPO_SUPPORTED
+               << "enabled" << endl
+#else
+               << "disabled" << endl
+#endif
                << endl;
 
     osfeatures << "Include search paths: " << endl;

--- a/src/predefined/CMakeLists.txt
+++ b/src/predefined/CMakeLists.txt
@@ -10,3 +10,7 @@ if (ENABLE_PCH)
 endif()
 target_link_libraries(predef PUBLIC matpack)
 target_include_directories(predef PRIVATE ${ARTS_SOURCE_DIR}/3rdparty/)
+
+if (IPO_SUPPORTED)
+  set_property(TARGET predef PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()


### PR DESCRIPTION
Experimental option to compile ARTS with interprocedural optimizations.  The cmake CheckIPOSupported macro seems to have some issues in certain configurations:

Linux:
gcc works.
clang only works if `-flto=thin` is manually added to `LDFLAGS`.
clang from mambaforge does not support LTO

macOS:
gcc does not work because it claims that `-fno-fat-lto-objects` is a linker only option although it works fine on Linux.
clang from homebrew works.
clang from mambaforge does not work.
