### PR TITLE
Set O0 for methods.cc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -388,6 +388,7 @@ add_library (methods STATIC
         wsv_aux.cc
         )
 
+set_source_files_properties (methods.cc PROPERTIES COMPILE_FLAGS "-O0")
 target_link_libraries(methods PUBLIC predef species)
 
 ########### next target ###############


### PR DESCRIPTION
Temporary workaround to avoid memory issues during compilation.