### PR TITLE
Enable thin lto for pybind

### DIFF
--- a/src/python_interface/CMakeLists.txt
+++ b/src/python_interface/CMakeLists.txt
@@ -67,7 +67,7 @@ add_custom_command(OUTPUT py_auto_interface.h
 ########################################################################################
 
 ########### pybind11 class interface
-pybind11_add_module(pyarts_cpp
+pybind11_add_module(pyarts_cpp THIN_LTO
     py_module.cpp
     py_matpack.cpp
     py_basic.cpp


### PR DESCRIPTION
Significantly improves pybind link times with Clang.