### PR TITLE
We can again compile with C++20 flags

### DIFF
--- a/3rdparty/gui/imgui-filebrowser/LICENSE
+++ b/3rdparty/gui/imgui-filebrowser/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2020 Zhuang Guan
+Copyright (c) 2019-2022 Zhuang Guan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/3rdparty/gui/imgui-filebrowser/README.md
+++ b/3rdparty/gui/imgui-filebrowser/README.md
@@ -1,19 +1,19 @@
 # imgui-filebrowser
 
-[imgui-filebrowser](https://github.com/AirGuanZ/imgui-filebrowser) is a simple file browser implementation for [dear-imgui](https://github.com/ocornut/imgui). C++ 17 is required.
+[imgui-filebrowser](https://github.com/AirGuanZ/imgui-filebrowser) is a header-only file browser implementation for [dear-imgui](https://github.com/ocornut/imgui). C++ 17 is required.
 
 ![IMG](./screenshots/0.png)
 
 ## Getting Started
 
-imgui-filebrowser is header-only and must be included after imgui.h:
+`imfilebrowser.h` should be included after `imgui.h`:
 
 ```cpp
 #include <imgui.h>
 #include <imfilebrowser.h>
 ```
 
-Instead of creating a file dialog by an immediate function call, you need to create a `ImGui::FileBrowser` instance, open it with member function `Open()`, and call `Display()` in each frame. Here is a simple example:
+Instead of creating a file dialog with an immediate function call, you need to create a `ImGui::FileBrowser` instance, open it with member function `Open()`, and call `Display()` in each frame. Here is a simple example:
 
 ```cpp
 #include <imgui.h>
@@ -65,17 +65,51 @@ Various options can be combined with '|' and passed to the constructor:
 ```cpp
 enum ImGuiFileBrowserFlags_
 {
-    ImGuiFileBrowserFlags_SelectDirectory  = 1 << 0, // select directory instead of regular file
-    ImGuiFileBrowserFlags_EnterNewFilename = 1 << 1, // allow user to enter new filename when selecting regular file
-    ImGuiFileBrowserFlags_NoModal          = 1 << 2, // file browsing window is modal by default. specify this to use a popup window
-    ImGuiFileBrowserFlags_NoTitleBar       = 1 << 3, // hide window title bar
-    ImGuiFileBrowserFlags_NoStatusBar      = 1 << 4, // hide status bar at the bottom of browsing window
-    ImGuiFileBrowserFlags_CloseOnEsc       = 1 << 5, // close file browser when pressing 'ESC'
-    ImGuiFileBrowserFlags_CreateNewDir     = 1 << 6, // allow user to create new directory
+    ImGuiFileBrowserFlags_SelectDirectory   = 1 << 0, // select directory instead of regular file
+    ImGuiFileBrowserFlags_EnterNewFilename  = 1 << 1, // allow user to enter new filename when selecting regular file
+    ImGuiFileBrowserFlags_NoModal           = 1 << 2, // file browsing window is modal by default. specify this to use a popup window
+    ImGuiFileBrowserFlags_NoTitleBar        = 1 << 3, // hide window title bar
+    ImGuiFileBrowserFlags_NoStatusBar       = 1 << 4, // hide status bar at the bottom of browsing window
+    ImGuiFileBrowserFlags_CloseOnEsc        = 1 << 5, // close file browser when pressing 'ESC'
+    ImGuiFileBrowserFlags_CreateNewDir      = 1 << 6, // allow user to create new directory
+    ImGuiFileBrowserFlags_MultipleSelection = 1 << 7, // allow user to select multiple files. this will hide ImGuiFileBrowserFlags_EnterNewFilename
 };
 ```
+
+When `ImGuiFileBrowserFlags_MultipleSelection` is enabled, use `fileBrowser.GetMultiSelected()` to get all selected filenames (instead of `fileBrowser.GetSelected()`, which returns only one of them).
+
+Here are some common examples:
+
+```cpp
+// select single regular file for opening
+0
+// select multiple regular files for opening
+ImGuiFileBrowserFlags_MultipleSelection
+// select single directory for opening
+ImGuiFileBrowserFlags_SelectDirectory
+// select multiple directories for opening
+ImGuiFileBrowserFlags_SelectDirectory | ImGuiFileBrowserFlags_MultipleSelection
+// select single regular file for saving
+ImGuiFileBrowserFlags_EnterNewFilename | ImGuiFileBrowserFlags_CreateNewDir
+// select single directory for saving
+ImGuiFileBrowserFlags_SelectDirectory | ImGuiFileBrowserFlags_CreateNewDir
+```
+
+## Usage
+
+* double click to enter a directory
+* single click to (de)select a regular file (or directory, when `ImGuiFileBrowserFlags_SelectDirectory` is enabled)
+*  When `ImGuiFileBrowserFlags_SelectDirectory` is enabled and no directory is selected, click `ok` to choose the current directory as selected result
+*  When `ImGuiFileBrowserFlags_MultipleSelection` is enabled, hold `Shift` or `Ctrl` to select more than one file
+*  When `ImGuiFileBrowserFlags_CreateNewDir` is enabled, click the top-right little button "+" to create a new directory
+*  When `ImGuiFileBrowserFlags_SelectDirectory` is not specified,  double click to choose a regular file as selected result.
+
+## Type Filters
+
+* (optionally) use `browser.SetTypeFilters({".h", ".cpp"})` to set file extension filters.
+* ".*" matches with any extension
+* filters are case-insensitive on Windows platform
 
 ## Note
 
 The filebrowser implementation queries drive list via Win32 API (only on Windows). Thus `<Windows.h>` is included in `<imfilebrowser.h>`, which may pollute the global namespace. This can be solved by simply moving the `GetDrivesBitMask()` definition into a cpp file.
-

--- a/3rdparty/gui/imgui-filebrowser/imfilebrowser.h
+++ b/3rdparty/gui/imgui-filebrowser/imfilebrowser.h
@@ -1,37 +1,14 @@
-﻿/*
-MIT License
+﻿#pragma once
 
-Copyright (c) 2019-2020 Zhuang Guan
-
-https://github.com/AirGuanZ
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-*/
-
-#pragma once
-
+#include <algorithm>
 #include <array>
+#include <cctype>
 #include <cstring>
 #include <filesystem>
-#include <functional>
 #include <memory>
+#include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #ifndef IMGUI_VERSION
@@ -42,13 +19,14 @@ using ImGuiFileBrowserFlags = int;
 
 enum ImGuiFileBrowserFlags_
 {
-    ImGuiFileBrowserFlags_SelectDirectory    = 1 << 0, // select directory instead of regular file
-    ImGuiFileBrowserFlags_EnterNewFilename   = 1 << 1, // allow user to enter new filename when selecting regular file
-    ImGuiFileBrowserFlags_NoModal            = 1 << 2, // file browsing window is modal by default. specify this to use a popup window
-    ImGuiFileBrowserFlags_NoTitleBar         = 1 << 3, // hide window title bar
-    ImGuiFileBrowserFlags_NoStatusBar        = 1 << 4, // hide status bar at the bottom of browsing window
-    ImGuiFileBrowserFlags_CloseOnEsc         = 1 << 5, // close file browser when pressing 'ESC'
-    ImGuiFileBrowserFlags_CreateNewDir       = 1 << 6, // allow user to create new directory
+    ImGuiFileBrowserFlags_SelectDirectory   = 1 << 0, // select directory instead of regular file
+    ImGuiFileBrowserFlags_EnterNewFilename  = 1 << 1, // allow user to enter new filename when selecting regular file
+    ImGuiFileBrowserFlags_NoModal           = 1 << 2, // file browsing window is modal by default. specify this to use a popup window
+    ImGuiFileBrowserFlags_NoTitleBar        = 1 << 3, // hide window title bar
+    ImGuiFileBrowserFlags_NoStatusBar       = 1 << 4, // hide status bar at the bottom of browsing window
+    ImGuiFileBrowserFlags_CloseOnEsc        = 1 << 5, // close file browser when pressing 'ESC'
+    ImGuiFileBrowserFlags_CreateNewDir      = 1 << 6, // allow user to create new directory
+    ImGuiFileBrowserFlags_MultipleSelection = 1 << 7, // allow user to select multiple files. this will hide ImGuiFileBrowserFlags_EnterNewFilename
 };
 
 namespace ImGui
@@ -63,6 +41,10 @@ namespace ImGui
         FileBrowser(const FileBrowser &copyFrom);
 
         FileBrowser &operator=(const FileBrowser &copyFrom);
+
+        // set the window position (in pixels)
+        // default is centered
+        void SetWindowPos(int posx, int posy) noexcept;
 
         // set the window size (in pixels)
         // default is (700, 450)
@@ -90,36 +72,79 @@ namespace ImGui
         bool SetPwd(const std::filesystem::path &pwd =
                                     std::filesystem::current_path());
 
+        // get current browsing directory
+        const std::filesystem::path &GetPwd() const noexcept;
+
         // returns selected filename. make sense only when HasSelected returns true
+        // when ImGuiFileBrowserFlags_MultipleSelection is enabled, only one of
+        // selected filename will be returned
         std::filesystem::path GetSelected() const;
+
+        // returns all selected filenames.
+        // when ImGuiFileBrowserFlags_MultipleSelection is enabled, use this
+        // instead of GetSelected
+        std::vector<std::filesystem::path> GetMultiSelected() const;
 
         // set selected filename to empty
         void ClearSelected();
 
-        // set file type filters. eg. { ".h", ".cpp", ".hpp", ".cc", ".inl" }
-        void SetTypeFilters(const std::vector<const char*> &typeFilters);
+        // (optional) set file type filters. eg. { ".h", ".cpp", ".hpp" }
+        // ".*" matches any file types
+        void SetTypeFilters(const std::vector<std::string> &typeFilters);
+
+        // set currently applied type filter
+        // default value is 0 (the first type filter)
+        void SetCurrentTypeFilterIndex(int index);
+
+        // when ImGuiFileBrowserFlags_EnterNewFilename is set
+        // this function will pre-fill the input dialog with a filename.
+        void SetInputName(std::string_view input);
 
     private:
 
-        class ScopeGuard
+        template <class Functor>
+        struct ScopeGuard
         {
-            std::function<void()> func_;
+            ScopeGuard(Functor&& t) : func(std::move(t)) { }
 
-        public:
+            ~ScopeGuard() { func(); }
 
-            template<typename T>
-            explicit ScopeGuard(T func) : func_(std::move(func)) { }
-            ~ScopeGuard() { func_(); }
+        private:
+
+            Functor func;
         };
 
+        struct FileRecord
+        {
+            bool                  isDir = false;
+            std::filesystem::path name;
+            std::string           showName;
+            std::filesystem::path extension;
+        };
+
+        static std::string ToLower(const std::string &s);
+
+        void UpdateFileRecords();
+
         void SetPwdUncatched(const std::filesystem::path &pwd);
+
+        bool IsExtensionMatched(const std::filesystem::path &extension) const;
 
 #ifdef _WIN32
         static std::uint32_t GetDrivesBitMask();
 #endif
 
+        // for c++17 compatibility
+
+#if defined(__cpp_lib_char8_t)
+        static std::string u8StrToStr(std::u8string s);
+#endif
+        static std::string u8StrToStr(std::string s);
+
         int width_;
         int height_;
+        int posX_;
+        int posY_;
         ImGuiFileBrowserFlags flags_;
 
         std::string title_;
@@ -129,22 +154,17 @@ namespace ImGui
         bool closeFlag_;
         bool isOpened_;
         bool ok_;
+        bool posIsSet_;
 
         std::string statusStr_;
 
-        std::vector<const char*> typeFilters_;
-        int typeFilterIndex_;
+        std::vector<std::string> typeFilters_;
+        unsigned int typeFilterIndex_;
+        bool hasAllFilter_;
 
         std::filesystem::path pwd_;
-        std::filesystem::path selectedFilename_;
+        std::set<std::filesystem::path> selectedFilenames_;
 
-        struct FileRecord
-        {
-            bool isDir = false;
-            std::filesystem::path name;
-            std::string showName;
-            std::filesystem::path extension;
-        };
         std::vector<FileRecord> fileRecords_;
 
         // IMPROVE: truncate when selectedFilename_.length() > inputNameBuf_.size() - 1
@@ -161,20 +181,24 @@ namespace ImGui
 } // namespace ImGui
 
 inline ImGui::FileBrowser::FileBrowser(ImGuiFileBrowserFlags flags)
-    : width_(700), height_(450), flags_(flags),
-      openFlag_(false), closeFlag_(false), isOpened_(false), ok_(false),
+    : width_(700), height_(450), posX_(0), posY_(0), flags_(flags),
+      openFlag_(false), closeFlag_(false), isOpened_(false), ok_(false), posIsSet_(false),
       inputNameBuf_(std::make_unique<std::array<char, INPUT_NAME_BUF_SIZE>>())
 {
     if(flags_ & ImGuiFileBrowserFlags_CreateNewDir)
-        newDirNameBuf_ = std::make_unique<
-                                std::array<char, INPUT_NAME_BUF_SIZE>>();
+    {
+        newDirNameBuf_ =
+            std::make_unique<std::array<char, INPUT_NAME_BUF_SIZE>>();
+    }
 
-    inputNameBuf_->at(0) = '\0';
+    inputNameBuf_->front() = '\0';
+    inputNameBuf_->back() = '\0';
     SetTitle("file browser");
     SetPwd(std::filesystem::current_path());
 
     typeFilters_.clear();
     typeFilterIndex_ = 0;
+    hasAllFilter_ = false;
 
 #ifdef _WIN32
     drives_ = GetDrivesBitMask();
@@ -190,6 +214,12 @@ inline ImGui::FileBrowser::FileBrowser(const FileBrowser &copyFrom)
 inline ImGui::FileBrowser &ImGui::FileBrowser::operator=(
     const FileBrowser &copyFrom)
 {
+    width_  = copyFrom.width_;
+    height_ = copyFrom.height_;
+
+    posX_ = copyFrom.posX_;
+    posY_ = copyFrom.posY_;
+
     flags_ = copyFrom.flags_;
     SetTitle(copyFrom.title_);
 
@@ -197,23 +227,41 @@ inline ImGui::FileBrowser &ImGui::FileBrowser::operator=(
     closeFlag_ = copyFrom.closeFlag_;
     isOpened_  = copyFrom.isOpened_;
     ok_        = copyFrom.ok_;
-    
+    posIsSet_  = copyFrom.posIsSet_;
+
     statusStr_ = "";
-    pwd_ = copyFrom.pwd_;
-    selectedFilename_ = copyFrom.selectedFilename_;
+
+    typeFilters_     = copyFrom.typeFilters_;
+    typeFilterIndex_ = copyFrom.typeFilterIndex_;
+    hasAllFilter_    = copyFrom.hasAllFilter_;
+
+    pwd_               = copyFrom.pwd_;
+    selectedFilenames_ = copyFrom.selectedFilenames_;
 
     fileRecords_ = copyFrom.fileRecords_;
 
     *inputNameBuf_ = *copyFrom.inputNameBuf_;
 
+    openNewDirLabel_ = copyFrom.openNewDirLabel_;
     if(flags_ & ImGuiFileBrowserFlags_CreateNewDir)
     {
         newDirNameBuf_ = std::make_unique<
-                                std::array<char, INPUT_NAME_BUF_SIZE>>();
+            std::array<char, INPUT_NAME_BUF_SIZE>>();
         *newDirNameBuf_ = *copyFrom.newDirNameBuf_;
     }
 
+#ifdef _WIN32
+    drives_ = copyFrom.drives_;
+#endif
+
     return *this;
+}
+
+inline void ImGui::FileBrowser::SetWindowPos(int posx, int posy) noexcept
+{
+    posX_ = posx;
+    posY_ = posy;
+    posIsSet_ = true;
 }
 
 inline void ImGui::FileBrowser::SetWindowSize(int width, int height) noexcept
@@ -235,6 +283,7 @@ inline void ImGui::FileBrowser::SetTitle(std::string title)
 inline void ImGui::FileBrowser::Open()
 {
     ClearSelected();
+    UpdateFileRecords();
     statusStr_ = std::string();
     openFlag_ = true;
     closeFlag_ = false;
@@ -264,18 +313,27 @@ inline void ImGui::FileBrowser::Display()
     });
 
     if(openFlag_)
+    {
         OpenPopup(openLabel_.c_str());
+    }
     isOpened_ = false;
 
     // open the popup window
 
     if(openFlag_ && (flags_ & ImGuiFileBrowserFlags_NoModal))
     {
+        if (posIsSet_)
+            SetNextWindowPos(
+                    ImVec2(static_cast<float>(posX_), static_cast<float>(posY_)));
         SetNextWindowSize(
             ImVec2(static_cast<float>(width_), static_cast<float>(height_)));
     }
     else
     {
+        if (posIsSet_)
+            SetNextWindowPos(
+                    ImVec2(static_cast<float>(posX_), static_cast<float>(posY_)),
+                    ImGuiCond_FirstUseEver);
         SetNextWindowSize(
             ImVec2(static_cast<float>(width_), static_cast<float>(height_)),
             ImGuiCond_FirstUseEver);
@@ -283,7 +341,9 @@ inline void ImGui::FileBrowser::Display()
     if(flags_ & ImGuiFileBrowserFlags_NoModal)
     {
         if(!BeginPopup(openLabel_.c_str()))
+        {
             return;
+        }
     }
     else if(!BeginPopupModal(openLabel_.c_str(), nullptr,
                              flags_ & ImGuiFileBrowserFlags_NoTitleBar ?
@@ -291,6 +351,7 @@ inline void ImGui::FileBrowser::Display()
     {
         return;
     }
+
     isOpened_ = true;
     ScopeGuard endPopup([] { EndPopup(); });
 
@@ -303,14 +364,19 @@ inline void ImGui::FileBrowser::Display()
     PushItemWidth(4 * GetFontSize());
     if(BeginCombo("##select_drive", driveStr))
     {
-        ScopeGuard guard([&] { ImGui::EndCombo(); });
+        ScopeGuard guard([&] { EndCombo(); });
+
         for(int i = 0; i < 26; ++i)
         {
             if(!(drives_ & (1 << i)))
+            {
                 continue;
+            }
+
             char driveCh = static_cast<char>('A' + i);
             char selectableStr[] = { driveCh, ':', '\0' };
             bool selected = currentDrive == driveCh;
+
             if(Selectable(selectableStr, selected) && !selected)
             {
                 char newPwd[] = { driveCh, ':', '\\', '\0' };
@@ -324,7 +390,7 @@ inline void ImGui::FileBrowser::Display()
 #endif
 
     int secIdx = 0, newPwdLastSecIdx = -1;
-    for(auto &&sec : pwd_)
+    for(const auto &sec : pwd_)
     {
 #ifdef _WIN32
         if(secIdx == 1)
@@ -333,12 +399,18 @@ inline void ImGui::FileBrowser::Display()
             continue;
         }
 #endif
+
         PushID(secIdx);
         if(secIdx > 0)
+        {
             SameLine();
-        if(SmallButton(sec.u8string().c_str()))
+        }
+        if(SmallButton(u8StrToStr(sec.u8string()).c_str()))
+        {
             newPwdLastSecIdx = secIdx;
+        }
         PopID();
+
         ++secIdx;
     }
 
@@ -346,23 +418,52 @@ inline void ImGui::FileBrowser::Display()
     {
         int i = 0;
         std::filesystem::path newPwd;
-        for(auto &&sec : pwd_)
+        for(const auto &sec : pwd_)
         {
             if(i++ > newPwdLastSecIdx)
+            {
                 break;
+            }
             newPwd /= sec;
         }
+
 #ifdef _WIN32
         if(newPwdLastSecIdx == 0)
+        {
             newPwd /= "\\";
+        }
 #endif
+
         SetPwd(newPwd);
     }
 
     SameLine();
 
     if(SmallButton("*"))
-        SetPwd(pwd_);
+    {
+        UpdateFileRecords();
+
+        std::set<std::filesystem::path> newSelectedFilenames;
+        for(auto &name : selectedFilenames_)
+        {
+            auto it = std::find_if(
+                fileRecords_.begin(), fileRecords_.end(),
+                [&](const FileRecord &record)
+            {
+                return name == record.name;
+            });
+
+            if(it != fileRecords_.end())
+            {
+                newSelectedFilenames.insert(name);
+            }
+        }
+
+        if(inputNameBuf_ && (*inputNameBuf_)[0])
+        {
+            newSelectedFilenames.insert(inputNameBuf_->data());
+        }
+    }
 
     if(newDirNameBuf_)
     {
@@ -384,7 +485,9 @@ inline void ImGui::FileBrowser::Display()
             {
                 ScopeGuard closeNewDirPopup([] { CloseCurrentPopup(); });
                 if(create_directory(pwd_ / newDirNameBuf_->data()))
-                    SetPwd(pwd_);
+                {
+                    UpdateFileRecords();
+                }
                 else
                 {
                     statusStr_ = "failed to create " +
@@ -409,21 +512,38 @@ inline void ImGui::FileBrowser::Display()
 
         for(auto &rsc : fileRecords_)
         {
-            if (!rsc.isDir && typeFilters_.size() > 0 &&
-                static_cast<size_t>(typeFilterIndex_) < typeFilters_.size() &&
-                !(rsc.extension == typeFilters_[typeFilterIndex_]))
+            if(!rsc.isDir && !IsExtensionMatched(rsc.extension))
+            {
                 continue;
+            }
 
             if(!rsc.name.empty() && rsc.name.c_str()[0] == '$')
+            {
                 continue;
+            }
 
-            const bool selected = selectedFilename_ == rsc.name;
+            bool selected = selectedFilenames_.find(rsc.name)
+                         != selectedFilenames_.end();
+
             if(Selectable(rsc.showName.c_str(), selected,
                           ImGuiSelectableFlags_DontClosePopups))
             {
+                const bool multiSelect =
+                    (flags_ & ImGuiFileBrowserFlags_MultipleSelection) &&
+                    IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) &&
+                    (GetIO().KeyCtrl || GetIO().KeyShift);
+
                 if(selected)
                 {
-                    selectedFilename_ = std::filesystem::path();
+                    if(!multiSelect)
+                    {
+                        selectedFilenames_.clear();
+                    }
+                    else
+                    {
+                        selectedFilenames_.erase(rsc.name);
+                    }
+
                     (*inputNameBuf_)[0] = '\0';
                 }
                 else if(rsc.name != "..")
@@ -431,32 +551,60 @@ inline void ImGui::FileBrowser::Display()
                     if((rsc.isDir && (flags_ & ImGuiFileBrowserFlags_SelectDirectory)) ||
                        (!rsc.isDir && !(flags_ & ImGuiFileBrowserFlags_SelectDirectory)))
                     {
-                        selectedFilename_ = rsc.name;
+                        if(multiSelect)
+                        {
+                            selectedFilenames_.insert(rsc.name);
+                        }
+                        else
+                        {
+                            selectedFilenames_ = { rsc.name };
+                        }
+
                         if(!(flags_ & ImGuiFileBrowserFlags_SelectDirectory))
                         {
 #ifdef _MSC_VER
-                            strcpy_s(inputNameBuf_->data(), inputNameBuf_->size(),
-                                     selectedFilename_.u8string().c_str());
+                            strcpy_s(
+                                inputNameBuf_->data(), inputNameBuf_->size(),
+                                u8StrToStr(rsc.name.u8string()).c_str());
 #else
-                            std::strncpy(inputNameBuf_->data(), selectedFilename_.u8string().c_str(),
-                                         inputNameBuf_->size());
+                            std::strncpy(inputNameBuf_->data(),
+                                         u8StrToStr(rsc.name.u8string()).c_str(),
+                                         inputNameBuf_->size() - 1);
 #endif
                         }
                     }
                 }
+                else
+                {
+                    if(!multiSelect)
+                    {
+                        selectedFilenames_.clear();
+                    }
+                }
             }
 
-            if(IsItemClicked(0) && IsMouseDoubleClicked(0) && rsc.isDir)
+            if(IsItemClicked(0) && IsMouseDoubleClicked(0))
             {
-                setNewPwd = true;
-                newPwd = (rsc.name != "..") ? (pwd_ / rsc.name) :
-                                               pwd_.parent_path();
+                if(rsc.isDir)
+                {
+                    setNewPwd = true;
+                    newPwd = (rsc.name != "..") ? (pwd_ / rsc.name) :
+                                                   pwd_.parent_path();
+                }
+                else if(!(flags_ & ImGuiFileBrowserFlags_SelectDirectory))
+                {
+                    selectedFilenames_ = { rsc.name };
+                    ok_ = true;
+                    CloseCurrentPopup();
+                }
             }
         }
     }
 
     if(setNewPwd)
+    {
         SetPwd(newPwd);
+    }
 
     if(!(flags_ & ImGuiFileBrowserFlags_SelectDirectory) &&
        (flags_ & ImGuiFileBrowserFlags_EnterNewFilename))
@@ -465,14 +613,17 @@ inline void ImGui::FileBrowser::Display()
         ScopeGuard popTextID([] { PopID(); });
 
         PushItemWidth(-1);
-        if(InputText("", inputNameBuf_->data(), inputNameBuf_->size()))
-            selectedFilename_ = inputNameBuf_->data();
+        if(InputText("", inputNameBuf_->data(), inputNameBuf_->size()) &&
+           inputNameBuf_->at(0) != '\0')
+        {
+            selectedFilenames_ = { inputNameBuf_->data() };
+        }
         PopItemWidth();
     }
 
     if(!(flags_ & ImGuiFileBrowserFlags_SelectDirectory))
     {
-        if(Button(" ok ") && !selectedFilename_.empty())
+        if(Button(" ok ") && !selectedFilenames_.empty())
         {
             ok_ = true;
             CloseCurrentPopup();
@@ -480,26 +631,24 @@ inline void ImGui::FileBrowser::Display()
     }
     else
     {
-        if(selectedFilename_.empty())
+        if(Button(" ok "))
         {
-            if(Button(" ok "))
-            {
-                ok_ = true;
-                CloseCurrentPopup();
-            }
+            ok_ = true;
+            CloseCurrentPopup();
         }
-        else if(Button("open"))
-            SetPwd(pwd_ / selectedFilename_);
     }
 
     SameLine();
 
-    int escIdx = GetIO().KeyMap[ImGuiKey_Escape];
-    if(Button("cancel") || closeFlag_ ||
+    bool shouldExit =
+        Button("cancel") || closeFlag_ ||
         ((flags_ & ImGuiFileBrowserFlags_CloseOnEsc) &&
-         IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) &&
-         escIdx >= 0 && IsKeyPressed(escIdx)))
+        IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) &&
+        IsKeyPressed(ImGuiKey_Escape));
+    if(shouldExit)
+    {
         CloseCurrentPopup();
+    }
 
     if(!statusStr_.empty() && !(flags_ & ImGuiFileBrowserFlags_NoStatusBar))
     {
@@ -507,12 +656,24 @@ inline void ImGui::FileBrowser::Display()
         Text("%s", statusStr_.c_str());
     }
 
-    if (!typeFilters_.empty())
+    if(!typeFilters_.empty())
     {
         SameLine();
         PushItemWidth(8 * GetFontSize());
-        Combo("##type_filters", &typeFilterIndex_,
-              typeFilters_.data(), int(typeFilters_.size()));
+        if(BeginCombo(
+            "##type_filters", typeFilters_[typeFilterIndex_].c_str()))
+        {
+            ScopeGuard guard([&] { EndCombo(); });
+
+            for(size_t i = 0; i < typeFilters_.size(); ++i)
+            {
+                bool selected = i == typeFilterIndex_;
+                if(Selectable(typeFilters_[i].c_str(), selected) && !selected)
+                {
+                    typeFilterIndex_ = static_cast<unsigned int>(i);
+                }
+            }
+        }
         PopItemWidth();
     }
 }
@@ -542,48 +703,168 @@ inline bool ImGui::FileBrowser::SetPwd(const std::filesystem::path &pwd)
     return false;
 }
 
+inline const class std::filesystem::path &ImGui::FileBrowser::GetPwd() const noexcept
+{
+    return pwd_;
+}
+
 inline std::filesystem::path ImGui::FileBrowser::GetSelected() const
 {
-    return pwd_ / selectedFilename_;
+    // when ok_ is true, selectedFilenames_ may be empty if SelectDirectory
+    // is enabled. return pwd in that case.
+    if(selectedFilenames_.empty())
+    {
+        return pwd_;
+    }
+    return pwd_ / *selectedFilenames_.begin();
+}
+
+inline std::vector<std::filesystem::path>
+    ImGui::FileBrowser::GetMultiSelected() const
+{
+    if(selectedFilenames_.empty())
+    {
+        return { pwd_ };
+    }
+
+    std::vector<std::filesystem::path> ret;
+    ret.reserve(selectedFilenames_.size());
+    for(auto &s : selectedFilenames_)
+    {
+        ret.push_back(pwd_ / s);
+    }
+
+    return ret;
 }
 
 inline void ImGui::FileBrowser::ClearSelected()
 {
-    selectedFilename_ = std::string();
+    selectedFilenames_.clear();
     (*inputNameBuf_)[0] = '\0';
     ok_ = false;
 }
 
 inline void ImGui::FileBrowser::SetTypeFilters(
-    const std::vector<const char*> &typeFilters)
+    const std::vector<std::string> &_typeFilters)
 {
-    typeFilters_ = typeFilters;
+    typeFilters_.clear();
+
+    // remove duplicate filter names due to case unsensitivity on windows
+
+#ifdef _WIN32
+
+    std::vector<std::string> typeFilters;
+    for(auto &rawFilter : _typeFilters)
+    {
+        std::string lowerFilter = ToLower(rawFilter);
+        auto it = std::find(typeFilters.begin(), typeFilters.end(), lowerFilter);
+        if(it == typeFilters.end())
+        {
+            typeFilters.push_back(std::move(lowerFilter));
+        }
+    }
+
+#else
+
+    auto &typeFilters = _typeFilters;
+
+#endif
+
+    // insert auto-generated filter
+
+    if(typeFilters.size() > 1)
+    {
+        hasAllFilter_  = true;
+        std::string allFiltersName = std::string();
+        for(size_t i = 0; i < typeFilters.size(); ++i)
+        {
+            if(typeFilters[i] == std::string_view(".*"))
+            {
+                hasAllFilter_ = false;
+                break;
+            }
+
+            if(i > 0)
+            {
+                allFiltersName += ",";
+            }
+            allFiltersName += typeFilters[i];
+        }
+
+        if(hasAllFilter_)
+        {
+            typeFilters_.push_back(std::move(allFiltersName));
+        }
+    }
+
+    std::copy(
+        typeFilters.begin(), typeFilters.end(),
+        std::back_inserter(typeFilters_));
+
     typeFilterIndex_ = 0;
 }
 
-inline void ImGui::FileBrowser::SetPwdUncatched(const std::filesystem::path &pwd)
+inline void ImGui::FileBrowser::SetCurrentTypeFilterIndex(int index)
+{
+    typeFilterIndex_ = static_cast<unsigned int>(index);
+}
+
+inline void ImGui::FileBrowser::SetInputName(std::string_view input)
+{
+    if(flags_ & ImGuiFileBrowserFlags_EnterNewFilename)
+    {
+        if(input.size() >= static_cast<size_t>(INPUT_NAME_BUF_SIZE))
+        {
+            // If input doesn't fit trim off characters
+            input = input.substr(0, INPUT_NAME_BUF_SIZE - 1);
+        }
+        std::copy(input.begin(), input.end(), inputNameBuf_->begin());
+        inputNameBuf_->at(input.size()) = '\0';
+        selectedFilenames_ = { inputNameBuf_->data() };
+    }
+}
+
+inline std::string ImGui::FileBrowser::ToLower(const std::string &s)
+{
+    std::string ret = s;
+    for(char &c : ret)
+    {
+        c = static_cast<char>(std::tolower(c));
+    }
+    return ret;
+}
+
+inline void ImGui::FileBrowser::UpdateFileRecords()
 {
     fileRecords_ = { FileRecord{ true, "..", "[D] ..", "" } };
 
-    for(auto &p : std::filesystem::directory_iterator(pwd))
+    for(auto &p : std::filesystem::directory_iterator(pwd_))
     {
         FileRecord rcd;
 
         if(p.is_regular_file())
+        {
             rcd.isDir = false;
+        }
         else if(p.is_directory())
+        {
             rcd.isDir = true;
+        }
         else
+        {
             continue;
+        }
 
         rcd.name = p.path().filename();
         if(rcd.name.empty())
+        {
             continue;
+        }
 
         rcd.extension = p.path().filename().extension();
 
         rcd.showName = (rcd.isDir ? "[D] " : "[F] ") +
-                        p.path().filename().u8string();
+                       u8StrToStr(p.path().filename().u8string());
         fileRecords_.push_back(rcd);
     }
 
@@ -592,10 +873,70 @@ inline void ImGui::FileBrowser::SetPwdUncatched(const std::filesystem::path &pwd
     {
         return (L.isDir ^ R.isDir) ? L.isDir : (L.name < R.name);
     });
+}
 
+inline void ImGui::FileBrowser::SetPwdUncatched(const std::filesystem::path &pwd)
+{
     pwd_ = absolute(pwd);
-    selectedFilename_ = std::string();
+    UpdateFileRecords();
+    selectedFilenames_.clear();
     (*inputNameBuf_)[0] = '\0';
+}
+
+inline bool ImGui::FileBrowser::IsExtensionMatched(
+    const std::filesystem::path &_extension) const
+{
+#ifdef _WIN32
+    std::filesystem::path extension = ToLower(_extension.string());
+#else
+    auto &extension = _extension;
+#endif
+
+    // no type filters
+    if(typeFilters_.empty())
+    {
+        return true;
+    }
+
+    // invalid type filter index
+    if(static_cast<size_t>(typeFilterIndex_) >= typeFilters_.size())
+    {
+        return true;
+    }
+
+    // all type filters
+    if(hasAllFilter_ && typeFilterIndex_ == 0)
+    {
+        for(size_t i = 1; i < typeFilters_.size(); ++i)
+        {
+            if(extension == typeFilters_[i])
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // universal filter
+    if(typeFilters_[typeFilterIndex_] == std::string_view(".*"))
+    {
+        return true;
+    }
+
+    // regular filter
+    return extension == typeFilters_[typeFilterIndex_];
+}
+
+#if defined(__cpp_lib_char8_t)
+inline std::string ImGui::FileBrowser::u8StrToStr(std::u8string s)
+{
+    return std::string(s.begin(), s.end());
+}
+#endif
+
+inline std::string ImGui::FileBrowser::u8StrToStr(std::string s)
+{
+    return s;
 }
 
 #ifdef _WIN32
@@ -625,11 +966,15 @@ inline std::uint32_t ImGui::FileBrowser::GetDrivesBitMask()
     for(int i = 0; i < 26; ++i)
     {
         if(!(mask & (1 << i)))
+        {
             continue;
+        }
         char rootName[4] = { static_cast<char>('A' + i), ':', '\\', '\0' };
         UINT type = GetDriveTypeA(rootName);
-        if(type == DRIVE_REMOVABLE || type == DRIVE_FIXED)
+        if(type == DRIVE_REMOVABLE || type == DRIVE_FIXED ||  type == DRIVE_REMOTE)
+        {
             ret |= (1 << i);
+        }
     }
     return ret;
 }

--- a/3rdparty/invlib/src/invlib/traits.h
+++ b/3rdparty/invlib/src/invlib/traits.h
@@ -154,7 +154,7 @@ template<typename T1>
 using is_move_assignable = typename std::is_move_assignable<T1>;
 
 template<typename T1>
-using return_type = typename std::result_of<T1>::type;
+using return_type = std::invoke_result_t<T1>;
 
 template<typename T1>
 using CopyWrapper = typename std::conditional<std::is_lvalue_reference<T1>::value,


### PR DESCRIPTION
Apparently we have been unable to compile with C++20 for some time.

@simonpf I made a small change in invlib.  Please have a look or leave it be; there was a deprecated feature used so I just used the new-and-fancy replacement.  result_of should use invoke_result in the future.  I think this didn't change anything but I am not sure how to debug this library.

@olemke We need two things here to not allow this to happen again
1. Activate C++20 for at least one of the CI
2. Activate deprecation warnings when compiling.  result_of was deprecated through all of C++17, I hope some warning in the compiler for future-proofing can be made.

I want make the case for switching to a limited subset of C++20.  Our oldest compiler is GCC9, which supports about half of C++20 (both lib and lang).  These are some of the most important things that we would gain immediately:
1. Complex constexpr from the standard, we could stop using our own limited overloads.
2. Attributes like [[likely]] and [[unlikely]] on switch and if-statements
3. standard linear interpolation and midpoint.

There are also things like constexpr try-catch, `<version>`-header, starts_with and ends_with on string-types, remove_cv_ref, move in `<numeric>`, contains on map and vector, and so on

Once we switch so GCC10 is the oldest compiler we will have much more important things like atomic floats and concepts