### PR TITLE
Make gen_auto_py build withoug needing artscore

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,8 +103,6 @@ add_executable (make_auto_md_h
         make_auto_md_h.cc
         messages.cc
         parameters.cc
-        workspace.cc
-        wsv_aux.cc
         )
 
 if (ENABLE_PCH)
@@ -127,8 +125,6 @@ add_executable (make_auto_md_cc
         make_auto_md_cc.cc
         messages.cc
         parameters.cc
-        workspace.cc
-        wsv_aux.cc
         )
 
 if (ENABLE_PCH)
@@ -285,10 +281,8 @@ add_library (artscore STATIC
   tokval_io.cc
   transmissionmatrix.cc
   wigner_functions.cc
-  workspace.cc
   workspace_ng.cc
   workspace_memory_handler.cc
-  wsv_aux.cc
   wsv_aux_operator.cc
   xml_io.cc
   xml_io_array_types.cc
@@ -390,6 +384,8 @@ add_library (methods STATIC
         methods_aux.cc
         groups.cc
         tokval.cc
+        workspace.cc
+        wsv_aux.cc
         )
 
 target_link_libraries(methods PUBLIC predef species)

--- a/src/docserver.cc
+++ b/src/docserver.cc
@@ -43,6 +43,7 @@
 #include "tokval_io.h"
 #include "workspace_ng.h"
 #include "workspace_global_data.h"
+#include "wsv_aux_operator.h"
 
 #define DOCSERVER_NAME "ARTS built-in documentation server"
 

--- a/src/global_data.h
+++ b/src/global_data.h
@@ -100,7 +100,6 @@ extern const map<String, Index> WsvGroupMap;
  * Defined in workspace_ng.cc.
  */
 extern WorkspaceMemoryHandler workspace_memory_handler;
-
 } /* namespace global_data */
 
 #endif /* global_data_h */

--- a/src/linemixing_jmh.cc
+++ b/src/linemixing_jmh.cc
@@ -124,11 +124,22 @@ int main() try {
           if(ji[iRp] > ji[iR]) continue;
           if (max(W(iRp, iR, joker)) == min(W(iRp, iR, joker))) continue;
           char str[200];
-          std::sprintf(str,
-                       " %0.12E %0.12E %0.12E %0.12E %0.12E %0.12E %0.12E %0.12E   %ld   %ld   %ld   %ld\n",
-                       W(iRp, iR, 0), W(iRp, iR, 1), W(iRp, iR, 2), W(iRp, iR, 3),
-                       W(iRp, iR, 4), W(iRp, iR, 5), W(iRp, iR, 6), W(iRp, iR, 7),
-                       ji[iR], jf[iR], ji[iRp], jf[iRp]);
+          std::sprintf(
+              str,
+              " %0.12E %0.12E %0.12E %0.12E %0.12E %0.12E %0.12E %0.12E   %" PRId64
+              "   %" PRId64 "   %" PRId64 "   %" PRId64 "\n",
+              W(iRp, iR, 0),
+              W(iRp, iR, 1),
+              W(iRp, iR, 2),
+              W(iRp, iR, 3),
+              W(iRp, iR, 4),
+              W(iRp, iR, 5),
+              W(iRp, iR, 6),
+              W(iRp, iR, 7),
+              ji[iR],
+              jf[iR],
+              ji[iRp],
+              jf[iRp]);
           fil << str;
         }
       }

--- a/src/main.cc
+++ b/src/main.cc
@@ -28,8 +28,8 @@
    \date   2001-07-24
 */
 
-#include <memory>
 #include "arts.h"
+#include <memory>
 
 #ifdef ENABLE_DOCSERVER
 #include <unistd.h>
@@ -53,9 +53,11 @@
 #include "mystring.h"
 #include "parameters.h"
 #include "parser.h"
+#include "workspace_global_data.h"
+#include "workspace.h"
 #include "workspace_ng.h"
 #include "wsv_aux.h"
