### PR TITLE
solar ref spectra in irradiance

### DIFF
--- a/src/m_star.cc
+++ b/src/m_star.cc
@@ -111,7 +111,6 @@ void starsAddSingleFromGrid(ArrayOfStar &stars,
   Star& new_star = stars.emplace_back();
 
   new_star.spectrum = int_data; // set spectrum
-  new_star.spectrum *= pi; // outgoing flux at the surface of the star.
 
   new_star.description = description;
   new_star.radius = radius;

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -19402,15 +19402,19 @@ where N>=0 and the species name is something line "H2O".
           "\n"
           "The method allows to obtain the star spectrum by\n"
           "interpolation from a field of such data. \n"
-          "The star spectrum is expected to be stored as:\n"
-          "   GriddedField2:\n"
-          "      Vector f_grid[N_f]\n"
-          "      Vector stockes_dim[N_s]\n"
+          "The star spectrum is expected to be stored as\n"
+          "the irradiance at the suns photosphere.\n"
+          "\n"
+          "Unit:        GriddedField2: [W m-2 Hz-1]\n"
+          "                 Vector *f_grid*[Hz]\n"
+          "                 Vector *stokes_dim*[1]\n"
+          "\n"
+          "Dimensions: [f_grid, stokes_dim]\n"
           "\n"
           "This method performs an interpolation onto the f_grid.\n"
           "The point of *f_grid* that are outside the data frequency grid\n"
           "are initialized according to planck's law of the temperature variable.\n"
-          "Hence, a temperature of 0 means 0 st the edges of the f_grid.\n"),
+          "Hence, a temperature of 0 means 0s the edges of the f_grid.\n"),
       AUTHORS("Jon Petersen"),
       OUT("stars",
           "stars_do"),
