### PR TITLE
Add ARTS_PYTHON_INTERPRETER cmake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,8 @@ find_package (Python3 REQUIRED COMPONENTS Interpreter Development.Module)
 include (CheckPythonModule)
 check_python_modules()
 
+set(ARTS_PYTHON_INTERPRETER "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/python" ${Python3_EXECUTABLE})
+
 if (ENABLE_FORTRAN)
   enable_language (Fortran)
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -48,7 +48,7 @@ add_custom_target(pyarts
   COMMENT "Building ARTS python package.")
 set(CONTROLFILE_DIR ${ARTS_SOURCE_DIR}/controlfiles)
 add_custom_target(python_tests
-  COMMAND PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR} ${Python3_EXECUTABLE} bin/arts_convert.py ${CONTROLFILE_DIR} -o controlfiles
+  COMMAND ${ARTS_PYTHON_INTERPRETER} bin/arts_convert.py ${CONTROLFILE_DIR} -o controlfiles
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS pyarts_tests
   COMMENT "Converting *.arts controlfiles to Python")

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -52,11 +52,6 @@ add_custom_target(python_tests
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS pyarts_tests
   COMMENT "Converting *.arts controlfiles to Python")
-add_custom_target(pyarts_agendatest
-  COMMAND ${Python3_EXECUTABLE} -m test.workspace.test_agendas
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS pyarts
-  COMMENT "Run PyARTS Agenda test")
 
 add_custom_target(pyarts_tests
   COMMAND ${Python3_EXECUTABLE} -m pytest -v test

--- a/python/doc/CMakeLists.txt
+++ b/python/doc/CMakeLists.txt
@@ -33,7 +33,13 @@ if (SPHINX_FOUND)
   configure_file(build/.nojekyll build/.nojekyll @ONLY)
   
   add_custom_target(gen_pyarts_arts_rst
-  COMMAND PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/.. ${Python3_EXECUTABLE} gen_pyarts_arts_rst.py > ${CMAKE_CURRENT_BINARY_DIR}/source/pyarts_arts.rst
+    COMMAND ${ARTS_PYTHON_INTERPRETER} gen_pyarts_arts_rst.py > ${CMAKE_CURRENT_BINARY_DIR}/source/pyarts_arts.rst
   )
   add_dependencies (gen_pyarts_arts_rst pyarts)
+
+  #
+  # Clean
+  #
+  set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
+    build source/pyarts_arts.rst)
 endif()


### PR DESCRIPTION
Use this to run Python scripts that import pyarts during the build process to ensure pyarts is correctly imported from the build directory.