### PR TITLE
Make docserver accessible from PyARTS

### DIFF
--- a/src/docserver.cc
+++ b/src/docserver.cc
@@ -2058,4 +2058,20 @@ static int ahc_echo(void* cls,
   return ret;
 }
 
+void run_docserver(Index port, const String& baseurl, bool daemon) {
+  if (daemon) {
+    int pid = fork();
+    if (!pid) {
+      Docserver docserver(port, baseurl);
+      docserver.launch(daemon);
+    } else {
+      std::cout << "Docserver daemon started with PID: " << pid << endl;
+    }
+  } else {
+    Docserver docserver(port, baseurl);
+    std::cout << "Starting the arts documentation server." << endl;
+    docserver.launch(daemon);
+  }
+}
+
 #endif /* ENABLE_DOCSERVER */

--- a/src/docserver.h
+++ b/src/docserver.h
@@ -105,6 +105,10 @@ class Docserver {
   int launch(bool daemon);
 };
 
+void run_docserver(Index port = 9000,
+                   const String& baseurl = "",
+                   bool daemon = false);
+
 #endif /* ENABLE_DOCSERVER */
 
 #endif /* docserver_h */

--- a/src/main.cc
+++ b/src/main.cc
@@ -884,22 +884,8 @@ int main(int argc, char** argv) {
 
 #ifdef ENABLE_DOCSERVER
   if (0 != parameters.docserver) {
-    if (parameters.daemon) {
-      int pid = fork();
-      if (!pid) {
-        Docserver docserver(parameters.docserver, parameters.baseurl);
-        docserver.launch(parameters.daemon);
-        arts_exit(0);
-      } else {
-        cout << "Docserver daemon started with PID: " << pid << endl;
-        arts_exit(0);
-      }
-    } else {
-      Docserver docserver(parameters.docserver, parameters.baseurl);
-      cout << "Starting the arts documentation server." << endl;
-      docserver.launch(parameters.daemon);
-      arts_exit(0);
-    }
+    run_docserver(parameters.docserver, parameters.baseurl, parameters.daemon);
+    arts_exit(0);
   }
 #endif
 

--- a/src/python_interface/CMakeLists.txt
+++ b/src/python_interface/CMakeLists.txt
@@ -71,6 +71,7 @@ pybind11_add_module(pyarts_cpp
     py_module.cpp
     py_matpack.cpp
     py_basic.cpp
+    py_docserver.cpp
     py_ppath.cpp
     py_griddedfield.cpp
     py_time.cpp

--- a/src/python_interface/py_docserver.cpp
+++ b/src/python_interface/py_docserver.cpp
@@ -1,0 +1,31 @@
+#include <docserver.h>
+#include <pybind11/pybind11.h>
+
+namespace Python {
+namespace py = pybind11;
+
+void py_docserver(py::module_& m) {
+  auto docserver = m.def_submodule("docserver");
+  docserver.doc() = R"--(Run the ARTS documentation server)--";
+  docserver.def("run",
+                &run_docserver,
+                py::arg("port") = 9000,
+                py::arg("baseurl") = "",
+                py::arg("daemon") = false,
+                R"--(Run the ARTS documentation server
+
+The ARTS documentation server provides a web interface to the ARTS
+documentation. It can be used to browse the documentation of variables,
+methods and agendas.
+
+By default, the server is started on port 9000 and is accessible via a
+web browser at `http://localhost:9000`.
+
+Parameters:
+    port (int): Port to run the server on
+    baseurl (str): Base URL to use for the server
+    daemon (bool): Run the server as a daemon
+)--");
+}
+}  // namespace Python
+

--- a/src/python_interface/py_module.cpp
+++ b/src/python_interface/py_module.cpp
@@ -13,6 +13,7 @@ namespace Python {
 namespace py = pybind11;
 
 void py_basic(py::module_&);
+void py_docserver(py::module_&);
 void py_matpack(py::module_&);
 void py_ppath(py::module_&);
 void py_griddedfield(py::module_&);
@@ -105,6 +106,7 @@ PYBIND11_MODULE(arts, m) {
   }
 
   py_basic(m);
+  py_docserver(m);
   py_matpack(m);
   py_griddedfield(m);
   py_time(m);


### PR DESCRIPTION
Use `pyarts.arts.docserver.run()` to launch the docserver from pyarts.