### PR TITLE
Add no negative flag to propmat_clearskyAddFromLookup

### DIFF
--- a/src/m_abs.cc
+++ b/src/m_abs.cc
@@ -1672,7 +1672,7 @@ struct MethodAppender {
 };
 }  // namespace
 
-void propmat_clearsky_agendaAuto(  // Workspace reference:
+void propmat_clearsky_agendaAuto(// Workspace reference:
     Workspace& ws,
     // WS Output:
     Agenda& propmat_clearsky_agenda,
@@ -1681,22 +1681,20 @@ void propmat_clearsky_agendaAuto(  // Workspace reference:
     const ArrayOfArrayOfSpeciesTag& abs_species,
     const ArrayOfArrayOfAbsorptionLines& abs_lines_per_species,
     // WS Generic Input:
+    const Numeric& H,
     const Numeric& T_extrapolfac,
-    const Index& ignore_errors,
+    const Numeric& eta,
     const Numeric& extpolfac,
-    const Index& no_negative_from_lut,
     const Numeric& force_p,
     const Numeric& force_t,
+    const Index& ignore_errors,
     const Numeric& lines_sparse_df,
     const Numeric& lines_sparse_lim,
     const String& lines_speedup_option,
-    const Index& no_negatives,
-    const Index& use_abs_as_ext,
     const Index& manual_mag_field,
-    const Numeric& H,
+    const Index& no_negatives,
     const Numeric& theta,
-    const Numeric& eta,
-    // Special parameter:
+    const Index& use_abs_as_ext,
     const Index& use_abs_lookup_ind,
     // Verbosity object:
     const Verbosity& verbosity) {
@@ -1720,7 +1718,7 @@ void propmat_clearsky_agendaAuto(  // Workspace reference:
   if (use_abs_lookup) {
     const std::array gins{
         MethodSetDelHelper(ws, "extpolfac", "Numeric", extpolfac),
-        MethodSetDelHelper(ws, "no_negative_from_lut", "Index", no_negative_from_lut)};
+        MethodSetDelHelper(ws, "no_negatives", "Index", no_negatives)};
     agenda.append_gin_method("propmat_clearskyAddFromLookup", gins);
   }
 

--- a/src/m_abs.cc
+++ b/src/m_abs.cc
@@ -1684,6 +1684,7 @@ void propmat_clearsky_agendaAuto(  // Workspace reference:
     const Numeric& T_extrapolfac,
     const Index& ignore_errors,
     const Numeric& extpolfac,
+    const Index& no_negative_from_lut,
     const Numeric& force_p,
     const Numeric& force_t,
     const Numeric& lines_sparse_df,
@@ -1718,7 +1719,8 @@ void propmat_clearsky_agendaAuto(  // Workspace reference:
   // propmat_clearskyAddFromLookup
   if (use_abs_lookup) {
     const std::array gins{
-        MethodSetDelHelper(ws, "extpolfac", "Numeric", extpolfac)};
+        MethodSetDelHelper(ws, "extpolfac", "Numeric", extpolfac),
+        MethodSetDelHelper(ws, "no_negative_from_lut", "Index", no_negative_from_lut)};
     agenda.append_gin_method("propmat_clearskyAddFromLookup", gins);
   }
 

--- a/src/m_abs_lookup.cc
+++ b/src/m_abs_lookup.cc
@@ -2021,6 +2021,7 @@ void propmat_clearskyAddFromLookup(
     const ArrayOfArrayOfSpeciesTag& abs_species,
     const ArrayOfSpeciesTag& select_abs_species,
     const Numeric& extpolfac,
+    const Index& no_negative_from_lut,
     const Verbosity& verbosity) {
   CREATE_OUT3;
 
@@ -2091,6 +2092,15 @@ void propmat_clearskyAddFromLookup(
                        a_vmr_list,
                        f_grid,
                        extpolfac);
+  }
+
+  if (no_negative_from_lut){
+    //Check for negative values due to interpolation and set them to zero
+    for (Index ir = 0; ir < abs_scalar_gas.nrows(); ir++){
+      for (Index ic = 0; ic < abs_scalar_gas.ncols(); ic++){
+        if (abs_scalar_gas(ir, ic)<0) abs_scalar_gas(ir, ic)=0;
+      }
+    }
   }
 
   // Now add to the right place in the absorption matrix.

--- a/src/m_abs_lookup.cc
+++ b/src/m_abs_lookup.cc
@@ -2021,7 +2021,7 @@ void propmat_clearskyAddFromLookup(
     const ArrayOfArrayOfSpeciesTag& abs_species,
     const ArrayOfSpeciesTag& select_abs_species,
     const Numeric& extpolfac,
-    const Index& no_negative_from_lut,
+    const Index& no_negatives,
     const Verbosity& verbosity) {
   CREATE_OUT3;
 
@@ -2094,7 +2094,7 @@ void propmat_clearskyAddFromLookup(
                        extpolfac);
   }
 
-  if (no_negative_from_lut){
+  if (no_negatives){
     //Check for negative values due to interpolation and set them to zero
     for (Index ir = 0; ir < abs_scalar_gas.nrows(); ir++){
       for (Index ic = 0; ic < abs_scalar_gas.ncols(); ic++){

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -13961,10 +13961,12 @@ Possible models:
          "jacobian_quantities",
          "abs_species",
          "select_abs_species"),
-      GIN("extpolfac"),
-      GIN_TYPE("Numeric"),
-      GIN_DEFAULT("0.5"),
-      GIN_DESC("Extrapolation factor (for temperature and VMR grid edges).")));
+      GIN("extpolfac","no_negative_from_lut"),
+      GIN_TYPE("Numeric","Index"),
+      GIN_DEFAULT("0.5","1"),
+      GIN_DESC("Extrapolation factor (for temperature and VMR grid edges).",
+               "Boolean. If it is true negative values due to interpolation\n"
+               "are set to zero.")));
 
   md_data_raw.push_back(create_mdrecord(
       NAME("propmat_clearskyAddHitranLineMixingLines"),


### PR DESCRIPTION
Due to the high order interpolation within *propmat_clearskyAddFromLookup* negative values can occur from the cross sections from the XFIT-method though the cross sections of the lookup table are >= 0.  Therefore, I add an check and replace negative values with zero in *propmat_clearskyAddFromLookup*. With the "no_negative_from_lut" flag the check can be switched off. The default is set to True (1).