### PR TITLE
Rename .val to .value for Index+Numeric

### DIFF
--- a/python/test/workspace/test_groups.py
+++ b/python/test/workspace/test_groups.py
@@ -686,7 +686,7 @@ class TestGroups:
         assert not ws.atmosphere_dim.init
         x(ws)
         assert ws.atmosphere_dim.init
-        assert ws.atmosphere_dim.value.val == 3
+        assert ws.atmosphere_dim.value.value == 3
 
         return x
 
@@ -767,9 +767,9 @@ class TestGroups:
         x = cxx.Index(0)
         test.io(x, delete=True)
 
-        assert x.val == 0
-        x.val = x + 3
-        assert x.val == 3
+        assert x.value == 0
+        x.value = x + 3
+        assert x.value == 3
 
         return x
 
@@ -823,9 +823,9 @@ class TestGroups:
         x = cxx.Numeric(0)
         test.io(x, delete=True)
 
-        assert x.val == 0
-        x.val = x + 2
-        assert x.val == 2
+        assert x.value == 0
+        x.value = x + 2
+        assert x.value == 2
 
         return x
 

--- a/python/test/workspace/test_variables.py
+++ b/python/test/workspace/test_variables.py
@@ -43,7 +43,7 @@ class TestVariables:
         self.ws.IndexCreate("index_variable")
         i = np.random.randint(0, 100)
         self.ws.index_variable = i
