### PR TITLE
Enable C++20

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -12,9 +12,6 @@ jobs:
       matrix:
         name: [
           ubuntu-doc,
-          ubuntu-gcc-9,
-          ubuntu-gcc-10,
-          ubuntu-gcc-10-cxx20,
           ubuntu-clang-13-debug,
           ubuntu-gcc-11,
           ubuntu-clang-13-nofortran,
@@ -33,43 +30,6 @@ jobs:
             fortran: "no"
             check: "no"
             libcxx: "yes"
-            buildtype: "Release"
-
-          - name: ubuntu-gcc-9
-            os: ubuntu-20.04
-            compiler: gcc
-            version: "9"
-            doc: "no"
-            arts: "yes"
-            fortran: "yes"
-            fortran-version: "9"
-            check: "yes"
-            libcxx: "no"
-            buildtype: "Release"
-
-          - name: ubuntu-gcc-10
-            os: ubuntu-20.04
-            compiler: gcc
-            version: "10"
-            doc: "no"
-            arts: "yes"
-            fortran: "yes"
-            fortran-version: "10"
-            check: "yes"
-            libcxx: "no"
-            buildtype: "Release"
-
-          - name: ubuntu-gcc-10-cxx20
-            os: ubuntu-20.04
-            compiler: gcc
-            version: "10"
-            doc: "no"
-            arts: "yes"
-            fortran: "yes"
-            fortran-version: "10"
-            check: "yes"
-            libcxx: "no"
-            cmakeflags: "-DENABLE_CXX20=1"
             buildtype: "Release"
 
           - name: ubuntu-clang-13-debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
-cmake_minimum_required (VERSION 3.18)
+if (ENABLE_CXX23)
+  cmake_minimum_required (VERSION 3.20)
+else ()
+  cmake_minimum_required (VERSION 3.18)
+endif ()
 
 project (ARTS C CXX)
 
@@ -36,7 +40,7 @@ endif()
 # User options (auto-complete and cmake gui works better like this)
 include(CMakeDependentOption)
 option (ENABLE_CCACHE "Turn on CCACHE" ON)
-option (ENABLE_CXX20 "Turn on C++20 (experimental)" OFF)
+option (ENABLE_CXX23 "Turn on C++23 (Don't use, only for future updates)" OFF)
 option (ENABLE_FORTRAN "Turn on Fortran code" OFF)
 option (ENABLE_GUI "Turn on Debug GUI" OFF)
 option (ENABLE_IPO "Turn on IPO (experimental)" OFF)
@@ -70,6 +74,19 @@ if (IGNORE_CONDA_PATH)
     endif()
   endif()
 endif()
+
+########### C++20/23 Support ##########
+
+if (NOT CMAKE_CXX_STANDARD)
+  if (ENABLE_CXX23)
+    set(CMAKE_CXX_STANDARD 23)
+  else ()
+    set(CMAKE_CXX_STANDARD 20)
+  endif ()
+endif ()
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 enable_testing ()
 
@@ -147,18 +164,7 @@ if (ENABLE_CCACHE)
   endif (CCACHE_FOUND)
 endif ()
 
-########### C++17/20 Support ##########
-
-if (NOT CMAKE_CXX_STANDARD)
-  if (ENABLE_CXX20)
-    set(CMAKE_CXX_STANDARD 20)
-  else ()
-    set(CMAKE_CXX_STANDARD 17)
-  endif ()
-endif()
-
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+########### IPO ##########
 
 if (ENABLE_IPO)
   include(CheckIPOSupported)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Building ARTS
 
 Build Prerequisites:
 
-- gcc/g++ >=9 (or llvm/clang >=13) older versions might work, but are untested
+- gcc/g++ >=11 (or llvm/clang >=13) older versions might work, but are untested
 - cmake (>=3.18)
 - zlib
 - openblas

--- a/actions/pypi/build_arts.sh
+++ b/actions/pypi/build_arts.sh
@@ -23,7 +23,7 @@ cmake -DCMAKE_PREFIX_PATH=$PYTHONDIR -DCMAKE_BUILD_TYPE=Release -DENABLE_FORTRAN
 echo "########## CMakeCache.txt ##########"
 cat CMakeCache.txt
 echo "########## CMakeCache.txt ##########"
-make -j2 arts
+make -j1 arts
 make -j1 pyarts
 echo "########## Check Python version ##########"
 make check-pyversion


### PR DESCRIPTION
Build requires GCC 11 now.

The manylinux image comes only with GCC 10 as the system compiler. GCC 11 is installed inside the Python environment. There might be an issue with the Python 3.8 if it only provides GCC 10. Deploy logs will tell.

TODO: Enforce minimum compiler version in CMakeLists.txt.