@@ -19444,7 +19448,8 @@ where N>=0 and the species name is something line "H2O".
       GIN_DESC("Raw data for monochromatic irradiance spectra.\n",
                "The radius of the star in meter.\n"
                "Default is the radius of our sun.\n",
-               "The average distance between the star and the planet in meter.\n"
+               "The average distance between the center of the star and the \n"
+               "center of the planet in meter.\n"
                "Default value is set to 1 a.u.\n",
                "The temperature of the padding if the f_grid is outside the \n"
                "star spectrum data. Choose 0 for 0 at the edges or a effective\n"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ arts_test_run_pyfile(fast core/spectroscopy/ckdmt252.py)
 arts_test_run_pyfile(fast core/spectroscopy/ckdmt100.py)
 arts_test_run_pyfile(fast core/spectroscopy/pwr98.py)
 arts_test_run_pyfile(fast core/spectroscopy/standard.py)
+arts_test_run_pyfile(fast core/star/get_top_of_atm.py)
 
 # CORE PROPMAT
 arts_test_run_pyfile(fast core/propmat/rescale_species.py)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ arts_test_run_pyfile(fast core/spectroscopy/ckdmt252.py)
 arts_test_run_pyfile(fast core/spectroscopy/ckdmt100.py)
 arts_test_run_pyfile(fast core/spectroscopy/pwr98.py)
 arts_test_run_pyfile(fast core/spectroscopy/standard.py)
-arts_test_run_pyfile(fast core/star/get_top_of_atm.py)
+arts_test_run_pyfile(fast core/star/solar_irradiance.py)
 
 # CORE PROPMAT
 arts_test_run_pyfile(fast core/propmat/rescale_species.py)

--- a/tests/core/star/solar_irradiance.py
+++ b/tests/core/star/solar_irradiance.py
@@ -1,0 +1,75 @@
+import numpy
+import pyarts
+
+solar_spec = pyarts.xml.load("star/Sun/solar_spectrum_May_2004.xml")
+
+ws = pyarts.workspace.Workspace()
+ws.PlanetSet(option="Earth")
+
+ws.jacobianOff()
+
+ws.Touch(ws.abs_species)
+ws.abs_lines_per_speciesSetEmpty()
+ws.propmat_clearsky_agendaAuto()
+
+ws.stokes_dim = 1
+ws.f_grid = solar_spec.grids[0]
+ws.lat_true = [0.0]
+ws.lon_true = [0.0]
+ws.p_grid = np.logspace(5, -1, 2)
+ws.z_surface = [[300]]
+
+ws.AtmRawRead(basename=path + "planets/Earth/Fascod/tropical/tropical")
+ws.AtmosphereSet1D()
+ws.AtmFieldsCalc()
+
+ws.surface_skin_t = ws.t_field.value[0, 0, 0]
+ws.surface_scalar_reflectivity = [0.3]
+
+ws.starsAddSingleFromGrid(
+    star_spectrum_raw=solar_spec,
+    latitude=0.0,
+    longitude=0.0,
+)
+
+ws.sensorOff()
+ws.cloudboxSetFullAtm()
+ws.Touch(ws.scat_data)
+ws.pnd_fieldZero()
+
+
+@pyarts.workspace.arts_agenda(ws=ws, set_agenda=True)
+def gas_scattering_agenda(ws):
+    ws.Ignore(ws.rtp_vmr)
+    ws.gas_scattering_coefAirSimple()
+    ws.gas_scattering_matRayleigh()
+
+
+ws.atmfields_checkedCalc()
+ws.lbl_checkedCalc()
+ws.scat_data_checkedCalc()
+ws.atmgeom_checkedCalc()
+ws.cloudbox_checkedCalc()
+
+ws.DisortCalcIrradiance(nstreams=2)
+
+sim_irrad = (
+    np.squeeze(ws.spectral_irradiance_field.value)[:, -1, 0] * -1
+)  # toa, downward
+data_irrad = flux_sun2flux_toa(ws, solar_spec.data[:, 0])  # stokes_dim 1
+
+assert np.allclose(
+    sim_irrad, data_irrad
+), "The simulated values do not match the solar ref spectra."
+
+
+def flux_sun2flux_toa(ws, irrad):
+    """scales the irradiance at Suns photosphere to TOA (100km)."""
+    star_distance = ws.stars.value[0].distance
+    star_radius = ws.stars.value[0].radius
+    earth_radius = ws.refellipsoid.value[0]
+    star_distance -= 100_000 + earth_radius
+
+    factor = star_radius**2 / (star_radius**2 + star_distance**2)
+
+    return irrad * factor

--- a/tests/core/star/solar_irradiance.py
+++ b/tests/core/star/solar_irradiance.py
@@ -10,7 +10,7 @@ def main():
     
     ws.jacobianOff()
     
-    ws.Touch(ws.abs_species)
+    ws.abs_speciesSet(species=['N2'])
     ws.abs_lines_per_speciesSetEmpty()
     ws.propmat_clearsky_agendaAuto()
     

--- a/tests/testdata/CMakeLists.txt
+++ b/tests/testdata/CMakeLists.txt
@@ -34,6 +34,7 @@ else()
         planets/Earth/Fascod/tropical/tropical.t.xml
         planets/Earth/Fascod/tropical/tropical.z.xml
         planets/Earth/Fascod/tropical/tropical.O2.xml
+        planets/Earth/Fascod/tropical/tropical.N2.xml
         star/Sun/solar_spectrum_May_2004.xml
     )
 endif()

--- a/tests/testdata/CMakeLists.txt
+++ b/tests/testdata/CMakeLists.txt
@@ -34,6 +34,7 @@ else()
         planets/Earth/Fascod/tropical/tropical.t.xml
         planets/Earth/Fascod/tropical/tropical.z.xml
         planets/Earth/Fascod/tropical/tropical.O2.xml
+        star/Sun/solar_spectrum_May_2004.xml
     )
 endif()
 


### PR DESCRIPTION
The solar reference spectra are now given in irradiance, and therefore the conversion is removed. 
The method docu got corrected and improved.