-        assert self.ws.index_variable.value.val == i
+        assert self.ws.index_variable.value.value == i
 
     def test_string_transfer(self):
         """

--- a/src/python_interface/py_basic.cpp
+++ b/src/python_interface/py_basic.cpp
@@ -102,6 +102,8 @@ be accessed without copy using element-wise access operators)--");
       .PythonInterfaceWorkspaceVariableConversion(ArrayOfIndex)
       .PythonInterfaceBasicRepresentation(ArrayOfIndex)
       .PythonInterfaceArrayDefault(Index)
+      .PythonInterfaceValueOperators
+      .PythonInterfaceNumpyValueProperties
       .def_buffer([](ArrayOfIndex& x) -> py::buffer_info {
         return py::buffer_info(x.data(),
                                sizeof(Index),

--- a/src/python_interface/py_basic.cpp
+++ b/src/python_interface/py_basic.cpp
@@ -147,7 +147,7 @@ object's instances (i.e., no element-wise comparisions))--");
       .PythonInterfaceComparisonOperators(Numeric_, Numeric_)
       .PythonInterfaceMathOperators(Numeric_, Numeric_)
       .def_property(
-          "val",
+          "value",
           [](Numeric_& x) { return x.val; },
           [](Numeric_& x, Numeric y) { x.val = y; })
       .PythonInterfaceBasicRepresentation(Numeric_)
@@ -203,7 +203,7 @@ object's instances (i.e., no element-wise comparisions))--");
 
 This is a wrapper class for Arts Numeric.
 
-You can get copies and set the value by the "val" property)--");
+You can get copies and set the value by the "value" property)--");
 
   py::class_<Index_>(m, "Index")
       .def(py::init([]() { return new Index_{}; }))
@@ -216,7 +216,7 @@ You can get copies and set the value by the "val" property)--");
       .PythonInterfaceComparisonOperators(Index_, Index_)
       .PythonInterfaceMathOperators(Index_, Index_)
       .def_property(
-          "val",
+          "value",
           [](Index_& x) { return x.val; },
           [](Index_& x, Index y) { x.val = y; })
       .PythonInterfaceBasicRepresentation(Index_)
@@ -272,7 +272,7 @@ You can get copies and set the value by the "val" property)--");
 
 This is a wrapper class for Arts Index.
 
-You can get copies and set the value by the "val" property)--");
+You can get copies and set the value by the "value" property)--");
 
   py::implicitly_convertible<py::str, String>();
   py::implicitly_convertible<std::vector<py::str>, ArrayOfString>();

--- a/src/python_interface/py_basic.cpp
+++ b/src/python_interface/py_basic.cpp
@@ -151,7 +151,7 @@ object's instances (i.e., no element-wise comparisions))--");
       .def_property(
           "value",
           [](Numeric_& x) { return x.val; },
-          [](Numeric_& x, Numeric y) { x.val = y; })
+          [](Numeric_& x, Numeric_ y) { x.val = y.val; })
       .PythonInterfaceBasicRepresentation(Numeric_)
       .def(
           "savexml",
@@ -220,7 +220,7 @@ You can get copies and set the value by the "value" property)--");
       .def_property(
           "value",
           [](Index_& x) { return x.val; },
-          [](Index_& x, Index y) { x.val = y; })
+          [](Index_& x, Index_ y) { x.val = y.val; })
       .PythonInterfaceBasicRepresentation(Index_)
       .def(
           "savexml",

--- a/src/python_interface/py_macros.h
+++ b/src/python_interface/py_macros.h
@@ -582,13 +582,14 @@ Returns:\
       },                                                \
       py::is_operator())
 
+#define PythonInterfaceNumpyValueProperties \
+  PythonInterfaceSelfAttribute(ndim)        \
+      .PythonInterfaceSelfAttribute(shape)  \
+      .PythonInterfaceSelfAttribute(size)   \
+      .PythonInterfaceSelfAttribute(dtype)
+
 #define PythonInterfaceValueOperators                      \
-  PythonInterfaceSelfAttribute(ndim)                       \
-      .PythonInterfaceSelfAttribute(shape)                 \
-      .PythonInterfaceSelfAttribute(size)                  \
-      .PythonInterfaceSelfAttribute(dtype)                 \
-                                                           \
-      .PythonInterfaceSelfOperator(__len__)                \
+  PythonInterfaceSelfOperator(__len__)                     \
       .PythonInterfaceSelfOperator(__iter__)               \
       .PythonInterfaceSelfOperator(__pos__)                \
       .PythonInterfaceSelfOperator(__neg__)                \

--- a/src/python_interface/py_matpack.cpp
+++ b/src/python_interface/py_matpack.cpp
@@ -76,8 +76,9 @@ void py_matpack(py::module_& m) {
            py::arg("vec").none(false))
       .PythonInterfaceCopyValue(Vector)
       .PythonInterfaceWorkspaceVariableConversion(Vector)
-      .PythonInterfaceValueOperators.PythonInterfaceBasicRepresentation(Vector)
+      .PythonInterfaceBasicRepresentation(Vector)
       .PythonInterfaceFileIO(Vector)
+      .PythonInterfaceValueOperators.PythonInterfaceNumpyValueProperties
       .def_buffer([](Vector& x) -> py::buffer_info {
         return py::buffer_info(x.get_c_array(),
                                sizeof(Numeric),
@@ -128,11 +129,7 @@ via x.value)--");
       .PythonInterfaceWorkspaceVariableConversion(Matrix)
       .PythonInterfaceBasicRepresentation(Matrix)
       .PythonInterfaceFileIO(Matrix)
-      .PythonInterfaceValueOperators
-      .def_property_readonly(
-          "T",
-          [](const Matrix& x) { return Matrix(transpose(x)); },
-          "Non-trivial transpose")
+      .PythonInterfaceValueOperators.PythonInterfaceNumpyValueProperties
       .def_buffer([](Matrix& x) -> py::buffer_info {
         return py::buffer_info(
             x.get_c_array(),
@@ -143,6 +140,10 @@ via x.value)--");
             {sizeof(Numeric) * static_cast<ssize_t>(x.ncols()),
              sizeof(Numeric)});
       })
+      .def_property_readonly(
+          "T",
+          [](const Matrix& x) { return Matrix(transpose(x)); },
+          "Non-trivial transpose")
       .def_property("value",
                     py::cpp_function(
                         [](Matrix& x) {
@@ -189,7 +190,7 @@ via x.value)--");
       .PythonInterfaceWorkspaceVariableConversion(Tensor3)
       .PythonInterfaceBasicRepresentation(Tensor3)
       .PythonInterfaceFileIO(Tensor3)
-      .PythonInterfaceValueOperators
+      .PythonInterfaceValueOperators.PythonInterfaceNumpyValueProperties
       .def_buffer([](Tensor3& x) -> py::buffer_info {
         return py::buffer_info(
             x.get_c_array(),
@@ -253,7 +254,7 @@ via x.value)--");
       .PythonInterfaceWorkspaceVariableConversion(Tensor4)
       .PythonInterfaceBasicRepresentation(Tensor4)
       .PythonInterfaceFileIO(Tensor4)
-      .PythonInterfaceValueOperators
+      .PythonInterfaceValueOperators.PythonInterfaceNumpyValueProperties
       .def_buffer([](Tensor4& x) -> py::buffer_info {
         return py::buffer_info(
             x.get_c_array(),
@@ -323,7 +324,7 @@ via x.value)--");
       .PythonInterfaceWorkspaceVariableConversion(Tensor5)
       .PythonInterfaceBasicRepresentation(Tensor5)
       .PythonInterfaceFileIO(Tensor5)
-      .PythonInterfaceValueOperators
+      .PythonInterfaceValueOperators.PythonInterfaceNumpyValueProperties
       .def_buffer([](Tensor5& x) -> py::buffer_info {
         return py::buffer_info(
             x.get_c_array(),
@@ -400,7 +401,7 @@ via x.value)--");
       .PythonInterfaceWorkspaceVariableConversion(Tensor6)
       .PythonInterfaceBasicRepresentation(Tensor6)
       .PythonInterfaceFileIO(Tensor6)
-      .PythonInterfaceValueOperators
+      .PythonInterfaceValueOperators.PythonInterfaceNumpyValueProperties
       .def_buffer([](Tensor6& x) -> py::buffer_info {
         return py::buffer_info(
             x.get_c_array(),
@@ -485,8 +486,9 @@ via x.value)--");
            py::arg("ten7").none(false))
       .PythonInterfaceCopyValue(Tensor7)
       .PythonInterfaceWorkspaceVariableConversion(Tensor7)
+      .PythonInterfaceBasicRepresentation(Tensor7)
       .PythonInterfaceFileIO(Tensor7)
-      .PythonInterfaceValueOperators.PythonInterfaceBasicRepresentation(Tensor7)
+      .PythonInterfaceValueOperators.PythonInterfaceNumpyValueProperties
       .def_buffer([](Tensor7& x) -> py::buffer_info {
         return py::buffer_info(
             x.get_c_array(),

--- a/src/python_interface/py_rte.cpp
+++ b/src/python_interface/py_rte.cpp
@@ -53,7 +53,7 @@ void py_rte(py::module_& m) {
                         },
                         py::keep_alive<0, 1>()),
                     [](TransmissionMatrix& x, TransmissionMatrix& y) { x = y; })
-      .PythonInterfaceValueOperators
+      .PythonInterfaceValueOperators.PythonInterfaceNumpyValueProperties
       .def(py::pickle(
           [](const TransmissionMatrix& self) {
             return py::make_tuple(
@@ -110,7 +110,7 @@ void py_rte(py::module_& m) {
                         },
                         py::keep_alive<0, 1>()),
                     [](RadiationVector& x, RadiationVector& y) { x = y; })
-      .PythonInterfaceValueOperators
+      .PythonInterfaceValueOperators.PythonInterfaceNumpyValueProperties
       .def(py::pickle(
           [](const RadiationVector& self) {
             return py::make_tuple(


### PR DESCRIPTION
Makes property for Index and Numeric types consistent with the other ARTS types.