### PR TITLE
arts user error for aa_grid len > 1 when star is off

### DIFF
--- a/src/m_disort.cc
+++ b/src/m_disort.cc
@@ -362,12 +362,9 @@ void DisortCalcWithARTSSurface(Workspace& ws,
 
 
   } else {
-    
-    ARTS_USER_ERROR_IF(aa_grid.nelem() != 1,
-                       "There is no star and therefore no azimuth dependency.\n",
-                       "The length of th aa_grid should be 1, but is",
-                       aa_grid.nelem(),
-                       "instead.")
+    CREATE_OUT3;
+    out3 << "There is no star and therefore no azimuth dependency.\n";
+    out3 << "The length of th aa_grid should be 1, but is" << aa_grid.nelem() << "instead.\n";
 
     init_ifield(cloudbox_field,
                 f_grid,

--- a/src/m_disort.cc
+++ b/src/m_disort.cc
@@ -363,8 +363,8 @@ void DisortCalcWithARTSSurface(Workspace& ws,
 
   } else {
     CREATE_OUT3;
-    out3 << "There is no star and therefore no azimuth dependency.\n";
-    out3 << "The length of th aa_grid should be 1, but is" << aa_grid.nelem() << "instead.\n";
+    out3 << "Disort calculation encountered aa_grid size larger than 1 in a case when it\n";
+    out3 << "does not use aa_grid. Calculations are performed as if there is no aa_grid.\n";
 
     init_ifield(cloudbox_field,
                 f_grid,

--- a/src/m_disort.cc
+++ b/src/m_disort.cc
@@ -362,6 +362,13 @@ void DisortCalcWithARTSSurface(Workspace& ws,
 
 
   } else {
+    
+    ARTS_USER_ERROR_IF(aa_grid.nelem() != 1,
+                       "There is no star and therefore no azimuth dependency.\n",
+                       "The length of th aa_grid should be 1, but is",
+                       aa_grid.nelem(),
+                       "instead.")
+
     init_ifield(cloudbox_field,
                 f_grid,
                 cloudbox_limits,

--- a/src/m_fluxes.cc
+++ b/src/m_fluxes.cc
@@ -412,8 +412,8 @@ void spectral_irradiance_fieldFromSpectralRadianceField(
     const Vector& za_grid_weights,
     const Verbosity&) {
   // Number of zenith angles.
-  const Index N_scat_za = za_grid.nelem();
-  const Index N_scat_aa = aa_grid.nelem();
+  const Index N_scat_za = spectral_radiance_field.npages();
+  const Index N_scat_aa = spectral_radiance_field.nrows();
 
   Tensor5 iy_field_aa_integrated;
 


### PR DESCRIPTION
When there is no star there is no azimuth dependency and therefore the `aa_grid` should have length 1. 
The Integration in `spectral_irradiance_fieldFromSpectralRadianceField` should run over the pen of the array itself and not other variables. 