### PR TITLE
Revert to gcc11 on macos

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
           ubuntu-gcc-12-debug,
           ubuntu-clang-13-nofortran,
           ubuntu-clang-14-nofortran,
-          macos-gcc-12,
+          macos-gcc-11,
           macos-clang-14,
         ]
 
@@ -91,14 +91,14 @@ jobs:
             libcxx: "yes"
             buildtype: "Release"
 
-          - name: macos-gcc-12
+          - name: macos-gcc-11
             os: macos-latest
             compiler: gcc
-            version: "12"
+            version: "11"
             doc: "no"
             arts: "yes"
             fortran: "yes"
-            fortran-version: "12"
+            fortran-version: "11"
             check: "yes"
             libcxx: "no"
             buildtype: "Release"


### PR DESCRIPTION
Workaround for a bug in the current OSX build tools.