### PR TITLE
Stick with OSX 11 for now in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -164,6 +164,7 @@ jobs:
       - name: Setup (macOS)
         if: runner.os == 'macOS'
         run: |
+          pkgutil --pkg-info=com.apple.pkg.CLTools_Executables
           brew upgrade python
           sudo pip3 install docutils lark-parser matplotlib netCDF4 numpy pytest scipy xarray
           if [ "${{ matrix.compiler }}" = "gcc" ]; then

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -102,7 +102,6 @@ jobs:
             check: "yes"
             libcxx: "no"
             buildtype: "Release"
-            cmakeflags: "-DRELEASE_O2=1"
 
           - name: macos-clang-14
             os: macos-latest

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -92,7 +92,7 @@ jobs:
             buildtype: "Release"
 
           - name: macos-gcc-12
-            os: macos-latest
+            os: macos-11
             compiler: gcc
             version: "12"
             doc: "no"
@@ -104,7 +104,7 @@ jobs:
             buildtype: "Release"
 
           - name: macos-clang-14
-            os: macos-latest
+            os: macos-11
             compiler: clang
             version: "14"
             doc: "no"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
           ubuntu-gcc-12-debug,
           ubuntu-clang-13-nofortran,
           ubuntu-clang-14-nofortran,
-          macos-gcc-11,
+          macos-gcc-12,
           macos-clang-14,
         ]
 
@@ -91,14 +91,14 @@ jobs:
             libcxx: "yes"
             buildtype: "Release"
 
-          - name: macos-gcc-11
+          - name: macos-gcc-12
             os: macos-latest
             compiler: gcc
-            version: "11"
+            version: "12"
             doc: "no"
             arts: "yes"
             fortran: "yes"
-            fortran-version: "11"
+            fortran-version: "12"
             check: "yes"
             libcxx: "no"
             buildtype: "Release"


### PR DESCRIPTION
The CLtools in OSX 12 currently suffer a bug that causes a compile
failure. Until this is fixed, we stick with OSX 11 for our builds.

E.g.: https://stackoverflow.com/questions/73734125/xcode-14-0-gcc-12-linker-issue