### PR TITLE
Add method to ignore lbl_checkedCalc line mixing check

### DIFF
--- a/src/m_absorptionlines.cc
+++ b/src/m_absorptionlines.cc
@@ -36,6 +36,7 @@
 #include "enums.h"
 #include "file.h"
 #include "global_data.h"
+#include "lineshapemodel.h"
 #include "m_xml.h"
 #include "quantum_numbers.h"
 #include <algorithm>
@@ -2584,5 +2585,27 @@ void abs_linesSort(ArrayOfAbsorptionLines & abs_lines,
       break;
     case Options::SortingOption::FINAL: { /*leave last*/
     }
+  }
+}
+
+void abs_linesTurnOffLineMixing(ArrayOfAbsorptionLines& abs_lines,
+                                const Verbosity&) {
+  for (auto& band : abs_lines) {
+    for (auto& line : band.lines) {
+      for (auto& slsm : line.lineshape) {
+        // Set the line mixing stuff to empty
+        slsm.Y() = LineShape::ModelParameters();
+        slsm.G() = LineShape::ModelParameters();
+        slsm.DV() = LineShape::ModelParameters();
+      }
+    }
+  }
+}
+
+void abs_lines_per_speciesTurnOffLineMixing(
+    ArrayOfArrayOfAbsorptionLines& abs_lines_per_species,
+    const Verbosity& verbosity) {
+  for (auto& abs_lines : abs_lines_per_species) {
+    abs_linesTurnOffLineMixing(abs_lines, verbosity);
   }
 }

--- a/src/m_checked.cc
+++ b/src/m_checked.cc
@@ -857,7 +857,8 @@ void lbl_checkedCalc(Index& lbl_checked,
               ARTS_USER_ERROR_IF(
                 single_data.Y().type not_eq LineShape::TemperatureModel::None or
                 single_data.DV().type not_eq LineShape::TemperatureModel::None,
-                                 "Cannot have Rosenkranz-style line mixing with cutoff calculations"
+                                 "Cannot have Rosenkranz-style line mixing with cutoff calculations\n"
+                                 "Note that abs_lines_per_speciesTurnOffLineMixing will make this error go away by modifying the data\n"
               )
             }
           }

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -2218,6 +2218,34 @@ For "ByLine", the negative frequency is at F0-cutoff-D0
       GIN_DESC()));
 
   md_data_raw.push_back(create_mdrecord(
+      NAME("abs_linesTurnOffLineMixing"),
+      DESCRIPTION("Sets all line mixing parameters to emtpy.\n"),
+      AUTHORS("Richard Larsson"),
+      OUT("abs_lines"),
+      GOUT(),
+      GOUT_TYPE(),
+      GOUT_DESC(),
+      IN(),
+      GIN(),
+      GIN_TYPE(),
+      GIN_DEFAULT(),
+      GIN_DESC()));
+
+  md_data_raw.push_back(create_mdrecord(
+      NAME("abs_lines_per_speciesTurnOffLineMixing"),
+      DESCRIPTION("Sets all line mixing parameters to emtpy.\n"),
+      AUTHORS("Richard Larsson"),
+      OUT("abs_lines_per_species"),
+      GOUT(),
+      GOUT_TYPE(),
+      GOUT_DESC(),
+      IN(),
+      GIN(),
+      GIN_TYPE(),
+      GIN_DEFAULT(),
+      GIN_DESC()));
+
+  md_data_raw.push_back(create_mdrecord(
       NAME("abs_lookupAdapt"),
       DESCRIPTION(
           "Adapts a gas absorption lookup table to the current calculation.\n"


### PR DESCRIPTION
This is of course not good for the accuracy of the calculations but it is a common use case because we are too slow otherwise