### PR TITLE
Some more compatibility for swap and destructors

### DIFF
--- a/src/agenda_record.cc
+++ b/src/agenda_record.cc
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <map>
 
+#include "debug.h"
 #include "groups.h"
 #include "messages.h"
 #include "workspace_ng.h"
@@ -120,9 +121,8 @@ bool check_agenda_data() {
   using global_data::agenda_data;
   DEBUG_ONLY(using global_data::AgendaMap);
 
-  Index i, j, k;
-
-  k = 0;
+  Index i, j;
+  DEBUG_ONLY(Index k=0;)
 
   // Check, that each agenda from agenda_data occurs in wsv_data:
   for (i = 0; i < agenda_data.nelem(); ++i) {
@@ -158,7 +158,7 @@ bool check_agenda_data() {
       ARTS_ASSERT(AgendaMap.end() != AgendaMap.find(global_data::wsv_data[j].Name()));
 
       // Counts the number of agenda WSVs in Workspace::wsv_data:
-      ++k;
+      DEBUG_ONLY(++k;)
     }
   }
 

--- a/src/doit.cc
+++ b/src/doit.cc
@@ -1425,7 +1425,7 @@ void cloud_RT_no_background(Workspace& ws,
   for (Index k = ppath_step.np - 1; k >= 0; k--) {
     // Save propmat_clearsky from previous level by
     // swapping it with current level
-    std::swap(cur_propmat_clearsky, prev_propmat_clearsky);
+    swap(cur_propmat_clearsky, prev_propmat_clearsky);
 
     //
     // Calculate scalar gas absorption

--- a/src/make_tokval.cc
+++ b/src/make_tokval.cc
@@ -98,7 +98,7 @@ public:
   TokVal& operator=(TokVal&& t) noexcept {using std::swap; swap(ptr, t.ptr); return*this;}
   TokVal(TokVal&& t) noexcept : ptr(nullptr) {using std::swap; swap(ptr, t.ptr);}
 
-  ~TokVal();
+  ~TokVal() noexcept;
 
   [[nodiscard]] std::shared_ptr<void> copy_value() const;
 
@@ -125,7 +125,7 @@ using TokValType = std::variant<
 
   file_var_h << R"--(>;
 
-inline TokValType* tokval_type(void * ptr) {
+inline TokValType* tokval_type(void * ptr) noexcept {
   return static_cast<TokValType*>(ptr);
 }
 )--";
@@ -188,7 +188,7 @@ TokVal::TokVal() : TokVal(Any{}) {}
 TokVal::TokVal(const TokVal& v) : TokVal(Any{}) { std::visit([&](auto&& in) {*this = *in;}, *tokval_type(v.ptr)); }
 TokVal& TokVal::operator=(const TokVal& v) {std::visit([&](auto&& in) {*this = *in;}, *tokval_type(v.ptr)); return *this; }
 
-TokVal::~TokVal() {delete tokval_type(ptr);}
+TokVal::~TokVal() noexcept {delete tokval_type(ptr);}
 
 std::shared_ptr<void> TokVal::copy_value() const {
   return std::visit(

--- a/src/make_tokval.cc
+++ b/src/make_tokval.cc
@@ -188,7 +188,7 @@ TokVal::TokVal() : TokVal(Any{}) {}
 TokVal::TokVal(const TokVal& v) : TokVal(Any{}) { std::visit([&](auto&& in) {*this = *in;}, *tokval_type(v.ptr)); }
 TokVal& TokVal::operator=(const TokVal& v) {std::visit([&](auto&& in) {*this = *in;}, *tokval_type(v.ptr)); return *this; }
 
-TokVal::~TokVal() noexcept {delete tokval_type(ptr);}
+TokVal::~TokVal() noexcept {delete tokval_type(ptr); ptr=nullptr;}
 
 std::shared_ptr<void> TokVal::copy_value() const {
   return std::visit(

--- a/src/make_tokval.cc
+++ b/src/make_tokval.cc
@@ -95,8 +95,8 @@ public:
   TokVal(const TokVal& v);
   TokVal& operator=(const TokVal& v);
   [[nodiscard]] std::string_view type() const;
-  TokVal& operator=(TokVal&& t) {swap(ptr, t.ptr); return*this;}
-  TokVal(TokVal&& t) : ptr(nullptr) {swap(ptr, t.ptr);}
+  TokVal& operator=(TokVal&& t) noexcept {using std::swap; swap(ptr, t.ptr); return*this;}
+  TokVal(TokVal&& t) noexcept : ptr(nullptr) {using std::swap; swap(ptr, t.ptr);}
 
   ~TokVal();
 

--- a/src/matpack.h
+++ b/src/matpack.h
@@ -30,12 +30,12 @@
 /** The type to use for all floating point numbers. You should never
     use float or double explicitly, unless you have a very good
     reason. Always use this type instead.  */
-typedef NUMERIC Numeric;
+using Numeric = NUMERIC;
 
 //--------------------< Set integer type >--------------------
 /** The type to use for all integer numbers and indices. You should never
     use int, long, or size_t explicitly, unless you have a very good
     reason. Always use this type instead.  */
-typedef INDEX Index;
+using Index = INDEX;
 
 #endif  // matpackI_h

--- a/src/matpackI.cc
+++ b/src/matpackI.cc
@@ -61,13 +61,13 @@ ConstVectorView ConstVectorView::operator[](const Range& r) const
 }
 
 ConstIterator1D ConstVectorView::begin() const ARTS_NOEXCEPT {
-  return ConstIterator1D(mdata + mrange.mstart, mrange.mstride);
+  return {mdata + mrange.mstart, mrange.mstride};
 }
 
 ConstIterator1D ConstVectorView::end() const ARTS_NOEXCEPT {
-  return ConstIterator1D(
+  return {
       mdata + mrange.mstart + (mrange.mextent) * mrange.mstride,
-      mrange.mstride);
+      mrange.mstride};
 }
 
 ConstVectorView::operator ConstMatrixView() const {
@@ -142,12 +142,12 @@ VectorView VectorView::operator[](const Range& r) ARTS_NOEXCEPT {
 }
 
 Iterator1D VectorView::begin() ARTS_NOEXCEPT {
-  return Iterator1D(mdata + mrange.mstart, mrange.mstride);
+  return {mdata + mrange.mstart, mrange.mstride};
 }
 
 Iterator1D VectorView::end() ARTS_NOEXCEPT {
-  return Iterator1D(mdata + mrange.mstart + (mrange.mextent) * mrange.mstride,
-                    mrange.mstride);
+  return {mdata + mrange.mstart + (mrange.mextent) * mrange.mstride,
+                    mrange.mstride};
 }
 
 VectorView& VectorView::operator=(const ConstVectorView& v) {
@@ -343,9 +343,9 @@ Vector::Vector(const Vector& v)
 
 Vector::Vector(const std::vector<Numeric>& v)
     : VectorView(new Numeric[v.size()], Range(0, v.size())) {
-  std::vector<Numeric>::const_iterator vec_it_end = v.end();
+  auto vec_it_end = v.end();
   Iterator1D this_it = this->begin();
-  for (std::vector<Numeric>::const_iterator vec_it = v.begin();
+  for (auto vec_it = v.begin();
        vec_it != vec_it_end;
        ++vec_it, ++this_it)
     *this_it = *vec_it;
@@ -447,14 +447,14 @@ ConstVectorView ConstMatrixView::operator()(Index r, const Range& c) const
 
 /** Return const iterator to first row. */
 ConstIterator2D ConstMatrixView::begin() const ARTS_NOEXCEPT {
-  return ConstIterator2D(ConstVectorView(mdata + mrr.mstart, mcr), mrr.mstride);
+  return {ConstVectorView(mdata + mrr.mstart, mcr), mrr.mstride};
 }
 
 /** Return const iterator behind last row. */
 ConstIterator2D ConstMatrixView::end() const ARTS_NOEXCEPT {
-  return ConstIterator2D(
+  return {
       ConstVectorView(mdata + mrr.mstart + (mrr.mextent) * mrr.mstride, mcr),
-      mrr.mstride);
+      mrr.mstride};
 }
 
 //! Matrix diagonal as vector.
@@ -1618,8 +1618,8 @@ VectorView& VectorView::operator=(const Array<Numeric>& v) {
   ARTS_ASSERT(mrange.mextent == v.nelem());
 
   // Iterators for Array:
-  Array<Numeric>::const_iterator i = v.begin();
-  const Array<Numeric>::const_iterator e = v.end();
+  auto i = v.begin();
+  const auto e = v.end();
   // Iterator for Vector:
   Iterator1D target = begin();
 

--- a/src/matpackI.cc
+++ b/src/matpackI.cc
@@ -398,9 +398,10 @@ void Vector::resize(Index n) {
   }
 }
 
-void swap(Vector& v1, Vector& v2) {
-  std::swap(v1.mrange, v2.mrange);
-  std::swap(v1.mdata, v2.mdata);
+void swap(Vector& v1, Vector& v2) noexcept {
+  using std::swap;
+  swap(v1.mrange, v2.mrange);
+  swap(v1.mdata, v2.mdata);
 }
 
 Vector::~Vector() { delete[] mdata; }
@@ -1026,10 +1027,11 @@ void Matrix::resize(Index r, Index c) {
 }
 
 /** Swaps two objects. */
-void swap(Matrix& m1, Matrix& m2) {
-  std::swap(m1.mrr, m2.mrr);
-  std::swap(m1.mcr, m2.mcr);
-  std::swap(m1.mdata, m2.mdata);
+void swap(Matrix& m1, Matrix& m2) noexcept {
+  using std::swap;
+  swap(m1.mrr, m2.mrr);
+  swap(m1.mcr, m2.mcr);
+  swap(m1.mdata, m2.mdata);
 }
 
 /** Destructor for Matrix. This is important, since Matrix uses new to

--- a/src/matpackI.cc
+++ b/src/matpackI.cc
@@ -404,7 +404,7 @@ void swap(Vector& v1, Vector& v2) noexcept {
   swap(v1.mdata, v2.mdata);
 }
 
-Vector::~Vector() { delete[] mdata; }
+Vector::~Vector() noexcept { delete[] mdata; }
 
 // Functions for ConstMatrixView:
 // ------------------------------
@@ -1036,7 +1036,7 @@ void swap(Matrix& m1, Matrix& m2) noexcept {
 
 /** Destructor for Matrix. This is important, since Matrix uses new to
     allocate storage. */
-Matrix::~Matrix() {
+Matrix::~Matrix() noexcept {
   //   cout << "Destroying a Matrix:\n"
   //        << *this << "\n........................................\n";
   delete[] mdata;

--- a/src/matpackI.h
+++ b/src/matpackI.h
@@ -284,7 +284,7 @@ class Range {
       ARTS_ASSERT(fin <= prev_fin);
 #endif
     }
-  };
+  }
 
   // Friends:
   friend class ConstVectorView;
@@ -361,6 +361,15 @@ class Range {
   };
 
   friend std::ostream& operator<<(std::ostream& os, const Range& r);
+
+  constexpr void swap(Range& other) noexcept {
+    using std::swap;
+    swap(mstart, other.mstart);
+    swap(mextent, other.mextent);
+    swap(mstride, other.mstride);
+  }
+
+  friend constexpr void swap(Range& a, Range& b) noexcept { a.swap(b); }
 
  private:
   /** The start index. */
@@ -1022,7 +1031,7 @@ class Vector : public VectorView {
   void resize(Index n);
 
   /** Swaps two objects. */
-  friend void swap(Vector& v1, Vector& v2);
+  friend void swap(Vector& v1, Vector& v2) noexcept;
 
   /** Destructor for Vector. This is important, since Vector uses new to
     allocate storage. */
@@ -1316,7 +1325,7 @@ class Matrix : public MatrixView {
   void resize(Index r, Index c);
 
   // Swap function:
-  friend void swap(Matrix& m1, Matrix& m2);
+  friend void swap(Matrix& m1, Matrix& m2) noexcept;
 
   // Destructor:
   virtual ~Matrix();

--- a/src/matpackI.h
+++ b/src/matpackI.h
@@ -96,6 +96,7 @@
 #define matpackI_h
 
 #include <algorithm>
+#include <utility>
 
 #include "array.h"
 #include "matpack.h"
@@ -769,7 +770,7 @@ class VectorView : public ConstVectorView {
   operator MatrixView() ARTS_NOEXCEPT;
 
   //! Destructor
-  virtual ~VectorView() = default;
+  ~VectorView() override = default;
 
   // Friends:
   friend class ConstIterator2D;
@@ -861,8 +862,8 @@ class ConstIterator2D {
   ConstIterator2D() = default;
 
   /** Explicit constructor. */
-  ConstIterator2D(const ConstVectorView& x, Index stride) ARTS_NOEXCEPT
-      : msv(x),
+  ConstIterator2D(ConstVectorView x, Index stride) ARTS_NOEXCEPT
+      : msv(std::move(x)),
         mstride(stride) { /* Nothing to do here. */
   }
 
@@ -1035,7 +1036,7 @@ class Vector : public VectorView {
 
   /** Destructor for Vector. This is important, since Vector uses new to
     allocate storage. */
-  virtual ~Vector() noexcept;
+  ~Vector() noexcept override;
 
   template <class F>
   void transform_elementwise(F&& func) {
@@ -1240,7 +1241,7 @@ class MatrixView : public ConstMatrixView {
   MatrixView& operator-=(const ConstVectorView& x) ARTS_NOEXCEPT;
 
   //! Destructor
-  virtual ~MatrixView() = default;
+  ~MatrixView() override = default;
 
   // Friends:
   friend class VectorView;
@@ -1328,7 +1329,7 @@ class Matrix : public MatrixView {
   friend void swap(Matrix& m1, Matrix& m2) noexcept;
 
   // Destructor:
-  virtual ~Matrix() noexcept;
+  ~Matrix() noexcept override;
 
   /*! Reduce a Matrix to a Vector and leave this in an empty state */
   template <std::size_t dim0>

--- a/src/matpackI.h
+++ b/src/matpackI.h
@@ -1035,7 +1035,7 @@ class Vector : public VectorView {
 
   /** Destructor for Vector. This is important, since Vector uses new to
     allocate storage. */
-  virtual ~Vector();
+  virtual ~Vector() noexcept;
 
   template <class F>
   void transform_elementwise(F&& func) {
@@ -1328,7 +1328,7 @@ class Matrix : public MatrixView {
   friend void swap(Matrix& m1, Matrix& m2) noexcept;
 
   // Destructor:
-  virtual ~Matrix();
+  virtual ~Matrix() noexcept;
 
   /*! Reduce a Matrix to a Vector and leave this in an empty state */
   template <std::size_t dim0>

--- a/src/matpackIII.cc
+++ b/src/matpackIII.cc
@@ -692,7 +692,7 @@ void swap(Tensor3& t1, Tensor3& t2) noexcept {
 
 /** Destructor for Tensor3. This is important, since Tensor3 uses new to
     allocate storage. */
-Tensor3::~Tensor3() {
+Tensor3::~Tensor3() noexcept {
   //   cout << "Destroying a Tensor3:\n"
   //        << *this << "\n........................................\n";
   delete[] mdata;

--- a/src/matpackIII.cc
+++ b/src/matpackIII.cc
@@ -682,11 +682,12 @@ void Tensor3::resize(Index p, Index r, Index c) {
 }
 
 /** Swaps two objects. */
-void swap(Tensor3& t1, Tensor3& t2) {
-  std::swap(t1.mpr, t2.mpr);
-  std::swap(t1.mrr, t2.mrr);
-  std::swap(t1.mcr, t2.mcr);
-  std::swap(t1.mdata, t2.mdata);
+void swap(Tensor3& t1, Tensor3& t2) noexcept {
+  using std::swap;
+  swap(t1.mpr, t2.mpr);
+  swap(t1.mrr, t2.mrr);
+  swap(t1.mcr, t2.mcr);
+  swap(t1.mdata, t2.mdata);
 }
 
 /** Destructor for Tensor3. This is important, since Tensor3 uses new to

--- a/src/matpackIII.h
+++ b/src/matpackIII.h
@@ -27,6 +27,8 @@
 #ifndef matpackIII_h
 #define matpackIII_h
 
+#include <utility>
+
 #include "matpackI.h"
 
 /** The outermost iterator class for rank 3 tensors. This takes into
@@ -79,8 +81,8 @@ class ConstIterator3D {
   ConstIterator3D() = default;
 
   /** Explicit constructor. */
-  ConstIterator3D(const ConstMatrixView& x, Index stride)
-      : msv(x), mstride(stride) { /* Nothing to do here. */
+  ConstIterator3D(ConstMatrixView x, Index stride)
+      : msv(std::move(x)), mstride(stride) { /* Nothing to do here. */
   }
 
   // Operators:
@@ -310,7 +312,7 @@ class Tensor3View : public ConstTensor3View {
   Tensor3View& operator-=(const ConstTensor3View& x);
 
   //! Destructor
-  virtual ~Tensor3View() = default;
+  ~Tensor3View() override = default;
 
   // Friends:
   friend class Iterator4D;
@@ -384,7 +386,7 @@ class Tensor3 : public Tensor3View {
   friend void swap(Tensor3& t1, Tensor3& t2) noexcept;
 
   // Destructor:
-  virtual ~Tensor3() noexcept;
+  ~Tensor3() noexcept override;
 
   /*! Reduce a Tensor3 to a Vector and leave this in an empty state */
   template <std::size_t dim0>

--- a/src/matpackIII.h
+++ b/src/matpackIII.h
@@ -384,7 +384,7 @@ class Tensor3 : public Tensor3View {
   friend void swap(Tensor3& t1, Tensor3& t2) noexcept;
 
   // Destructor:
-  virtual ~Tensor3();
+  virtual ~Tensor3() noexcept;
 
   /*! Reduce a Tensor3 to a Vector and leave this in an empty state */
   template <std::size_t dim0>

--- a/src/matpackIII.h
+++ b/src/matpackIII.h
@@ -381,7 +381,7 @@ class Tensor3 : public Tensor3View {
   void resize(Index p, Index r, Index c);
 
   // Swap function:
-  friend void swap(Tensor3& t1, Tensor3& t2);
+  friend void swap(Tensor3& t1, Tensor3& t2) noexcept;
 
   // Destructor:
   virtual ~Tensor3();

--- a/src/matpackIV.cc
+++ b/src/matpackIV.cc
@@ -1092,7 +1092,7 @@ void swap(Tensor4& t1, Tensor4& t2) noexcept {
 
 /** Destructor for Tensor4. This is important, since Tensor4 uses new to
     allocate storage. */
-Tensor4::~Tensor4() {
+Tensor4::~Tensor4() noexcept {
   //   cout << "Destroying a Tensor4:\n"
   //        << *this << "\n........................................\n";
   delete[] mdata;

--- a/src/matpackIV.cc
+++ b/src/matpackIV.cc
@@ -1081,12 +1081,13 @@ void Tensor4::resize(Index b, Index p, Index r, Index c) {
 }
 
 /** Swaps two objects. */
-void swap(Tensor4& t1, Tensor4& t2) {
-  std::swap(t1.mbr, t2.mbr);
-  std::swap(t1.mpr, t2.mpr);
-  std::swap(t1.mrr, t2.mrr);
-  std::swap(t1.mcr, t2.mcr);
-  std::swap(t1.mdata, t2.mdata);
+void swap(Tensor4& t1, Tensor4& t2) noexcept {
+  using std::swap;
+  swap(t1.mbr, t2.mbr);
+  swap(t1.mpr, t2.mpr);
+  swap(t1.mrr, t2.mrr);
+  swap(t1.mcr, t2.mcr);
+  swap(t1.mdata, t2.mdata);
 }
 
 /** Destructor for Tensor4. This is important, since Tensor4 uses new to

--- a/src/matpackIV.h
+++ b/src/matpackIV.h
@@ -31,6 +31,8 @@
 #ifndef matpackIV_h
 #define matpackIV_h
 
+#include <utility>
+
 #include "matpackIII.h"
 
 /** The outermost iterator class for rank 4 tensors. This takes into
@@ -83,8 +85,8 @@ class ConstIterator4D {
   ConstIterator4D() = default;
 
   /** Explicit constructor. */
-  ConstIterator4D(const ConstTensor3View& x, Index stride)
-      : msv(x), mstride(stride) { /* Nothing to do here. */
+  ConstIterator4D(ConstTensor3View x, Index stride)
+      : msv(std::move(x)), mstride(stride) { /* Nothing to do here. */
   }
 
   // Operators:
@@ -385,7 +387,7 @@ class Tensor4View : public ConstTensor4View {
   Tensor4View& operator-=(const ConstTensor4View& x);
 
   //! Destructor
-  virtual ~Tensor4View() = default;
+  ~Tensor4View() override = default;
 
   // Friends:
   // friend class VectorView;
@@ -472,7 +474,7 @@ class Tensor4 : public Tensor4View {
   friend void swap(Tensor4& t1, Tensor4& t2) noexcept;
 
   // Destructor:
-  virtual ~Tensor4() noexcept;
+  ~Tensor4() noexcept override;
   
   // Returns data as a Vector
   Vector flatten() && ARTS_NOEXCEPT;

--- a/src/matpackIV.h
+++ b/src/matpackIV.h
@@ -472,7 +472,7 @@ class Tensor4 : public Tensor4View {
   friend void swap(Tensor4& t1, Tensor4& t2) noexcept;
 
   // Destructor:
-  virtual ~Tensor4();
+  virtual ~Tensor4() noexcept;
   
   // Returns data as a Vector
   Vector flatten() && ARTS_NOEXCEPT;

--- a/src/matpackIV.h
+++ b/src/matpackIV.h
@@ -469,7 +469,7 @@ class Tensor4 : public Tensor4View {
   void resize(Index b, Index p, Index r, Index c);
 
   // Swap function:
-  friend void swap(Tensor4& t1, Tensor4& t2);
+  friend void swap(Tensor4& t1, Tensor4& t2) noexcept;
 
   // Destructor:
   virtual ~Tensor4();

--- a/src/matpackV.cc
+++ b/src/matpackV.cc
@@ -1773,13 +1773,14 @@ void Tensor5::resize(Index s, Index b, Index p, Index r, Index c) {
 }
 
 /** Swaps two objects. */
-void swap(Tensor5& t1, Tensor5& t2) {
-  std::swap(t1.msr, t2.msr);
-  std::swap(t1.mbr, t2.mbr);
-  std::swap(t1.mpr, t2.mpr);
-  std::swap(t1.mrr, t2.mrr);
-  std::swap(t1.mcr, t2.mcr);
-  std::swap(t1.mdata, t2.mdata);
+void swap(Tensor5& t1, Tensor5& t2) noexcept {
+  using std::swap;
+  swap(t1.msr, t2.msr);
+  swap(t1.mbr, t2.mbr);
+  swap(t1.mpr, t2.mpr);
+  swap(t1.mrr, t2.mrr);
+  swap(t1.mcr, t2.mcr);
+  swap(t1.mdata, t2.mdata);
 }
 
 /** Destructor for Tensor5. This is important, since Tensor5 uses new to

--- a/src/matpackV.cc
+++ b/src/matpackV.cc
@@ -1785,7 +1785,7 @@ void swap(Tensor5& t1, Tensor5& t2) noexcept {
 
 /** Destructor for Tensor5. This is important, since Tensor5 uses new to
     allocate storage. */
-Tensor5::~Tensor5() {
+Tensor5::~Tensor5() noexcept {
   //   cout << "Destroying a Tensor5:\n"
   //        << *this << "\n........................................\n";
   delete[] mdata;

--- a/src/matpackV.h
+++ b/src/matpackV.h
@@ -559,7 +559,7 @@ class Tensor5 : public Tensor5View {
   void resize(Index s, Index b, Index p, Index r, Index c);
 
   // Swap function:
-  friend void swap(Tensor5& t1, Tensor5& t2);
+  friend void swap(Tensor5& t1, Tensor5& t2) noexcept;
 
   // Destructor:
   virtual ~Tensor5();

--- a/src/matpackV.h
+++ b/src/matpackV.h
@@ -31,6 +31,8 @@
 #ifndef matpackV_h
 #define matpackV_h
 
+#include <utility>
+
 #include "matpackIV.h"
 
 /** The outermost iterator class for rank 5 tensors. This takes into
@@ -88,8 +90,8 @@ class ConstIterator5D {
   ConstIterator5D() = default;
 
   /** Explicit constructor. */
-  ConstIterator5D(const ConstTensor4View& x, Index stride)
-      : msv(x), mstride(stride) { /* Nothing to do here. */
+  ConstIterator5D(ConstTensor4View x, Index stride)
+      : msv(std::move(x)), mstride(stride) { /* Nothing to do here. */
   }
 
   // Operators:
@@ -470,7 +472,7 @@ class Tensor5View : public ConstTensor5View {
   Tensor5View& operator-=(const ConstTensor5View& x);
 
   //! Destructor
-  virtual ~Tensor5View() = default;
+  ~Tensor5View() override = default;
 
   // Friends:
   // friend class VectorView;
@@ -562,7 +564,7 @@ class Tensor5 : public Tensor5View {
   friend void swap(Tensor5& t1, Tensor5& t2) noexcept;
 
   // Destructor:
-  virtual ~Tensor5() noexcept;
+  ~Tensor5() noexcept override;
 
   /*! Reduce a Tensor5 to a Vector and leave this in an empty state */
   template <std::size_t dim0>

--- a/src/matpackV.h
+++ b/src/matpackV.h
@@ -562,7 +562,7 @@ class Tensor5 : public Tensor5View {
   friend void swap(Tensor5& t1, Tensor5& t2) noexcept;
 
   // Destructor:
-  virtual ~Tensor5();
+  virtual ~Tensor5() noexcept;
 
   /*! Reduce a Tensor5 to a Vector and leave this in an empty state */
   template <std::size_t dim0>

--- a/src/matpackVI.cc
+++ b/src/matpackVI.cc
@@ -2226,7 +2226,7 @@ void swap(Tensor6& t1, Tensor6& t2) noexcept {
 
 /** Destructor for Tensor6. This is important, since Tensor6 uses new to
     allocate storage. */
-Tensor6::~Tensor6() {
+Tensor6::~Tensor6() noexcept {
   //   cout << "Destroying a Tensor6:\n"
   //        << *this << "\n........................................\n";
   delete[] mdata;

--- a/src/matpackVI.cc
+++ b/src/matpackVI.cc
@@ -2213,14 +2213,15 @@ void Tensor6::resize(Index v, Index s, Index b, Index p, Index r, Index c) {
 }
 
 /** Swaps two objects. */
-void swap(Tensor6& t1, Tensor6& t2) {
-  std::swap(t1.mvr, t2.mvr);
-  std::swap(t1.msr, t2.msr);
-  std::swap(t1.mbr, t2.mbr);
-  std::swap(t1.mpr, t2.mpr);
-  std::swap(t1.mrr, t2.mrr);
-  std::swap(t1.mcr, t2.mcr);
-  std::swap(t1.mdata, t2.mdata);
+void swap(Tensor6& t1, Tensor6& t2) noexcept {
+  using std::swap;
+  swap(t1.mvr, t2.mvr);
+  swap(t1.msr, t2.msr);
+  swap(t1.mbr, t2.mbr);
+  swap(t1.mpr, t2.mpr);
+  swap(t1.mrr, t2.mrr);
+  swap(t1.mcr, t2.mcr);
+  swap(t1.mdata, t2.mdata);
 }
 
 /** Destructor for Tensor6. This is important, since Tensor6 uses new to

--- a/src/matpackVI.h
+++ b/src/matpackVI.h
@@ -1149,7 +1149,7 @@ class Tensor6 : public Tensor6View {
   friend void swap(Tensor6& t1, Tensor6& t2) noexcept;
 
   // Destructor:
-  virtual ~Tensor6();
+  virtual ~Tensor6() noexcept;
 
   /*! Reduce a Tensor6 to a Vector and leave this in an empty state */
   template <std::size_t dim0>

--- a/src/matpackVI.h
+++ b/src/matpackVI.h
@@ -1146,7 +1146,7 @@ class Tensor6 : public Tensor6View {
   void resize(Index v, Index s, Index b, Index p, Index r, Index c);
 
   // Swap function:
-  friend void swap(Tensor6& t1, Tensor6& t2);
+  friend void swap(Tensor6& t1, Tensor6& t2) noexcept;
 
   // Destructor:
   virtual ~Tensor6();

--- a/src/matpackVI.h
+++ b/src/matpackVI.h
@@ -28,6 +28,8 @@
 #ifndef matpackVI_h
 #define matpackVI_h
 
+#include <utility>
+
 #include "matpackV.h"
 
 #define CHECK(x)       \
@@ -90,8 +92,8 @@ class ConstIterator6D {
   ConstIterator6D() = default;
 
   /** Explicit constructor. */
-  ConstIterator6D(const ConstTensor5View& x, Index stride)
-      : msv(x), mstride(stride) { /* Nothing to do here. */
+  ConstIterator6D(ConstTensor5View x, Index stride)
+      : msv(std::move(x)), mstride(stride) { /* Nothing to do here. */
   }
 
   // Operators:
@@ -1054,7 +1056,7 @@ class Tensor6View : public ConstTensor6View {
   Tensor6View& operator-=(const ConstTensor6View& x);
 
   // Destructor:
-  virtual ~Tensor6View() = default;
+  ~Tensor6View() override = default;
 
   // Friends:
   friend class Iterator7D;
@@ -1149,7 +1151,7 @@ class Tensor6 : public Tensor6View {
   friend void swap(Tensor6& t1, Tensor6& t2) noexcept;
 
   // Destructor:
-  virtual ~Tensor6() noexcept;
+  ~Tensor6() noexcept override;
 
   /*! Reduce a Tensor6 to a Vector and leave this in an empty state */
   template <std::size_t dim0>

--- a/src/matpackVII.cc
+++ b/src/matpackVII.cc
@@ -5532,15 +5532,16 @@ void Tensor7::resize(
 }
 
 /** Swaps two objects. */
-void swap(Tensor7& t1, Tensor7& t2) {
-  std::swap(t1.mlr, t2.mlr);
-  std::swap(t1.mvr, t2.mvr);
-  std::swap(t1.msr, t2.msr);
-  std::swap(t1.mbr, t2.mbr);
-  std::swap(t1.mpr, t2.mpr);
-  std::swap(t1.mrr, t2.mrr);
-  std::swap(t1.mcr, t2.mcr);
-  std::swap(t1.mdata, t2.mdata);
+void swap(Tensor7& t1, Tensor7& t2) noexcept {
+  using std::swap;
+  swap(t1.mlr, t2.mlr);
+  swap(t1.mvr, t2.mvr);
+  swap(t1.msr, t2.msr);
+  swap(t1.mbr, t2.mbr);
+  swap(t1.mpr, t2.mpr);
+  swap(t1.mrr, t2.mrr);
+  swap(t1.mcr, t2.mcr);
+  swap(t1.mdata, t2.mdata);
 }
 
 /** Destructor for Tensor7. This is important, since Tensor7 uses new to

--- a/src/matpackVII.cc
+++ b/src/matpackVII.cc
@@ -5546,7 +5546,7 @@ void swap(Tensor7& t1, Tensor7& t2) noexcept {
 
 /** Destructor for Tensor7. This is important, since Tensor7 uses new to
     allocate storage. */
-Tensor7::~Tensor7() {
+Tensor7::~Tensor7() noexcept {
   //   cout << "Destroying a Tensor7:\n"
   //        << *this << "\n........................................\n";
   delete[] mdata;

--- a/src/matpackVII.h
+++ b/src/matpackVII.h
@@ -2424,7 +2424,7 @@ class Tensor7 : public Tensor7View {
   void resize(Index l, Index v, Index s, Index b, Index p, Index r, Index c);
 
   // Swap function:
-  friend void swap(Tensor7& t1, Tensor7& t2);
+  friend void swap(Tensor7& t1, Tensor7& t2) noexcept;
 
   // Destructor:
   virtual ~Tensor7();

--- a/src/matpackVII.h
+++ b/src/matpackVII.h
@@ -2427,7 +2427,7 @@ class Tensor7 : public Tensor7View {
   friend void swap(Tensor7& t1, Tensor7& t2) noexcept;
 
   // Destructor:
-  virtual ~Tensor7();
+  virtual ~Tensor7() noexcept;
 
   /*! Reduce a Tensor7 to a Vector and leave this in an empty state */
   template <std::size_t dim0>

--- a/src/matpackVII.h
+++ b/src/matpackVII.h
@@ -29,6 +29,8 @@ USA. */
 #ifndef matpackVII_h
 #define matpackVII_h
 
+#include <utility>
+
 #include "matpackVI.h"
 
 /** The outermost iterator class for rank 7 tensors. This takes into
@@ -87,8 +89,8 @@ class ConstIterator7D {
   ConstIterator7D() = default;
 
   /** Explicit constructor. */
-  ConstIterator7D(const ConstTensor6View& x, Index stride)
-      : msv(x), mstride(stride) { /* Nothing to do here. */
+  ConstIterator7D(ConstTensor6View x, Index stride)
+      : msv(std::move(x)), mstride(stride) { /* Nothing to do here. */
   }
 
   // Operators:
@@ -2353,7 +2355,7 @@ class Tensor7View : public ConstTensor7View {
   Tensor7View& operator-=(const ConstTensor7View& x);
 
   //! Destructor.
-  virtual ~Tensor7View() = default;
+  ~Tensor7View() override = default;
 
   // Friends:
 
@@ -2427,7 +2429,7 @@ class Tensor7 : public Tensor7View {
   friend void swap(Tensor7& t1, Tensor7& t2) noexcept;
 
   // Destructor:
-  virtual ~Tensor7() noexcept;
+  ~Tensor7() noexcept override;
 
   /*! Reduce a Tensor7 to a Vector and leave this in an empty state */
   template <std::size_t dim0>

--- a/src/matpack_complex.cc
+++ b/src/matpack_complex.cc
@@ -717,9 +717,10 @@ void ComplexVector::resize(Index n) {
 }
 
 /** Swaps two objects. */
-void swap(ComplexVector& v1, ComplexVector& v2) {
-  std::swap(v1.mrange, v2.mrange);
-  std::swap(v1.mdata, v2.mdata);
+void swap(ComplexVector& v1, ComplexVector& v2) noexcept {
+  using std::swap;
+  swap(v1.mrange, v2.mrange);
+  swap(v1.mdata, v2.mdata);
 }
 
 /** Destructor for ComplexVector. This is important, since Vector uses new to
@@ -1430,10 +1431,11 @@ void ComplexMatrix::resize(Index r, Index c) {
 }
 
 /** Swaps two objects. */
-void swap(ComplexMatrix& m1, ComplexMatrix& m2) {
-  std::swap(m1.mrr, m2.mrr);
-  std::swap(m1.mcr, m2.mcr);
-  std::swap(m1.mdata, m2.mdata);
+void swap(ComplexMatrix& m1, ComplexMatrix& m2) noexcept {
+  using std::swap;
+  swap(m1.mrr, m2.mrr);
+  swap(m1.mcr, m2.mcr);
+  swap(m1.mdata, m2.mdata);
 }
 
 /** Destructor for Matrix. This is important, since Matrix uses new to

--- a/src/matpack_complex.cc
+++ b/src/matpack_complex.cc
@@ -725,7 +725,7 @@ void swap(ComplexVector& v1, ComplexVector& v2) noexcept {
 
 /** Destructor for ComplexVector. This is important, since Vector uses new to
  *   allocate storage. */
-ComplexVector::~ComplexVector() { delete[] mdata; }
+ComplexVector::~ComplexVector() noexcept { delete[] mdata; }
 
 // Functions for ConstMatrixView:
 // ------------------------------
@@ -1440,7 +1440,7 @@ void swap(ComplexMatrix& m1, ComplexMatrix& m2) noexcept {
 
 /** Destructor for Matrix. This is important, since Matrix uses new to
     allocate storage. */
-ComplexMatrix::~ComplexMatrix() {
+ComplexMatrix::~ComplexMatrix() noexcept {
   //   cout << "Destroying a Matrix:\n"
   //        << *this << "\n........................................\n";
   delete[] mdata;

--- a/src/matpack_complex.cc
+++ b/src/matpack_complex.cc
@@ -645,20 +645,61 @@ ComplexVector::ComplexVector(const std::vector<Numeric>& v)
  * \date   2002-12-19
  */
 ComplexVector& ComplexVector::operator=(const ComplexVector& v) {
-  const auto n = v.nelem();
-  resize(n);
-
-  auto* in = v.mdata + v.mrange.mstart;
-  auto* end = v.mdata + n;
-  auto* out = mdata;
-
-  while (in < end) {
-    out = in;
-    out++;
-    in += v.mrange.mstride;
+  if (this not_eq &v) {
+    resize(v.nelem());
+    matpack::eigen::row_vec(*this).noalias() = matpack::eigen::row_vec(v);
   }
 
   return *this;
+}
+
+ConstVectorView ConstComplexVectorView::real() const {
+  return ConstVectorView(
+      reinterpret_cast<Numeric*>(mdata),
+      Range(2 * mrange.mstart, mrange.mextent, mrange.mstride * 2));
+}
+
+ConstVectorView ConstComplexVectorView::imag() const {
+  return ConstVectorView(
+      reinterpret_cast<Numeric*>(mdata),
+      Range(2 * mrange.mstart + 1, mrange.mextent, mrange.mstride * 2));
+}
+
+VectorView ComplexVectorView::real() {
+  return VectorView(
+      reinterpret_cast<Numeric*>(mdata),
+      Range(2 * mrange.mstart, mrange.mextent, mrange.mstride * 2));
+}
+
+VectorView ComplexVectorView::imag() {
+  return VectorView(
+      reinterpret_cast<Numeric*>(mdata),
+      Range(2 * mrange.mstart + 1, mrange.mextent, mrange.mstride * 2));
+}
+
+MatrixView ComplexMatrixView::real() {
+  return MatrixView(reinterpret_cast<Numeric*>(mdata),
+                    Range(2 * mrr.mstart, mrr.mextent, mrr.mstride * 2),
+                    Range(2 * mcr.mstart, mcr.mextent, mcr.mstride * 2));
+}
+
+MatrixView ComplexMatrixView::imag() {
+  return MatrixView(reinterpret_cast<Numeric*>(mdata),
+                    Range(2 * mrr.mstart, mrr.mextent, mrr.mstride * 2),
+                    Range(2 * mcr.mstart + 1, mcr.mextent, mcr.mstride * 2));
+}
+
+ConstMatrixView ConstComplexMatrixView::real() const {
+  return ConstMatrixView(reinterpret_cast<Numeric*>(mdata),
+                         Range(2 * mrr.mstart, mrr.mextent, mrr.mstride * 2),
+                         Range(2 * mcr.mstart, mcr.mextent, mcr.mstride * 2));
+}
+
+ConstMatrixView ConstComplexMatrixView::imag() const {
+  return ConstMatrixView(
+      reinterpret_cast<Numeric*>(mdata),
+      Range(2 * mrr.mstart, mrr.mextent, mrr.mstride * 2),
+      Range(2 * mcr.mstart + 1, mcr.mextent, mcr.mstride * 2));
 }
 
 //! Assignment operator from Array<Numeric>.

--- a/src/matpack_complex.h
+++ b/src/matpack_complex.h
@@ -321,10 +321,10 @@ class ConstComplexVectorView {
   }
   
   /** Get a view of the real part of the vector */
-  [[nodiscard]] ConstVectorView real() const {return ConstVectorView(reinterpret_cast<Numeric *>(mdata), Range(2*mrange.mstart, mrange.mextent, mrange.mstride*2));}
+  [[nodiscard]] ConstVectorView real() const;
   
   /** Get a view of the imaginary part of the vector */
-  [[nodiscard]] ConstVectorView imag() const {return ConstVectorView(reinterpret_cast<Numeric *>(mdata), Range(2*mrange.mstart + 1, mrange.mextent, mrange.mstride*2));}
+  [[nodiscard]] ConstVectorView imag() const;
 
   ConstComplexVectorView operator[](const Range& r) const;
   friend Complex operator*(const ConstComplexVectorView& a,
@@ -428,10 +428,10 @@ class ComplexVectorView : public ConstComplexVectorView {
   }
   
   /** Get a view of the real part of the vector */
-  VectorView real() {return VectorView(reinterpret_cast<Numeric *>(mdata), Range(2*mrange.mstart, mrange.mextent, mrange.mstride*2));}
+  [[nodiscard]] VectorView real();
   
   /** Get a view of the imaginary part of the vector */
-  VectorView imag() {return VectorView(reinterpret_cast<Numeric *>(mdata), Range(2*mrange.mstart + 1, mrange.mextent, mrange.mstride*2));}
+  [[nodiscard]] VectorView imag();
 
   ComplexVectorView operator[](const Range& r);
 
@@ -706,12 +706,10 @@ class ConstComplexMatrixView {
   [[nodiscard]] Numeric get_imag(Index r, Index c) const { return get(r, c).imag(); }
   
   /** Get a view of the real part of the matrix */
-  [[nodiscard]] ConstMatrixView real() const {return ConstMatrixView(reinterpret_cast<Numeric *>(mdata), Range(2*mrr.mstart, mrr.mextent, mrr.mstride*2), 
-                                                                                           Range(2*mcr.mstart, mcr.mextent, mcr.mstride*2));}
-  
+  [[nodiscard]] ConstMatrixView real() const;
+
   /** Get a view of the imaginary part of the matrix */
-  [[nodiscard]] ConstMatrixView imag() const {return ConstMatrixView(reinterpret_cast<Numeric *>(mdata), Range(2*mrr.mstart, mrr.mextent, mrr.mstride*2),
-                                                                                           Range(2*mcr.mstart + 1, mcr.mextent, mcr.mstride*2));}
+  [[nodiscard]] ConstMatrixView imag() const;
   
   /** Get the extent of the underlying data */
   [[nodiscard]] Index get_column_extent() const {return mcr.get_extent();}
@@ -826,12 +824,10 @@ class ComplexMatrixView : public ConstComplexMatrixView {
   }
   
   /** Get a view of the real part of the matrix */
-  MatrixView real() {return MatrixView(reinterpret_cast<Numeric *>(mdata), Range(2*mrr.mstart, mrr.mextent, mrr.mstride*2), 
-                                                                           Range(2*mcr.mstart, mcr.mextent, mcr.mstride*2));}
-  
+ [[nodiscard]] MatrixView real();
+
   /** Get a view of the imaginary parts of the matrix */
-  MatrixView imag() {return MatrixView(reinterpret_cast<Numeric *>(mdata), Range(2*mrr.mstart, mrr.mextent, mrr.mstride*2),
-                                                                           Range(2*mcr.mstart + 1, mcr.mextent, mcr.mstride*2));}
+  [[nodiscard]] MatrixView imag();
 
   ComplexMatrixView operator()(const Range& r, const Range& c);
   ComplexVectorView operator()(const Range& r, Index c);

--- a/src/matpack_complex.h
+++ b/src/matpack_complex.h
@@ -645,7 +645,7 @@ class ComplexVector : public ComplexVectorView {
   friend void swap(ComplexVector& v1, ComplexVector& v2) noexcept;
 
   // Destructor:
-   ~ComplexVector() override;
+   ~ComplexVector() noexcept override;
 };
 
 // Declare class ComplexMatrix:
@@ -941,7 +941,7 @@ class ComplexMatrix : public ComplexMatrixView {
   friend void swap(ComplexMatrix& m1, ComplexMatrix& m2) noexcept;
 
   // Destructor:
-   ~ComplexMatrix() override;
+   ~ComplexMatrix() noexcept override;
 
   Complex* get_raw_data() { return mdata; }
 };

--- a/src/matpack_complex.h
+++ b/src/matpack_complex.h
@@ -642,7 +642,7 @@ class ComplexVector : public ComplexVectorView {
   void resize(Index n);
 
   // Swap function:
-  friend void swap(ComplexVector& v1, ComplexVector& v2);
+  friend void swap(ComplexVector& v1, ComplexVector& v2) noexcept;
 
   // Destructor:
    ~ComplexVector() override;
@@ -938,7 +938,7 @@ class ComplexMatrix : public ComplexMatrixView {
   void resize(Index r, Index c);
 
   // Swap function:
-  friend void swap(ComplexMatrix& m1, ComplexMatrix& m2);
+  friend void swap(ComplexMatrix& m1, ComplexMatrix& m2) noexcept;
 
   // Destructor:
    ~ComplexMatrix() override;

--- a/src/propagationmatrix.cc
+++ b/src/propagationmatrix.cc
@@ -2044,3 +2044,15 @@ std::ostream& operator<<(std::ostream& os, const StokesVector& sv) {
   os << sv.Data() << "\n";
   return os;
 }
+
+void PropagationMatrix::swap(PropagationMatrix& pm) noexcept {
+  using std::swap;
+  swap(mfreqs, pm.mfreqs);
+  swap(mstokes_dim, pm.mstokes_dim);
+  swap(mza, pm.mza);
+  swap(maa, pm.maa);
+  swap(mdata, pm.mdata);
+  swap(mvectortype, pm.mvectortype);
+}
+
+void swap(PropagationMatrix& a, PropagationMatrix& b) noexcept { a.swap(b); }

--- a/src/propagationmatrix.cc
+++ b/src/propagationmatrix.cc
@@ -2056,3 +2056,13 @@ void PropagationMatrix::swap(PropagationMatrix& pm) noexcept {
 }
 
 void swap(PropagationMatrix& a, PropagationMatrix& b) noexcept { a.swap(b); }
+
+LazyScale<PropagationMatrix> operator*(const PropagationMatrix& pm,
+                                       const Numeric& x) {
+  return LazyScale<PropagationMatrix>(pm, x);
+}
+
+LazyScale<PropagationMatrix> operator*(const Numeric& x,
+                                       const PropagationMatrix& pm) {
+  return LazyScale<PropagationMatrix>(pm, x);
+}

--- a/src/propagationmatrix.h
+++ b/src/propagationmatrix.h
@@ -961,6 +961,9 @@ class PropagationMatrix {
 
   friend std::ostream& operator<<(std::ostream& os, const PropagationMatrix& pm);
 
+  void swap(PropagationMatrix&) noexcept;
+  friend void swap(PropagationMatrix&, PropagationMatrix&) noexcept;
+
  protected:
   Index mfreqs, mstokes_dim;
   Index mza, maa;

--- a/src/propagationmatrix.h
+++ b/src/propagationmatrix.h
@@ -1378,10 +1378,8 @@ using ArrayOfArrayOfArrayOfStokesVector = Array<ArrayOfArrayOfStokesVector>;
  * @param[in] x Scale
  * @return LazyScale<PropagationMatrix> A lazy multiplier
  */
-inline LazyScale<PropagationMatrix> operator*(const PropagationMatrix& pm,
-                                              const Numeric& x) {
-  return LazyScale<PropagationMatrix>(pm, x);
-}
+LazyScale<PropagationMatrix> operator*(const PropagationMatrix& pm,
+                                       const Numeric& x);
 
 /** Returns a lazy multiplier
  * 
@@ -1389,11 +1387,8 @@ inline LazyScale<PropagationMatrix> operator*(const PropagationMatrix& pm,
  * @param[in] pm Propagation matrix
  * @return LazyScale<PropagationMatrix> A lazy multiplier
  */
-inline LazyScale<PropagationMatrix> operator*(const Numeric& x,
-                                              const PropagationMatrix& pm) {
-  return LazyScale<PropagationMatrix>(pm, x);
-}
-
+LazyScale<PropagationMatrix> operator*(const Numeric& x,
+                                       const PropagationMatrix& pm);
 
 /** Checks if a Propagation Matrix or something similar has good grids */
 template <class T>


### PR DESCRIPTION
I came across the [core guidelines](https://github.com/isocpp/CppCoreGuidelines/blob/036324/CppCoreGuidelines.md#cctor-constructors-assignments-and-destructors) and they claim we should mark destructors and swaps as noexcept for better code gen.  I just applied this to matpack.  I've no idea if it makes any differences, but it makes sense from logical POV that swapping things around or freeing memory cannot yield exceptions, so it cannot hurt