-#include "workspace_global_data.h"
+#include "wsv_aux_operator.h"
 
 /** Remind the user of --help and exit return value 1. */
 void polite_goodby() {

--- a/src/make_auto_md_cc.cc
+++ b/src/make_auto_md_cc.cc
@@ -21,6 +21,7 @@
 #include "file.h"
 #include "global_data.h"
 #include "methods.h"
+#include "workspace.h"
 #include "workspace_ng.h"
 #include "workspace_global_data.h"
 

--- a/src/make_auto_md_h.cc
+++ b/src/make_auto_md_h.cc
@@ -71,6 +71,7 @@
 #include "file.h"
 #include "global_data.h"
 #include "methods.h"
+#include "workspace.h"
 #include "workspace_ng.h"
 #include "workspace_global_data.h"
 

--- a/src/make_tokval.cc
+++ b/src/make_tokval.cc
@@ -4,8 +4,6 @@
 
 #include "global_data.h"
 
-void define_wsv_groups();
-
 int main() {
   std::ofstream file_var_h("tokval_variant.h");
   std::ofstream file_h("tokval.h");

--- a/src/predefined.cc
+++ b/src/predefined.cc
@@ -26,7 +26,7 @@ int main(int argc, char** argv) try {
   ArrayOfPropagationMatrix x(0);
 
   Absorption::PredefinedModel::compute(
-      propmat_clearsky, x, tag.Isotopologue(), f_grid, P, T, vmr, {});
+      propmat_clearsky, x, tag.Isotopologue(), f_grid, P, T, vmr, {}, {});
 
   if (not gui)
     std::cout << std::setprecision(15) << propmat_clearsky << '\n';

--- a/src/python_interface/CMakeLists.txt
+++ b/src/python_interface/CMakeLists.txt
@@ -51,7 +51,7 @@ endwhile()
 ########################################################################################
 # Build the generator
 add_executable(gen_auto_py gen_auto_py.cpp)
-target_link_libraries(gen_auto_py PUBLIC ${ALL_ARTS_LIBRARIES})
+target_link_libraries(gen_auto_py PUBLIC methods)
 target_include_directories(gen_auto_py PUBLIC ${ARTS_SOURCE_DIR}/src)
 
 # Generate the actual files with this command

--- a/src/python_interface/gen_auto_py.cpp
+++ b/src/python_interface/gen_auto_py.cpp
@@ -1,4 +1,3 @@
-#include <auto_md.h>
 #include <global_data.h>
 
 #include <algorithm>
@@ -12,6 +11,13 @@
 #include "debug.h"
 #include "mystring.h"
 #include "tokval_io.h"
+#include "workspace.h"
+
+namespace global_data {
+extern Array<WsvRecord> wsv_data;
+
+extern std::map<String, Index> WsvMap;
+} // namespace global_data
 
 /** Implements pybind11 bindings generation for Arts workspace
  *
@@ -103,11 +109,7 @@ std::map<std::string, Group> groups() {
     auto& val = desc[x.Name()];
     val = x.Description();
     if (x.has_defaults())
-      val += var_string("\nDefault: ", [](auto&& tokval) {
-        std::string out = var_string(TokValPrinter{tokval});
-        if (out.length() == 0) out += "[]";
-        return out;
-      }(x.default_value()));
+      val += "\nDefault exist: Please see builtin documentation for value";
   }
   std::map<std::string, std::size_t> pos;
   for (auto& x : global_data::WsvMap) pos[x.first] = x.second;

--- a/src/python_interface/gen_auto_py.cpp
+++ b/src/python_interface/gen_auto_py.cpp
@@ -107,9 +107,9 @@ std::map<std::string, Group> groups() {
   std::map<std::string, std::string> desc;
   for (auto& x : global_data::wsv_data) {
     auto& val = desc[x.Name()];
-    val = x.Description();
+    val = var_string("Group: pyarts.arts.", global_data::wsv_groups[x.Group()].name, "\n\n", x.Description());
     if (x.has_defaults())
-      val += "\nDefault exist: use the value property to see the default value";
+      val += var_string("\nUse import pyarts; pyarts.workspace.Workspace().", x.Name(), ".value to see default");
   }
   std::map<std::string, std::size_t> pos;
   for (auto& x : global_data::WsvMap) pos[x.first] = x.second;
@@ -433,7 +433,7 @@ void workspace_variables(size_t n, const NameMaps& arts) {
     os << R"--(  py::cpp_function([](Workspace& w) -> WorkspaceVariable {
     return WorkspaceVariable{w, )--"
        << data.artspos
-       << "};\n  }, py::return_value_policy::reference_internal),\n";
+       << "};\n  }, py::return_value_policy::reference_internal, py::keep_alive<0, 1>()),\n";
 
     os << "  [](Workspace& w, " << data.varname_group << "& val) {\n";
 
@@ -1736,7 +1736,7 @@ void workspace_access(std::ofstream& os, const NameMaps& arts) {
 
   os << R"--(wsv.def_property("value",
   py::cpp_function([](const WorkspaceVariable& w) -> WorkspaceVariablesVariant {
-    return w; }, py::return_value_policy::reference_internal),
+    return w; }, py::return_value_policy::reference_internal, py::keep_alive<0, 1>()),
   py::cpp_function([](WorkspaceVariable& w, WorkspaceVariablesVariant v) {
     WorkspaceVariablesVariant wvv{w};
     )--";

--- a/src/python_interface/gen_auto_py.cpp
+++ b/src/python_interface/gen_auto_py.cpp
@@ -109,7 +109,7 @@ std::map<std::string, Group> groups() {
     auto& val = desc[x.Name()];
     val = x.Description();
     if (x.has_defaults())
-      val += "\nDefault exist: Please see builtin documentation for value";
+      val += "\nDefault exist: use the value property to see the default value";
   }
   std::map<std::string, std::size_t> pos;
   for (auto& x : global_data::WsvMap) pos[x.first] = x.second;

--- a/src/python_interface/py_module.cpp
+++ b/src/python_interface/py_module.cpp
@@ -1,4 +1,5 @@
 #include <workspace_ng.h>
+#include <workspace.h>
 #include <memory>
 
 #include "py_auto_interface.h"

--- a/src/python_interface/py_workspace.cpp
+++ b/src/python_interface/py_workspace.cpp
@@ -1,5 +1,7 @@
 #include <global_data.h>
 #include <parameters.h>
+#include <wsv_aux_operator.h>
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl/filesystem.h>
 

--- a/src/workspace.cc
+++ b/src/workspace.cc
@@ -29,7 +29,8 @@
   \author Stefan Buehler
   \date   2000-06-10
 */
-#include "workspace_ng.h"
+#include "workspace.h"
+#include "tokval_io.h"
 
 // Some #defines to make the records better readable:
 #define NAME(x) x
@@ -39,7 +40,7 @@
 namespace global_data {
 Array<WsvRecord> wsv_data;
 
-map<String, Index> WsvMap;
+std::map<String, Index> WsvMap;
 }  // namespace global_data
 
 using global_data::wsv_data;

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -1,0 +1,15 @@
+#ifndef workspace_h
+#define workspace_h
+
+#include <map>
+
+#include "array.h"
+#include "matpack.h"
+#include "mystring.h"
+#include "wsv_aux.h"
+
+void define_wsv_data();
+
+void define_wsv_map();
+
+#endif  // workspace_h

--- a/src/workspace_ng.h
+++ b/src/workspace_ng.h
@@ -201,10 +201,6 @@ class Workspace final : public std::enable_shared_from_this<Workspace> {
   std::shared_ptr<Workspace> shared_ptr() {return shared_from_this();}
 };
 
-void define_wsv_data();
-
-void define_wsv_map();
-
 template <class T>
 class OmpParallelCopyGuard {
   T &orig;

--- a/src/wsv_aux.h
+++ b/src/wsv_aux.h
@@ -103,11 +103,6 @@ class WsvRecord {
 
   [[nodiscard]] const TokVal& default_value() const { return defval; }
 
-  /** Output operator for WsvRecord.
-
-      \author Stefan Buehler */
-  friend ostream& operator<<(ostream& os, const WsvRecord& wr);
-
  private:
   String mname;
 

--- a/src/wsv_aux_operator.cc
+++ b/src/wsv_aux_operator.cc
@@ -24,8 +24,9 @@
   \brief  Implementation of WSV aux functions.
 */
 
+#include "wsv_aux_operator.h"
+
 #include "tokval_io.h"
-#include "wsv_aux.h"
 
 #include <iostream>
 #include <map>
@@ -43,7 +44,7 @@
 
   \return Output stream.
 */
-ostream& operator<<(ostream& os, const WsvRecord& wr) {
+std::ostream& operator<<(std::ostream& os, const WsvRecord& wr) {
   using global_data::wsv_groups;
 
   // We need a special treatment for the case that the WSV is an agenda.
@@ -76,7 +77,7 @@ ostream& operator<<(ostream& os, const WsvRecord& wr) {
     // AgendaMap is constant here and should never be changed
     using global_data::AgendaMap;
 
-    map<String, Index>::const_iterator j = AgendaMap.find(wr.Name());
+    auto j = AgendaMap.find(wr.Name());
 
     // Just for added safety, check that we really found something:
     ARTS_ASSERT(j != AgendaMap.end());

--- a/src/wsv_aux_operator.h
+++ b/src/wsv_aux_operator.h
@@ -1,0 +1,11 @@
+#ifndef wsv_aux_operator_h
+#define wsv_aux_operator_h
+
+#include "wsv_aux.h"
+
+/** Output operator for WsvRecord.
+
+    \author Stefan Buehler */
+std::ostream& operator<<(std::ostream& os, const WsvRecord& wr);
+
+#endif  // wsv_aux_operator_h


### PR DESCRIPTION
This moves some stuff around to solve the problem of dependencies above.
It has one key drawback: The default value of workspace variables cannot
be printed anymore.  It can still be accessed on an empty variable but
it cannot be printed.  I am not sure if this can be fixed or if there is
a way to be self-referential in pyarts documentation somehow (e.g., access
the variable some way while building the string that becomes the
documentation)

@olemke This should help your conda tree.  I had to reduce on the documentation somewhat.  I think this is fine in pyarts as we can just to ws.wsv.value to see the default though