### PR TITLE
Fix some cppcheck

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,4 @@ BinPackArguments: false
 BinPackParameters: false
 BreakStringLiterals: false
 ReflowComments: false
+QualifierAlignment: left

--- a/src/absorptionlines.cc
+++ b/src/absorptionlines.cc
@@ -75,7 +75,7 @@ LineShape::Output Absorption::Lines::ShapeParameters_dT(
 }
 
 Index Absorption::Lines::LineShapePos(
-    const Species::Species spec) const noexcept {
+    const Species::Species spec) const ARTS_NOEXCEPT {
   // Is always first if this is self and self broadening exists
   if (selfbroadening and spec == quantumidentity.Species()) {
     return 0;
@@ -99,7 +99,7 @@ LineShape::Output Absorption::Lines::ShapeParameters_dVMR(
     size_t k,
     Numeric T,
     Numeric P,
-    const QuantumIdentifier& vmr_qid) const noexcept {
+    const QuantumIdentifier& vmr_qid) const ARTS_NOEXCEPT {
   const Index pos = LineShapePos(vmr_qid);
   if (pos >= 0) return lines[k].lineshape.GetVMRDerivs(T, T0, P, pos);
   return LineShape::Output{};
@@ -110,7 +110,7 @@ Numeric Absorption::Lines::ShapeParameter_dInternal(
     Numeric T,
     Numeric P,
     const Vector& vmrs,
-    const RetrievalQuantity& derivative) const noexcept {
+    const RetrievalQuantity& derivative) const ARTS_NOEXCEPT {
   const auto self = derivative.Mode() == LineShape::self_broadening;
   const auto bath = derivative.Mode() == LineShape::bath_broadening;
   const auto& ls = lines[k].lineshape;
@@ -2116,7 +2116,7 @@ Absorption::SingleLineExternal Absorption::ReadFromJplStream(istream& is) {
   return data;
 }
 
-bool Absorption::Lines::OK() const noexcept {
+bool Absorption::Lines::OK() const ARTS_NOEXCEPT {
   const Index nb = broadeningspecies.nelem();
 
   // Check that the isotopologue is ok
@@ -2331,7 +2331,7 @@ const Quantum::Number::Value& get(const Quantum::Number::LocalState& qns)
                                            : qns.val[QuantumNumberType::J];
 }
 
-Index Lines::ZeemanCount(size_t k, Zeeman::Polarization type) const noexcept {
+Index Lines::ZeemanCount(size_t k, Zeeman::Polarization type) const ARTS_NOEXCEPT {
   if (type == Zeeman::Polarization::None) return 1;
 
   // Select F before J but assume one of them exist
@@ -2341,7 +2341,7 @@ Index Lines::ZeemanCount(size_t k, Zeeman::Polarization type) const noexcept {
 
 Numeric Lines::ZeemanStrength(size_t k,
                               Zeeman::Polarization type,
-                              Index i) const noexcept {
+                              Index i) const ARTS_NOEXCEPT {
   if (type == Zeeman::Polarization::None) return 1.0;
 
   // Select F before J but assume one of them exist
@@ -2351,7 +2351,7 @@ Numeric Lines::ZeemanStrength(size_t k,
 
 Numeric Lines::ZeemanSplitting(size_t k,
                                Zeeman::Polarization type,
-                               Index i) const noexcept {
+                               Index i) const ARTS_NOEXCEPT {
   if (type == Zeeman::Polarization::None) return 0.0;
 
   // Select F before J but assume one of them exist
@@ -2398,8 +2398,6 @@ Numeric Lines::F_mean(Numeric T) const noexcept {
   return F_mean(wgts);
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wreturn-type"
 Numeric Lines::CutoffFreq(size_t k, Numeric shift) const noexcept {
   switch (cutoff) {
     case CutoffType::ByLine:
@@ -2410,11 +2408,9 @@ Numeric Lines::CutoffFreq(size_t k, Numeric shift) const noexcept {
     case CutoffType::FINAL:
       break;
   }
+  return std::numeric_limits<Numeric>::max();
 }
-#pragma GCC diagnostic pop
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wreturn-type"
 Numeric Lines::CutoffFreqMinus(size_t k, Numeric shift) const noexcept {
   switch (cutoff) {
     case CutoffType::ByLine:
@@ -2425,8 +2421,9 @@ Numeric Lines::CutoffFreqMinus(size_t k, Numeric shift) const noexcept {
     case CutoffType::FINAL:
       break;
   }
+  
+  return std::numeric_limits<Numeric>::lowest();
 }
-#pragma GCC diagnostic pop
 
 bifstream& Lines::read(bifstream& is) {
   for (auto& line : lines) line.read(is);

--- a/src/absorptionlines.h
+++ b/src/absorptionlines.h
@@ -73,6 +73,7 @@ constexpr std::string_view mirroringtype2metadatastring(MirroringType in) noexce
       return "There are manual line entries in the catalog to mirror this line.\n";
     case MirroringType::FINAL: break;
   }
+  return "There's an error";
 }
 #pragma GCC diagnostic pop
 
@@ -108,6 +109,7 @@ constexpr std::string_view normalizationtype2metadatastring(NormalizationType in
         "i.e. F ~ (f / f0) * ((1 - exp(- hf / kT)) / (1 - exp(- hf0 / kT)))\n";
     case NormalizationType::FINAL: break;
   }
+  return "There's an error";
 }
 #pragma GCC diagnostic pop
 
@@ -145,6 +147,7 @@ constexpr std::string_view populationtype2metadatastring(PopulationType in) {
       return "The lines are considered as in pure NLTE.\n";
     case PopulationType::FINAL: return "There's an error";
   }
+  return "There's an error";
 }
 #pragma GCC diagnostic pop
 
@@ -239,7 +242,7 @@ struct SingleLine {
   [[nodiscard]] Index LineShapeElems() const noexcept {return lineshape.nelem();}
   
   /** Number of lower quantum numbers */
-  [[nodiscard]] Index LocalQuantumElems() const noexcept {return localquanta.val.nelem();}
+  [[nodiscard]] Index LocalQuantumElems() const ARTS_NOEXCEPT {return localquanta.val.nelem();}
   
   //////////////////////////////////////////////////////////////////
   ///////////////////////////////////////////////// Special settings
@@ -500,7 +503,7 @@ struct Lines {
   void MakeLineShapeModelCommon();
   
   /** Number of broadening species */
-  [[nodiscard]] Index NumBroadeners() const noexcept {return Index(broadeningspecies.nelem());}
+  [[nodiscard]] Index NumBroadeners() const ARTS_NOEXCEPT {return Index(broadeningspecies.nelem());}
   
   /** Number of broadening species */
   [[nodiscard]] Index NumLocalQuanta() const noexcept {
@@ -511,7 +514,7 @@ struct Lines {
    * @param[in] k Line number (less than NumLines())
    * @param[in] type Type of Zeeman polarization
    */
-  [[nodiscard]] Index ZeemanCount(size_t k, Zeeman::Polarization type) const noexcept;
+  [[nodiscard]] Index ZeemanCount(size_t k, Zeeman::Polarization type) const ARTS_NOEXCEPT;
   
   /** Returns the strength of a Zeeman split line
    * 
@@ -519,7 +522,7 @@ struct Lines {
    * @param[in] type Type of Zeeman polarization
    * @param[in] i Zeeman line count
    */
-  [[nodiscard]] Numeric ZeemanStrength(size_t k, Zeeman::Polarization type, Index i) const noexcept;
+  [[nodiscard]] Numeric ZeemanStrength(size_t k, Zeeman::Polarization type, Index i) const ARTS_NOEXCEPT;
   
   /** Returns the splitting of a Zeeman split line
    * 
@@ -527,7 +530,7 @@ struct Lines {
    * @param[in] type Type of Zeeman polarization
    * @param[in] i Zeeman line count
    */
-  [[nodiscard]] Numeric ZeemanSplitting(size_t k, Zeeman::Polarization type, Index i) const noexcept;
+  [[nodiscard]] Numeric ZeemanSplitting(size_t k, Zeeman::Polarization type, Index i) const ARTS_NOEXCEPT;
   
   /** Set Zeeman effect for all lines that have the correct quantum numbers */
   void SetAutomaticZeeman() noexcept;
@@ -616,14 +619,14 @@ struct Lines {
    * @param[in] A species index that might be among the broadener species
    * @return Position among broadening species or -1
    */
-  [[nodiscard]] Index LineShapePos(const Species::Species spec) const noexcept;
+  [[nodiscard]] Index LineShapePos(const Species::Species spec) const ARTS_NOEXCEPT;
   
   /** Position among broadening species or -1
    * 
    * @param[in] An identity that might be among the broadener species
    * @return Position among broadening species or -1
    */
-  [[nodiscard]] Index LineShapePos(const QuantumIdentifier& qid) const noexcept {
+  [[nodiscard]] Index LineShapePos(const QuantumIdentifier& qid) const ARTS_NOEXCEPT {
     return LineShapePos(qid.Species());
   }
   
@@ -636,7 +639,7 @@ struct Lines {
    * @return Line shape parameters vmr derivative
    */
   [[nodiscard]] LineShape::Output ShapeParameters_dVMR(size_t k, Numeric T, Numeric P,
-                                         const QuantumIdentifier& vmr_qid) const noexcept;
+                                         const QuantumIdentifier& vmr_qid) const ARTS_NOEXCEPT;
   
   /** Line shape parameter internal derivative
    * 
@@ -649,7 +652,7 @@ struct Lines {
    */
   [[nodiscard]] Numeric ShapeParameter_dInternal(size_t k, Numeric T, Numeric P,
                                    const Vector& vmrs,
-                                   const RetrievalQuantity& derivative) const noexcept;
+                                   const RetrievalQuantity& derivative) const ARTS_NOEXCEPT;
   
   /** Returns cutoff frequency or maximum value
    * 
@@ -719,7 +722,7 @@ struct Lines {
   /** Binary write for Lines */
   bofstream& write(bofstream& os) const;
   
-  [[nodiscard]] bool OK() const noexcept;
+  [[nodiscard]] bool OK() const ARTS_NOEXCEPT;
   
   [[nodiscard]] Numeric DopplerConstant(Numeric T) const noexcept;
 

--- a/src/energylevelmap.cc
+++ b/src/energylevelmap.cc
@@ -28,7 +28,7 @@
 #include "special_interp.h"
 
 
-bool EnergyLevelMap::OK() const noexcept {
+bool EnergyLevelMap::OK() const ARTS_NOEXCEPT {
   if (not (value.nbooks() == levels.nelem() and 
           (vib_energy.nelem() == levels.nelem() or vib_energy.nelem() == 0))) {
     return false;  // Bad dimensions, vibrational energies and IDs and data of strange size

--- a/src/energylevelmap.h
+++ b/src/energylevelmap.h
@@ -92,7 +92,7 @@ struct EnergyLevelMap {
   Vector vib_energy;
   Tensor4 value;
   
-  [[nodiscard]] bool OK() const noexcept;
+  [[nodiscard]] bool OK() const ARTS_NOEXCEPT;
   
   void ThrowIfNotOK() const ARTS_NOEXCEPT {ARTS_ASSERT (OK(), "Class in bad state");}
   

--- a/src/lineshape.cc
+++ b/src/lineshape.cc
@@ -11,11 +11,11 @@
 using Constant::inv_pi;
 using Constant::inv_sqrt_pi;
 using Constant::pi;
+using Constant::sqrt_ln_2;
+using Constant::sqrt_pi;
 using Math::pow2;
 using Math::pow3;
 using Math::pow4;
-using Constant::sqrt_ln_2;
-using Constant::sqrt_pi;
 
 constexpr Numeric ln_16 =
     2.772588722239781237668928485832706272302000537441021016482720037973574487879;
@@ -34,377 +34,368 @@ Complex Voigt::operator()(Numeric f) noexcept {
   return F;
 }
 
-SpeedDependentVoigt::SpeedDependentVoigt(Numeric F0_noshift,
-                                         const Output &ls,
-                                         Numeric GD_div_F0,
-                                         Numeric dZ) noexcept
+SpeedDependentVoigt::SpeedDependentVoigt(Numeric F0_noshift, const Output &ls,
+                                         Numeric GD_div_F0, Numeric dZ) noexcept
     : mF0(F0_noshift + dZ + ls.D0 - 1.5 * ls.D2),
       invGD(sqrt_ln_2 / nonstd::abs(GD_div_F0 * mF0)),
-      invc2(1.0 / Complex(ls.G2, ls.D2)),
-      dx(Complex(ls.G0 - 1.5 * ls.G2, mF0)),
-      x(dx * invc2),
-      sqrty(invc2 / (2 * invGD)),
+      invc2(1.0 / Complex(ls.G2, ls.D2)), dx(Complex(ls.G0 - 1.5 * ls.G2, mF0)),
+      x(dx * invc2), sqrty(invc2 / (2 * invGD)),
       calcs(init(Complex(ls.G2, ls.D2))) {
   calc();
 }
 
 Complex SpeedDependentVoigt::dFdf() const noexcept {
   switch (calcs) {
-    case CalcType::Full:
-      return invGD * invc2 * (dw1 - dw2) / (2 * sqrt_pi * sq);
-    case CalcType::Voigt:
-      return dw1 * pow2(invGD) * inv_sqrt_pi;
-    case CalcType::LowXandHighY:
-      return dw1 * pow2(invGD) * inv_sqrt_pi -
-             dw2 * invGD * invc2 / (2 * sqrt_pi * sq);
-    case CalcType::LowYandLowX:
-      return pow2(invc2) * (-dw1 * sq + 1i * w1) / (sqrt_pi * sq);
-    case CalcType::LowYandHighX:
-      return 1i * pow2(invc2) * (x - 3) / (pi * pow3(x));
+  case CalcType::Full:
+    return invGD * invc2 * (dw1 - dw2) / (2 * sqrt_pi * sq);
+  case CalcType::Voigt:
+    return dw1 * pow2(invGD) * inv_sqrt_pi;
+  case CalcType::LowXandHighY:
+    return dw1 * pow2(invGD) * inv_sqrt_pi -
+           dw2 * invGD * invc2 / (2 * sqrt_pi * sq);
+  case CalcType::LowYandLowX:
+    return pow2(invc2) * (-dw1 * sq + 1i * w1) / (sqrt_pi * sq);
+  case CalcType::LowYandHighX:
+    return 1i * pow2(invc2) * (x - 3) / (pi * pow3(x));
   }
   return {};
 }
 
 Complex SpeedDependentVoigt::dFdF0() const noexcept {
   switch (calcs) {
-    case CalcType::Full:
-      return (4 * pow2(invGD) * (-w1 + w2) * sq +
-              1i * invc2 *
-                  (dw1 * (Complex(0, 2 * mF0 * pow2(invGD)) - 2 * invGD * sq +
-                          invc2) -
-                   dw2 * (Complex(0, 2 * mF0 * pow2(invGD)) + 2 * invGD * sq +
-                          invc2))) /
-             (4 * sqrt_pi * invGD * mF0 * sq);
-    case CalcType::Voigt:
-      return -invGD * (Complex(0, invGD) * dw1 * (dx - Complex(0, mF0)) + w1) /
-             (sqrt_pi * mF0);
-    case CalcType::LowXandHighY:
-      return (4 * pow2(invGD) * (-w1 + w2) * sq -
-              1i * (4 * dw1 * pow3(invGD) * (dx - Complex(0, mF0)) * sq +
-                    dw2 * invc2 *
-                        (Complex(0, 2 * mF0 * pow2(invGD)) + 2 * invGD * sq +
-                         invc2))) /
-             (4 * sqrt_pi * invGD * mF0 * sq);
-    case CalcType::LowYandLowX:
-      return pow2(invc2) * (dw1 * sq - 1i * w1) / (sqrt_pi * sq);
-    case CalcType::LowYandHighX:
-      return 1i * pow2(invc2) * (3 - x) / (pi * pow3(x));
+  case CalcType::Full:
+    return (4 * pow2(invGD) * (-w1 + w2) * sq +
+            1i * invc2 *
+                (dw1 * (Complex(0, 2 * mF0 * pow2(invGD)) - 2 * invGD * sq +
+                        invc2) -
+                 dw2 * (Complex(0, 2 * mF0 * pow2(invGD)) + 2 * invGD * sq +
+                        invc2))) /
+           (4 * sqrt_pi * invGD * mF0 * sq);
+  case CalcType::Voigt:
+    return -invGD * (Complex(0, invGD) * dw1 * (dx - Complex(0, mF0)) + w1) /
+           (sqrt_pi * mF0);
+  case CalcType::LowXandHighY:
+    return (4 * pow2(invGD) * (-w1 + w2) * sq -
+            1i * (4 * dw1 * pow3(invGD) * (dx - Complex(0, mF0)) * sq +
+                  dw2 * invc2 *
+                      (Complex(0, 2 * mF0 * pow2(invGD)) + 2 * invGD * sq +
+                       invc2))) /
+           (4 * sqrt_pi * invGD * mF0 * sq);
+  case CalcType::LowYandLowX:
+    return pow2(invc2) * (dw1 * sq - 1i * w1) / (sqrt_pi * sq);
+  case CalcType::LowYandHighX:
+    return 1i * pow2(invc2) * (3 - x) / (pi * pow3(x));
   }
   return {};
 }
 
 Complex SpeedDependentVoigt::dFdD0(Numeric dD0dD0) const noexcept {
   switch (calcs) {
-    case CalcType::Full:
-      return -dD0dD0 *
-             (4 * pow2(invGD) * (w1 - w2) * sq +
-              1i * invc2 *
-                  (-dw1 * (Complex(0, 2 * mF0 * pow2(invGD)) - 2 * invGD * sq +
-                           invc2) +
-                   dw2 * (Complex(0, 2 * mF0 * pow2(invGD)) + 2 * invGD * sq +
-                          invc2))) /
-             (4 * sqrt_pi * invGD * mF0 * sq);
-    case CalcType::Voigt:
-      return -dD0dD0 * invGD *
-             (Complex(0, invGD) * dw1 * (dx - Complex(0, mF0)) + w1) /
-             (sqrt_pi * mF0);
-    case CalcType::LowXandHighY:
-      return -dD0dD0 *
-             (4 * pow2(invGD) * (w1 - w2) * sq +
-              1i * (4 * dw1 * pow3(invGD) * (dx - Complex(0, mF0)) * sq +
-                    dw2 * invc2 *
-                        (Complex(0, 2 * mF0 * pow2(invGD)) + 2 * invGD * sq +
-                         invc2))) /
-             (4 * sqrt_pi * invGD * mF0 * sq);
-    case CalcType::LowYandLowX:
-      return dD0dD0 * pow2(invc2) * (dw1 * sq - 1i * w1) / (sqrt_pi * sq);
-    case CalcType::LowYandHighX:
-      return -Complex(0, dD0dD0) * pow2(invc2) * (x - 3) / (pi * pow3(x));
+  case CalcType::Full:
+    return -dD0dD0 *
+           (4 * pow2(invGD) * (w1 - w2) * sq +
+            1i * invc2 *
+                (-dw1 * (Complex(0, 2 * mF0 * pow2(invGD)) - 2 * invGD * sq +
+                         invc2) +
+                 dw2 * (Complex(0, 2 * mF0 * pow2(invGD)) + 2 * invGD * sq +
+                        invc2))) /
+           (4 * sqrt_pi * invGD * mF0 * sq);
+  case CalcType::Voigt:
+    return -dD0dD0 * invGD *
+           (Complex(0, invGD) * dw1 * (dx - Complex(0, mF0)) + w1) /
+           (sqrt_pi * mF0);
+  case CalcType::LowXandHighY:
+    return -dD0dD0 *
+           (4 * pow2(invGD) * (w1 - w2) * sq +
+            1i * (4 * dw1 * pow3(invGD) * (dx - Complex(0, mF0)) * sq +
+                  dw2 * invc2 *
+                      (Complex(0, 2 * mF0 * pow2(invGD)) + 2 * invGD * sq +
+                       invc2))) /
+           (4 * sqrt_pi * invGD * mF0 * sq);
+  case CalcType::LowYandLowX:
+    return dD0dD0 * pow2(invc2) * (dw1 * sq - 1i * w1) / (sqrt_pi * sq);
+  case CalcType::LowYandHighX:
+    return -Complex(0, dD0dD0) * pow2(invc2) * (x - 3) / (pi * pow3(x));
   }
   return {};
 }
 
 Complex SpeedDependentVoigt::dFdG0(Numeric dG0dG0) const noexcept {
   switch (calcs) {
-    case CalcType::Full:
-      return Complex(0, dG0dG0) * invGD * invc2 * (dw1 - dw2) /
-             (2 * sqrt_pi * sq);
-    case CalcType::Voigt:
-      return Complex(0, dG0dG0) * dw1 * pow2(invGD) * inv_sqrt_pi;
-    case CalcType::LowXandHighY:
-      return Complex(0, dG0dG0) * invGD * (2 * dw1 * invGD * sq - dw2 * invc2) /
-             (2 * sqrt_pi * sq);
-    case CalcType::LowYandLowX:
-      return -dG0dG0 * pow2(invc2) * (1i * dw1 * sq + w1) / (sqrt_pi * sq);
-    case CalcType::LowYandHighX:
-      return -dG0dG0 * pow2(invc2) * (x - 3) / (pi * pow3(x));
+  case CalcType::Full:
+    return Complex(0, dG0dG0) * invGD * invc2 * (dw1 - dw2) /
+           (2 * sqrt_pi * sq);
+  case CalcType::Voigt:
+    return Complex(0, dG0dG0) * dw1 * pow2(invGD) * inv_sqrt_pi;
+  case CalcType::LowXandHighY:
+    return Complex(0, dG0dG0) * invGD * (2 * dw1 * invGD * sq - dw2 * invc2) /
+           (2 * sqrt_pi * sq);
+  case CalcType::LowYandLowX:
+    return -dG0dG0 * pow2(invc2) * (1i * dw1 * sq + w1) / (sqrt_pi * sq);
+  case CalcType::LowYandHighX:
+    return -dG0dG0 * pow2(invc2) * (x - 3) / (pi * pow3(x));
   }
   return {};
 }
 
 Complex SpeedDependentVoigt::dFdD2(Numeric dD2dD2) const noexcept {
   switch (calcs) {
-    case CalcType::Full:
-      return dD2dD2 *
-             (12 * pow2(invGD) * (w1 - w2) * sq +
-              1i * invc2 *
-                  (dw1 * (-Complex(0, 2 * mF0 * pow2(invGD)) *
-                              (2 * dx * invc2 + 3) +
-                          4 * Complex(0, invGD) * invc2 * mF0 * sq +
-                          6 * invGD * sq - Complex(0, 2 * mF0) * pow2(invc2) -
-                          3 * invc2) +
-                   dw2 * (Complex(0, 2 * mF0 * pow2(invGD)) *
-                              (2 * dx * invc2 + 3) +
-                          4 * Complex(0, invGD) * invc2 * mF0 * sq +
-                          6 * invGD * sq + Complex(0, 2 * mF0) * pow2(invc2) +
-                          3 * invc2))) /
-             (8 * sqrt_pi * invGD * mF0 * sq);
-    case CalcType::Voigt:
-      return 3 * dD2dD2 * invGD *
-             (Complex(0, invGD) * dw1 * (dx - Complex(0, mF0)) + w1) /
-             (2 * sqrt_pi * mF0);
-    case CalcType::LowXandHighY:
-      return dD2dD2 *
-             (12 * pow2(invGD) * (w1 - w2) * sq +
-              1i * (12 * dw1 * pow3(invGD) * (dx - Complex(0, mF0)) * sq +
-                    dw2 * invc2 *
-                        (Complex(0, 2 * mF0 * pow2(invGD)) *
-                             (2 * dx * invc2 + 3) +
-                         4 * Complex(0, invGD) * invc2 * mF0 * sq +
-                         6 * invGD * sq + Complex(0, 2 * mF0) * pow2(invc2) +
-                         3 * invc2))) /
-             (8 * sqrt_pi * invGD * mF0 * sq);
-    case CalcType::LowYandLowX:
-      return dD2dD2 * pow2(invc2) *
-             (4 * 1i * sq * (sqrt_pi * w1 * sq - 1) -
-              sqrt_pi * (dw1 * sq - 1i * w1) * (2 * dx * invc2 + 3)) /
-             (2 * pi * sq);
-    case CalcType::LowYandHighX:
-      return Complex(0, dD2dD2) * pow2(invc2) *
-             (-x * (2 * x - 3) + (x - 3) * (2 * dx * invc2 + 3)) /
-             (2 * pi * pow3(x));
+  case CalcType::Full:
+    return dD2dD2 *
+           (12 * pow2(invGD) * (w1 - w2) * sq +
+            1i * invc2 *
+                (dw1 * (-Complex(0, 2 * mF0 * pow2(invGD)) *
+                            (2 * dx * invc2 + 3) +
+                        4 * Complex(0, invGD) * invc2 * mF0 * sq +
+                        6 * invGD * sq - Complex(0, 2 * mF0) * pow2(invc2) -
+                        3 * invc2) +
+                 dw2 *
+                     (Complex(0, 2 * mF0 * pow2(invGD)) * (2 * dx * invc2 + 3) +
+                      4 * Complex(0, invGD) * invc2 * mF0 * sq +
+                      6 * invGD * sq + Complex(0, 2 * mF0) * pow2(invc2) +
+                      3 * invc2))) /
+           (8 * sqrt_pi * invGD * mF0 * sq);
+  case CalcType::Voigt:
+    return 3 * dD2dD2 * invGD *
+           (Complex(0, invGD) * dw1 * (dx - Complex(0, mF0)) + w1) /
+           (2 * sqrt_pi * mF0);
+  case CalcType::LowXandHighY:
+    return dD2dD2 *
+           (12 * pow2(invGD) * (w1 - w2) * sq +
+            1i *
+                (12 * dw1 * pow3(invGD) * (dx - Complex(0, mF0)) * sq +
+                 dw2 * invc2 *
+                     (Complex(0, 2 * mF0 * pow2(invGD)) * (2 * dx * invc2 + 3) +
+                      4 * Complex(0, invGD) * invc2 * mF0 * sq +
+                      6 * invGD * sq + Complex(0, 2 * mF0) * pow2(invc2) +
+                      3 * invc2))) /
+           (8 * sqrt_pi * invGD * mF0 * sq);
+  case CalcType::LowYandLowX:
+    return dD2dD2 * pow2(invc2) *
+           (4 * 1i * sq * (sqrt_pi * w1 * sq - 1) -
+            sqrt_pi * (dw1 * sq - 1i * w1) * (2 * dx * invc2 + 3)) /
+           (2 * pi * sq);
+  case CalcType::LowYandHighX:
+    return Complex(0, dD2dD2) * pow2(invc2) *
+           (-x * (2 * x - 3) + (x - 3) * (2 * dx * invc2 + 3)) /
+           (2 * pi * pow3(x));
   }
   return {};
 }
 
 Complex SpeedDependentVoigt::dFdG2(Numeric dG2dG2) const noexcept {
   switch (calcs) {
-    case CalcType::Full:
-      return Complex(0, dG2dG2) * invc2 *
-             (dw1 * (-pow2(invGD) * (2 * dx * invc2 + 3) +
-                     2 * invGD * invc2 * sq - pow2(invc2)) +
-              dw2 * (pow2(invGD) * (2 * dx * invc2 + 3) +
-                     2 * invGD * invc2 * sq + pow2(invc2))) /
-             (4 * sqrt_pi * invGD * sq);
-    case CalcType::Voigt:
-      return -3 * Complex(0, dG2dG2) * dw1 * pow2(invGD) / (2 * sqrt_pi);
-    case CalcType::LowXandHighY:
-      return Complex(0, dG2dG2) *
-             (-6 * dw1 * pow3(invGD) * sq +
-              dw2 * invc2 *
-                  (pow2(invGD) * (2 * dx * invc2 + 3) + 2 * invGD * invc2 * sq +
+  case CalcType::Full:
+    return Complex(0, dG2dG2) * invc2 *
+           (dw1 * (-pow2(invGD) * (2 * dx * invc2 + 3) +
+                   2 * invGD * invc2 * sq - pow2(invc2)) +
+            dw2 * (pow2(invGD) * (2 * dx * invc2 + 3) + 2 * invGD * invc2 * sq +
                    pow2(invc2))) /
-             (4 * sqrt_pi * invGD * sq);
-    case CalcType::LowYandLowX:
-      return dG2dG2 * pow2(invc2) *
-             (4 * sq * (sqrt_pi * w1 * sq - 1) +
-              sqrt_pi * (2 * dx * invc2 + 3) * (1i * dw1 * sq + w1)) /
-             (2 * pi * sq);
-    case CalcType::LowYandHighX:
-      return dG2dG2 * pow2(invc2) *
-             (-x * (2 * x - 3) + (x - 3) * (2 * dx * invc2 + 3)) /
-             (2 * pi * pow3(x));
+           (4 * sqrt_pi * invGD * sq);
+  case CalcType::Voigt:
+    return -3 * Complex(0, dG2dG2) * dw1 * pow2(invGD) / (2 * sqrt_pi);
+  case CalcType::LowXandHighY:
+    return Complex(0, dG2dG2) *
+           (-6 * dw1 * pow3(invGD) * sq +
+            dw2 * invc2 *
+                (pow2(invGD) * (2 * dx * invc2 + 3) + 2 * invGD * invc2 * sq +
+                 pow2(invc2))) /
+           (4 * sqrt_pi * invGD * sq);
+  case CalcType::LowYandLowX:
+    return dG2dG2 * pow2(invc2) *
+           (4 * sq * (sqrt_pi * w1 * sq - 1) +
+            sqrt_pi * (2 * dx * invc2 + 3) * (1i * dw1 * sq + w1)) /
+           (2 * pi * sq);
+  case CalcType::LowYandHighX:
+    return dG2dG2 * pow2(invc2) *
+           (-x * (2 * x - 3) + (x - 3) * (2 * dx * invc2 + 3)) /
+           (2 * pi * pow3(x));
   }
   return {};
 }
 
 Complex SpeedDependentVoigt::dFdH(Numeric dZ) const noexcept {
   switch (calcs) {
-    case CalcType::Full:
-      return -dZ *
-             (4 * pow2(invGD) * (w1 - w2) * sq +
-              1i * invc2 *
-                  (-dw1 * (Complex(0, 2 * mF0 * pow2(invGD)) - 2 * invGD * sq +
-                           invc2) +
-                   dw2 * (Complex(0, 2 * mF0 * pow2(invGD)) + 2 * invGD * sq +
-                          invc2))) /
-             (4 * sqrt_pi * invGD * mF0 * sq);
-    case CalcType::Voigt:
-      return -dZ * invGD *
-             (Complex(0, invGD) * dw1 * (dx - Complex(0, mF0)) + w1) /
-             (sqrt_pi * mF0);
-    case CalcType::LowXandHighY:
-      return -dZ *
-             (4 * pow2(invGD) * (w1 - w2) * sq +
-              1i * (4 * dw1 * pow3(invGD) * (dx - Complex(0, mF0)) * sq +
-                    dw2 * invc2 *
-                        (Complex(0, 2 * mF0 * pow2(invGD)) + 2 * invGD * sq +
-                         invc2))) /
-             (4 * sqrt_pi * invGD * mF0 * sq);
-    case CalcType::LowYandLowX:
-      return dZ * pow2(invc2) * (dw1 * sq - 1i * w1) / (sqrt_pi * sq);
-    case CalcType::LowYandHighX:
-      return -Complex(0, dZ) * pow2(invc2) * (x - 3) / (pi * pow3(x));
+  case CalcType::Full:
+    return -dZ *
+           (4 * pow2(invGD) * (w1 - w2) * sq +
+            1i * invc2 *
+                (-dw1 * (Complex(0, 2 * mF0 * pow2(invGD)) - 2 * invGD * sq +
+                         invc2) +
+                 dw2 * (Complex(0, 2 * mF0 * pow2(invGD)) + 2 * invGD * sq +
+                        invc2))) /
+           (4 * sqrt_pi * invGD * mF0 * sq);
+  case CalcType::Voigt:
+    return -dZ * invGD *
+           (Complex(0, invGD) * dw1 * (dx - Complex(0, mF0)) + w1) /
+           (sqrt_pi * mF0);
+  case CalcType::LowXandHighY:
+    return -dZ *
+           (4 * pow2(invGD) * (w1 - w2) * sq +
+            1i * (4 * dw1 * pow3(invGD) * (dx - Complex(0, mF0)) * sq +
+                  dw2 * invc2 *
+                      (Complex(0, 2 * mF0 * pow2(invGD)) + 2 * invGD * sq +
+                       invc2))) /
+           (4 * sqrt_pi * invGD * mF0 * sq);
+  case CalcType::LowYandLowX:
+    return dZ * pow2(invc2) * (dw1 * sq - 1i * w1) / (sqrt_pi * sq);
+  case CalcType::LowYandHighX:
+    return -Complex(0, dZ) * pow2(invc2) * (x - 3) / (pi * pow3(x));
   }
   return {};
 }
 
 Complex SpeedDependentVoigt::dFdVMR(const Output &d) const noexcept {
   switch (calcs) {
-    case CalcType::Full:
-      return (-4 * pow2(invGD) * (2 * d.D0 - 3 * d.D2) * (w1 - w2) * sq +
-              1i * invc2 *
-                  (dw1 *
-                       (-2 * pow2(invGD) * mF0 *
+  case CalcType::Full:
+    return (-4 * pow2(invGD) * (2 * d.D0 - 3 * d.D2) * (w1 - w2) * sq +
+            1i * invc2 *
+                (dw1 * (-2 * pow2(invGD) * mF0 *
                             (Complex(3 * d.G2 - 2 * d.G0, 3 * d.D2 - 2 * d.D0) +
                              2 * dx * invc2 * Complex(d.G2, d.D2)) +
                         4 * invGD * invc2 * mF0 * sq * Complex(d.G2, d.D2) -
                         2 * invGD * (2 * d.D0 - 3 * d.D2) * sq -
                         2 * pow2(invc2) * mF0 * Complex(d.G2, d.D2) +
                         invc2 * (2 * d.D0 - 3 * d.D2)) -
-                   dw2 *
-                       (-2 * pow2(invGD) * mF0 *
+                 dw2 * (-2 * pow2(invGD) * mF0 *
                             (Complex(3 * d.G2 - 2 * d.G0, 3 * d.D2 - 2 * d.D0) +
                              2 * dx * invc2 * Complex(d.G2, d.D2)) -
                         4 * invGD * invc2 * mF0 * sq * Complex(d.G2, d.D2) +
                         2 * invGD * (2 * d.D0 - 3 * d.D2) * sq -
                         2 * pow2(invc2) * mF0 * Complex(d.G2, d.D2) +
                         invc2 * (2 * d.D0 - 3 * d.D2)))) /
-             (8 * sqrt_pi * invGD * mF0 * sq);
-    case CalcType::Voigt:
-      return -invGD *
-             (Complex(0, invGD) * dw1 *
-                  (dx * (2 * d.D0 - 3 * d.D2) -
-                   mF0 * Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2)) +
-              w1 * (2 * d.D0 - 3 * d.D2)) /
-             (2 * sqrt_pi * mF0);
-    case CalcType::LowXandHighY:
-      return -(4 * pow2(invGD) * (2 * d.D0 - 3 * d.D2) * (w1 - w2) * sq +
-               1i * (4 * dw1 * pow3(invGD) * sq *
-                         (dx * (2 * d.D0 - 3 * d.D2) -
-                          mF0 * Complex(2 * d.G0 - 3 * d.G2,
-                                        2 * d.D0 - 3 * d.D2)) +
-                     dw2 * invc2 *
-                         (2 * pow2(invGD) * mF0 *
-                              (Complex(2 * d.G0 - 3 * d.G2,
-                                       2 * d.D0 - 3 * d.D2) -
-                               2 * dx * invc2 * Complex(d.G2, d.D2)) -
-                          4 * invGD * invc2 * mF0 * sq * Complex(d.G2, d.D2) +
-                          2 * invGD * (2 * d.D0 - 3 * d.D2) * sq -
-                          2 * pow2(invc2) * mF0 * Complex(d.G2, d.D2) +
-                          invc2 * (2 * d.D0 - 3 * d.D2)))) /
-             (8 * sqrt_pi * invGD * mF0 * sq);
-    case CalcType::LowYandLowX:
-      return pow2(invc2) *
-             (4 * sq * Complex(d.G2, d.D2) * (sqrt_pi * w1 * sq - 1) -
-              sqrt_pi * (1i * dw1 * sq + w1) *
-                  (Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) -
-                   2 * dx * invc2 * Complex(d.G2, d.D2))) /
-             (2 * pi * sq);
-    case CalcType::LowYandHighX:
-      return -pow2(invc2) *
-             (x * (2 * x - 3) * Complex(d.G2, d.D2) +
-              (x - 3) * (Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) -
-                         2 * dx * invc2 * Complex(d.G2, d.D2))) /
-             (2 * pi * pow3(x));
+           (8 * sqrt_pi * invGD * mF0 * sq);
+  case CalcType::Voigt:
+    return -invGD *
+           (Complex(0, invGD) * dw1 *
+                (dx * (2 * d.D0 - 3 * d.D2) -
+                 mF0 * Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2)) +
+            w1 * (2 * d.D0 - 3 * d.D2)) /
+           (2 * sqrt_pi * mF0);
+  case CalcType::LowXandHighY:
+    return -(4 * pow2(invGD) * (2 * d.D0 - 3 * d.D2) * (w1 - w2) * sq +
+             1i * (4 * dw1 * pow3(invGD) * sq *
+                       (dx * (2 * d.D0 - 3 * d.D2) -
+                        mF0 *
+                            Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2)) +
+                   dw2 * invc2 *
+                       (2 * pow2(invGD) * mF0 *
+                            (Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) -
+                             2 * dx * invc2 * Complex(d.G2, d.D2)) -
+                        4 * invGD * invc2 * mF0 * sq * Complex(d.G2, d.D2) +
+                        2 * invGD * (2 * d.D0 - 3 * d.D2) * sq -
+                        2 * pow2(invc2) * mF0 * Complex(d.G2, d.D2) +
+                        invc2 * (2 * d.D0 - 3 * d.D2)))) /
+           (8 * sqrt_pi * invGD * mF0 * sq);
+  case CalcType::LowYandLowX:
+    return pow2(invc2) *
+           (4 * sq * Complex(d.G2, d.D2) * (sqrt_pi * w1 * sq - 1) -
+            sqrt_pi * (1i * dw1 * sq + w1) *
+                (Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) -
+                 2 * dx * invc2 * Complex(d.G2, d.D2))) /
+           (2 * pi * sq);
+  case CalcType::LowYandHighX:
+    return -pow2(invc2) *
+           (x * (2 * x - 3) * Complex(d.G2, d.D2) +
+            (x - 3) * (Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) -
+                       2 * dx * invc2 * Complex(d.G2, d.D2))) /
+           (2 * pi * pow3(x));
   }
   return {};
 }
 
 Complex SpeedDependentVoigt::dFdT(const Output &d, Numeric T) const noexcept {
   switch (calcs) {
-    case CalcType::Full:
-      return (-pow2(invGD) * (w1 - w2) * sq *
-                  (T * (2 * d.D0 - 3 * d.D2) * sqrt_ln_2 - pow3(invGD) * mF0) *
-                  ln_16 +
-              1i * invc2 *
-                  (dw1 * (T * invGD * invc2 * mF0 * sq * Complex(d.G2, d.D2) *
-                              ln_16 -
-                          2 * invGD * sq *
-                              (T * (2 * d.D0 - 3 * d.D2) * sqrt_ln_2 -
-                               pow3(invGD) * mF0) *
-                              sqrt_ln_2 -
-                          (2 * T * pow2(invGD) * mF0 *
-                               (Complex(3 * d.G2 - 2 * d.G0,
-                                        3 * d.D2 - 2 * d.D0) +
-                                2 * dx * invc2 * Complex(d.G2, d.D2)) *
-                               sqrt_ln_2 +
-                           2 * T * pow2(invc2) * mF0 * Complex(d.G2, d.D2) *
-                               sqrt_ln_2 +
-                           invc2 * (T * (-2 * d.D0 + 3 * d.D2) * sqrt_ln_2 +
-                                    pow3(invGD) * mF0)) *
-                              sqrt_ln_2) +
-                   dw2 * (T * invGD * invc2 * mF0 * sq * Complex(d.G2, d.D2) *
-                              ln_16 +
-                          2 * invGD * sq *
-                              (T * (-2 * d.D0 + 3 * d.D2) * sqrt_ln_2 +
-                               pow3(invGD) * mF0) *
-                              sqrt_ln_2 +
-                          (-2 * T * pow2(invGD) * mF0 *
-                               (Complex(2 * d.G0 - 3 * d.G2,
-                                        2 * d.D0 - 3 * d.D2) -
-                                2 * dx * invc2 * Complex(d.G2, d.D2)) *
-                               sqrt_ln_2 +
-                           2 * T * pow2(invc2) * mF0 * Complex(d.G2, d.D2) *
-                               sqrt_ln_2 +
-                           invc2 * (T * (-2 * d.D0 + 3 * d.D2) * sqrt_ln_2 +
-                                    pow3(invGD) * mF0)) *
-                              sqrt_ln_2)) *
-                  sqrt_ln_2) /
-             (8 * sqrt_pi * T * invGD * mF0 * sq * pow3(sqrt_ln_2));
-    case CalcType::Voigt:
-      return -invGD *
-             (-Complex(0, invGD) * dw1 *
-                  (T * mF0 * Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) *
-                       sqrt_ln_2 -
-                   dx * (T * (2 * d.D0 - 3 * d.D2) * sqrt_ln_2 -
-                         pow3(invGD) * mF0)) +
-              w1 *
-                  (T * (2 * d.D0 - 3 * d.D2) * sqrt_ln_2 - pow3(invGD) * mF0)) /
-             (2 * sqrt_pi * T * mF0 * sqrt_ln_2);
-    case CalcType::LowXandHighY:
-      return (-pow2(invGD) * (w1 - w2) * sq *
-                  (T * (2 * d.D0 - 3 * d.D2) * sqrt_ln_2 - pow3(invGD) * mF0) *
-                  ln_16 +
-              1i * (dw1 * pow3(invGD) * sq *
-                        (T * mF0 *
-                             Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) *
-                             sqrt_ln_2 -
-                         dx * (T * (2 * d.D0 - 3 * d.D2) * sqrt_ln_2 -
-                               pow3(invGD) * mF0)) *
-                        ln_16 +
-                    dw2 * invc2 *
-                        (T * invGD * invc2 * mF0 * sq * Complex(d.G2, d.D2) *
-                             ln_16 +
-                         2 * invGD * sq *
-                             (T * (-2 * d.D0 + 3 * d.D2) * sqrt_ln_2 +
-                              pow3(invGD) * mF0) *
-                             sqrt_ln_2 +
-                         (-2 * T * pow2(invGD) * mF0 *
-                              (Complex(2 * d.G0 - 3 * d.G2,
-                                       2 * d.D0 - 3 * d.D2) -
-                               2 * dx * invc2 * Complex(d.G2, d.D2)) *
-                              sqrt_ln_2 +
-                          2 * T * pow2(invc2) * mF0 * Complex(d.G2, d.D2) *
-                              sqrt_ln_2 +
-                          invc2 * (T * (-2 * d.D0 + 3 * d.D2) * sqrt_ln_2 +
-                                   pow3(invGD) * mF0)) *
-                             sqrt_ln_2) *
-                        sqrt_ln_2)) /
-             (8 * sqrt_pi * T * invGD * mF0 * sq * pow3(sqrt_ln_2));
-    case CalcType::LowYandLowX:
-      return pow2(invc2) *
-             (4 * sq * Complex(d.G2, d.D2) * (sqrt_pi * w1 * sq - 1) -
-              sqrt_pi * (1i * dw1 * sq + w1) *
-                  (Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) -
-                   2 * dx * invc2 * Complex(d.G2, d.D2))) /
-             (2 * pi * sq);
-    case CalcType::LowYandHighX:
-      return -pow2(invc2) *
-             (x * (2 * x - 3) * Complex(d.G2, d.D2) +
-              (x - 3) * (Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) -
-                         2 * dx * invc2 * Complex(d.G2, d.D2))) /
-             (2 * pi * pow3(x));
+  case CalcType::Full:
+    return (-pow2(invGD) * (w1 - w2) * sq *
+                (T * (2 * d.D0 - 3 * d.D2) * sqrt_ln_2 - pow3(invGD) * mF0) *
+                ln_16 +
+            1i * invc2 *
+                (dw1 *
+                     (T * invGD * invc2 * mF0 * sq * Complex(d.G2, d.D2) *
+                          ln_16 -
+                      2 * invGD * sq *
+                          (T * (2 * d.D0 - 3 * d.D2) * sqrt_ln_2 -
+                           pow3(invGD) * mF0) *
+                          sqrt_ln_2 -
+                      (2 * T * pow2(invGD) * mF0 *
+                           (Complex(3 * d.G2 - 2 * d.G0, 3 * d.D2 - 2 * d.D0) +
+                            2 * dx * invc2 * Complex(d.G2, d.D2)) *
+                           sqrt_ln_2 +
+                       2 * T * pow2(invc2) * mF0 * Complex(d.G2, d.D2) *
+                           sqrt_ln_2 +
+                       invc2 * (T * (-2 * d.D0 + 3 * d.D2) * sqrt_ln_2 +
+                                pow3(invGD) * mF0)) *
+                          sqrt_ln_2) +
+                 dw2 *
+                     (T * invGD * invc2 * mF0 * sq * Complex(d.G2, d.D2) *
+                          ln_16 +
+                      2 * invGD * sq *
+                          (T * (-2 * d.D0 + 3 * d.D2) * sqrt_ln_2 +
+                           pow3(invGD) * mF0) *
+                          sqrt_ln_2 +
+                      (-2 * T * pow2(invGD) * mF0 *
+                           (Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) -
+                            2 * dx * invc2 * Complex(d.G2, d.D2)) *
+                           sqrt_ln_2 +
+                       2 * T * pow2(invc2) * mF0 * Complex(d.G2, d.D2) *
+                           sqrt_ln_2 +
+                       invc2 * (T * (-2 * d.D0 + 3 * d.D2) * sqrt_ln_2 +
+                                pow3(invGD) * mF0)) *
+                          sqrt_ln_2)) *
+                sqrt_ln_2) /
+           (8 * sqrt_pi * T * invGD * mF0 * sq * pow3(sqrt_ln_2));
+  case CalcType::Voigt:
+    return -invGD *
+           (-Complex(0, invGD) * dw1 *
+                (T * mF0 * Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) *
+                     sqrt_ln_2 -
+                 dx * (T * (2 * d.D0 - 3 * d.D2) * sqrt_ln_2 -
+                       pow3(invGD) * mF0)) +
+            w1 * (T * (2 * d.D0 - 3 * d.D2) * sqrt_ln_2 - pow3(invGD) * mF0)) /
+           (2 * sqrt_pi * T * mF0 * sqrt_ln_2);
+  case CalcType::LowXandHighY:
+    return (-pow2(invGD) * (w1 - w2) * sq *
+                (T * (2 * d.D0 - 3 * d.D2) * sqrt_ln_2 - pow3(invGD) * mF0) *
+                ln_16 +
+            1i * (dw1 * pow3(invGD) * sq *
+                      (T * mF0 *
+                           Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) *
+                           sqrt_ln_2 -
+                       dx * (T * (2 * d.D0 - 3 * d.D2) * sqrt_ln_2 -
+                             pow3(invGD) * mF0)) *
+                      ln_16 +
+                  dw2 * invc2 *
+                      (T * invGD * invc2 * mF0 * sq * Complex(d.G2, d.D2) *
+                           ln_16 +
+                       2 * invGD * sq *
+                           (T * (-2 * d.D0 + 3 * d.D2) * sqrt_ln_2 +
+                            pow3(invGD) * mF0) *
+                           sqrt_ln_2 +
+                       (-2 * T * pow2(invGD) * mF0 *
+                            (Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) -
+                             2 * dx * invc2 * Complex(d.G2, d.D2)) *
+                            sqrt_ln_2 +
+                        2 * T * pow2(invc2) * mF0 * Complex(d.G2, d.D2) *
+                            sqrt_ln_2 +
+                        invc2 * (T * (-2 * d.D0 + 3 * d.D2) * sqrt_ln_2 +
+                                 pow3(invGD) * mF0)) *
+                           sqrt_ln_2) *
+                      sqrt_ln_2)) /
+           (8 * sqrt_pi * T * invGD * mF0 * sq * pow3(sqrt_ln_2));
+  case CalcType::LowYandLowX:
+    return pow2(invc2) *
+           (4 * sq * Complex(d.G2, d.D2) * (sqrt_pi * w1 * sq - 1) -
+            sqrt_pi * (1i * dw1 * sq + w1) *
+                (Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) -
+                 2 * dx * invc2 * Complex(d.G2, d.D2))) /
+           (2 * pi * sq);
+  case CalcType::LowYandHighX:
+    return -pow2(invc2) *
+           (x * (2 * x - 3) * Complex(d.G2, d.D2) +
+            (x - 3) * (Complex(2 * d.G0 - 3 * d.G2, 2 * d.D0 - 3 * d.D2) -
+                       2 * dx * invc2 * Complex(d.G2, d.D2))) /
+           (2 * pi * pow3(x));
   }
   return {};
 }
@@ -421,68 +412,63 @@ constexpr Numeric abs_squared(Complex z) noexcept {
   return pow2(z.real()) + pow2(z.imag());
 }
 
-SpeedDependentVoigt::CalcType SpeedDependentVoigt::init(
-    const Complex c2) const noexcept {
-  if (abs_squared(c2) == 0) return CalcType::Voigt;
+SpeedDependentVoigt::CalcType
+SpeedDependentVoigt::init(const Complex c2) const noexcept {
+  if (abs_squared(c2) == 0)
+    return CalcType::Voigt;
   if (abs_squared(x) <= 9e-16 * abs_squared(sqrty * sqrty))
     return CalcType::LowXandHighY;
   if ((abs_squared(sqrty * sqrty) <= 1.e-30 * abs_squared(x)) and
       abs_squared(std::sqrt(x)) <= 16.e6)
-    return CalcType::LowYandLowX;  // Weird case, untested
+    return CalcType::LowYandLowX; // Weird case, untested
   if ((abs_squared(sqrty * sqrty) <= 1.e-30 * abs_squared(x)))
     return CalcType::LowYandHighX;
   return CalcType::Full;
 }
 
 void SpeedDependentVoigt::update_calcs() noexcept {
-  if (calcs not_eq CalcType::Voigt) calcs = init(Complex(1, 1));
+  if (calcs not_eq CalcType::Voigt)
+    calcs = init(Complex(1, 1));
 }
 
 void SpeedDependentVoigt::calc() noexcept {
   switch (calcs) {
-    case CalcType::Full:
-      sq = std::sqrt(x + sqrty * sqrty);
-      w1 = Faddeeva::w(1i * (sq - sqrty));
-      w2 = Faddeeva::w(1i * (sq + sqrty));
-      F = inv_sqrt_pi * invGD * (w1 - w2);
-      dw1 = 2i * (inv_sqrt_pi - (sq - sqrty) * w1);
-      dw2 = 2i * (inv_sqrt_pi - (sq + sqrty) * w2);
-      break;
-    case CalcType::Voigt:
-      w1 = Faddeeva::w(1i * dx * invGD);
-      F = inv_sqrt_pi * invGD * w1;
-      dw1 = 2i * (inv_sqrt_pi - dx * invGD * w1);
-      break;
-    case CalcType::LowXandHighY:
-      sq = std::sqrt(x + sqrty * sqrty);
-      w1 = Faddeeva::w(1i * dx * invGD);
-      w2 = Faddeeva::w(1i * (sq + sqrty));
-      F = inv_sqrt_pi * invGD * (w1 - w2);
-      dw1 = 2i * (inv_sqrt_pi - dx * invGD * w1);
-      dw2 = 2i * (inv_sqrt_pi - (sq + sqrty) * w2);
-      break;
-    case CalcType::LowYandLowX:
-      sq = std::sqrt(x);
-      w1 = Faddeeva::w(1i * sq);
-      F = 2 * inv_pi * invc2 * (1 - sqrt_pi * sq * w1);
-      dw1 = 2i * (inv_sqrt_pi - sq * w1);
-      break;
-    case CalcType::LowYandHighX:
-      F = inv_pi * invc2 * (1 / x - 1.5 / pow2(x));
-      break;
+  case CalcType::Full:
+    sq = std::sqrt(x + sqrty * sqrty);
+    w1 = Faddeeva::w(1i * (sq - sqrty));
+    w2 = Faddeeva::w(1i * (sq + sqrty));
+    F = inv_sqrt_pi * invGD * (w1 - w2);
+    dw1 = 2i * (inv_sqrt_pi - (sq - sqrty) * w1);
+    dw2 = 2i * (inv_sqrt_pi - (sq + sqrty) * w2);
+    break;
+  case CalcType::Voigt:
+    w1 = Faddeeva::w(1i * dx * invGD);
+    F = inv_sqrt_pi * invGD * w1;
+    dw1 = 2i * (inv_sqrt_pi - dx * invGD * w1);
+    break;
+  case CalcType::LowXandHighY:
+    sq = std::sqrt(x + sqrty * sqrty);
+    w1 = Faddeeva::w(1i * dx * invGD);
+    w2 = Faddeeva::w(1i * (sq + sqrty));
+    F = inv_sqrt_pi * invGD * (w1 - w2);
+    dw1 = 2i * (inv_sqrt_pi - dx * invGD * w1);
+    dw2 = 2i * (inv_sqrt_pi - (sq + sqrty) * w2);
+    break;
+  case CalcType::LowYandLowX:
+    sq = std::sqrt(x);
+    w1 = Faddeeva::w(1i * sq);
+    F = 2 * inv_pi * invc2 * (1 - sqrt_pi * sq * w1);
+    dw1 = 2i * (inv_sqrt_pi - sq * w1);
+    break;
+  case CalcType::LowYandHighX:
+    F = inv_pi * invc2 * (1 / x - 1.5 / pow2(x));
+    break;
   }
 }
 
-HartmannTran::HartmannTran(Numeric F0_noshift,
-                           const Output &ls,
-                           Numeric GD_div_F0,
-                           Numeric dZ) noexcept
-    : G0(ls.G0),
-      D0(ls.D0),
-      G2(ls.G2),
-      D2(ls.D2),
-      FVC(ls.FVC),
-      ETA(ls.ETA),
+HartmannTran::HartmannTran(Numeric F0_noshift, const Output &ls,
+                           Numeric GD_div_F0, Numeric dZ) noexcept
+    : G0(ls.G0), D0(ls.D0), G2(ls.G2), D2(ls.D2), FVC(ls.FVC), ETA(ls.ETA),
       mF0(F0_noshift + dZ + (1 - ls.ETA) * (ls.D0 - 1.5 * ls.D2)),
       invGD(sqrt_ln_2 / nonstd::abs(GD_div_F0 * mF0)),
       deltax(ls.FVC + (1 - ls.ETA) * (ls.G0 - 3 * ls.G2 / 2), mF0),
@@ -492,1222 +478,1262 @@ HartmannTran::HartmannTran(Numeric F0_noshift,
 
 Complex HartmannTran::dFdf() const noexcept {
   constexpr Complex ddeltax = -1i;
-  Complex dx = -ddeltax / ((ETA - 1) * Complex(G2, D2));
-  Complex dsqrtxy = dx / (2 * sqrtxy);
+  const Complex dx = -ddeltax / ((ETA - 1) * Complex(G2, D2));
+  const Complex dsqrtxy = dx / (2 * sqrtxy);
 
   switch (calcs) {
-    case CalcType::Full: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dsqrtxy;
-      Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
-      Complex dB =
-          sqrt_pi *
-          ((pow2(z1) - 1) * 1i * dw1 * dz1 - (pow2(z2) - 1) * 1i * dw2 * dz2 +
-           2 * w1 * z1 * dz1 - 2 * w2 * z2 * dz2) /
-          (2 * sqrty * (ETA - 1) * Complex(G2, D2));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tLowZ: {
-      Complex dz1 = invGD * ddeltax;
-      Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
-      Complex dB =
-          -invGD *
-          (sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
-           dz1);
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tHighZ: {
-      Complex dz1 = invGD * ddeltax;
-      Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
-      Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
-                   invGD * dz1 / (2 * pow2(z1)) +
-                   9 * invGD * dz1 / (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowXandHighY: {
-      Complex dz1 = invGD * ddeltax;
-      Complex dz2 = dsqrtxy;
-      Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
-      Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
-                   invGD * dz1 / (2 * pow2(z1)) +
-                   9 * invGD * dz1 / (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandLowX: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dx / (2 * sqrtx);
-      Complex dA = 2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) /
-                   ((ETA - 1) * Complex(G2, D2));
-      Complex dB =
-          -(2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
-                (2 * pow2(sqrty) + x - 1) +
-            2 * sqrt_pi * w1 * dz1 + Complex(0, 2 * sqrt_pi) * z1 * dw1 * dz1 +
-            2 * (sqrt_pi * w2 * z2 - 1) * dx) /
-          ((ETA - 1) * Complex(G2, D2));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandHighX: {
-      Complex dz1 = dsqrtxy;
-      Complex dA = (x - 3) * dx / ((ETA - 1) * Complex(G2, D2) * pow3(x));
-      Complex dB = (-2 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) -
-                    (x - 3) * (2 * pow2(sqrty) + x - 1) * dx +
-                    (2 * x - 3) * x * dx / 2) /
-                   ((ETA - 1) * Complex(G2, D2) * pow3(x));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
+  case CalcType::Full: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dsqrtxy;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
+    const Complex dB =
+        sqrt_pi *
+        ((pow2(z1) - 1) * 1i * dw1 * dz1 - (pow2(z2) - 1) * 1i * dw2 * dz2 +
+         2 * w1 * z1 * dz1 - 2 * w2 * z2 * dz2) /
+        (2 * sqrty * (ETA - 1) * Complex(G2, D2));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tLowZ: {
+    const Complex dz1 = invGD * ddeltax;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
+    const Complex dB =
+        -invGD *
+        (sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) - dz1);
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tHighZ: {
+    const Complex dz1 = invGD * ddeltax;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
+    const Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
+                       invGD * dz1 / (2 * pow2(z1)) +
+                       9 * invGD * dz1 / (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowXandHighY: {
+    const Complex dz1 = invGD * ddeltax;
+    const Complex dz2 = dsqrtxy;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
+    const Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
+                       invGD * dz1 / (2 * pow2(z1)) +
+                       9 * invGD * dz1 / (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandLowX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dx / (2 * sqrtx);
+    const Complex dA = 2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) /
+                       ((ETA - 1) * Complex(G2, D2));
+    const Complex dB =
+        -(2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
+              (2 * pow2(sqrty) + x - 1) +
+          2 * sqrt_pi * w1 * dz1 + Complex(0, 2 * sqrt_pi) * z1 * dw1 * dz1 +
+          2 * (sqrt_pi * w2 * z2 - 1) * dx) /
+        ((ETA - 1) * Complex(G2, D2));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandHighX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dA = (x - 3) * dx / ((ETA - 1) * Complex(G2, D2) * pow3(x));
+    const Complex dB =
+        (-2 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) -
+         (x - 3) * (2 * pow2(sqrty) + x - 1) * dx + (2 * x - 3) * x * dx / 2) /
+        ((ETA - 1) * Complex(G2, D2) * pow3(x));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
   }
   return {};
 }
 
 Complex HartmannTran::dFdF0() const noexcept {
-  Numeric dGD = (1 / (invGD * mF0));
-  Numeric dinvGD = -dGD * pow2(invGD);
-  Complex dsqrty = dinvGD / (2 * (ETA - 1) * Complex(G2, D2) * pow2(invGD));
+  const Numeric dGD = (1 / (invGD * mF0));
+  const Numeric dinvGD = -dGD * pow2(invGD);
+  const Complex dsqrty =
+      dinvGD / (2 * (ETA - 1) * Complex(G2, D2) * pow2(invGD));
   constexpr Complex ddeltax = 1i;
-  Complex dx = -ddeltax / ((ETA - 1) * Complex(G2, D2));
-  Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
+  const Complex dx = -ddeltax / ((ETA - 1) * Complex(G2, D2));
+  const Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
 
   switch (calcs) {
-    case CalcType::Full: {
-      Complex dz1 = dsqrtxy - dsqrty;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB =
-          sqrt_pi *
-          ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
-           ((pow2(z1) - 1) * 1i * dw1 * dz1 - (pow2(z2) - 1) * 1i * dw2 * dz2 +
-            2 * w1 * z1 * dz1 - 2 * w2 * z2 * dz2) *
-               sqrty) /
-          (2 * (ETA - 1) * Complex(G2, D2) * pow2(sqrty));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tLowZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
-            dz1) *
-              invGD -
-          (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tHighZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowXandHighY: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandLowX: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dx / (2 * sqrtx);
-      Complex dA = 2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) /
-                   ((ETA - 1) * Complex(G2, D2));
-      Complex dB =
-          -(2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
-                (2 * pow2(sqrty) + x - 1) +
-            2 * sqrt_pi * w1 * dz1 + Complex(0, 2 * sqrt_pi) * z1 * dw1 * dz1 +
-            2 * (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) /
-          ((ETA - 1) * Complex(G2, D2));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandHighX: {
-      Complex dz1 = dsqrtxy;
-      Complex dA = (x - 3) * dx / ((ETA - 1) * Complex(G2, D2) * pow3(x));
-      Complex dB = (-2 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
-                    (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x / 2 -
-                    (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) /
-                   ((ETA - 1) * Complex(G2, D2) * pow3(x));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
+  case CalcType::Full: {
+    const Complex dz1 = dsqrtxy - dsqrty;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        sqrt_pi *
+        ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
+         ((pow2(z1) - 1) * 1i * dw1 * dz1 - (pow2(z2) - 1) * 1i * dw2 * dz2 +
+          2 * w1 * z1 * dz1 - 2 * w2 * z2 * dz2) *
+             sqrty) /
+        (2 * (ETA - 1) * Complex(G2, D2) * pow2(sqrty));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tLowZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
+          dz1) *
+            invGD -
+        (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tHighZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowXandHighY: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandLowX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dx / (2 * sqrtx);
+    const Complex dA = 2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) /
+                       ((ETA - 1) * Complex(G2, D2));
+    const Complex dB =
+        -(2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
+              (2 * pow2(sqrty) + x - 1) +
+          2 * sqrt_pi * w1 * dz1 + Complex(0, 2 * sqrt_pi) * z1 * dw1 * dz1 +
+          2 * (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) /
+        ((ETA - 1) * Complex(G2, D2));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandHighX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dA = (x - 3) * dx / ((ETA - 1) * Complex(G2, D2) * pow3(x));
+    const Complex dB =
+        (-2 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
+         (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x / 2 -
+         (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) /
+        ((ETA - 1) * Complex(G2, D2) * pow3(x));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
   }
   return {};
 }
 
 Complex HartmannTran::dFdD0(Numeric dD0) const noexcept {
-  Numeric dmF0 = (1 - ETA) * dD0;
-  Numeric dGD = (dmF0 / (invGD * mF0));
-  Numeric dinvGD = -dGD * pow2(invGD);
-  Complex dsqrty = dinvGD / (2 * (ETA - 1) * Complex(G2, D2) * pow2(invGD));
-  Complex ddeltax = Complex(0, 1 - ETA) * dD0;
-  Complex dx = -ddeltax / ((ETA - 1) * Complex(G2, D2));
-  Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
+  const Numeric dmF0 = (1 - ETA) * dD0;
+  const Numeric dGD = (dmF0 / (invGD * mF0));
+  const Numeric dinvGD = -dGD * pow2(invGD);
+  const Complex dsqrty =
+      dinvGD / (2 * (ETA - 1) * Complex(G2, D2) * pow2(invGD));
+  const Complex ddeltax = Complex(0, 1 - ETA) * dD0;
+  const Complex dx = -ddeltax / ((ETA - 1) * Complex(G2, D2));
+  const Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
 
   switch (calcs) {
-    case CalcType::Full: {
-      Complex dz1 = dsqrtxy - dsqrty;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB =
-          sqrt_pi *
-          ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
-           ((pow2(z1) - 1) * 1i * dw1 * dz1 - (pow2(z2) - 1) * 1i * dw2 * dz2 +
-            2 * w1 * z1 * dz1 - 2 * w2 * z2 * dz2) *
-               sqrty) /
-          (2 * (ETA - 1) * Complex(G2, D2) * pow2(sqrty));
-      Complex dK = ETA * Complex(G2, D2) * dB + Complex(0, ETA * dD0) * A +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tLowZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
-            dz1) *
-              invGD -
-          (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
-      Complex dK = ETA * Complex(G2, D2) * dB + Complex(0, ETA * dD0) * A +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tHighZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB + Complex(0, ETA * dD0) * A +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowXandHighY: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB + Complex(0, ETA * dD0) * A +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandLowX: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dx / (2 * sqrtx);
-      Complex dA = 2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) /
-                   ((ETA - 1) * Complex(G2, D2));
-      Complex dB =
-          -(2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
-                (2 * pow2(sqrty) + x - 1) +
-            2 * sqrt_pi * w1 * dz1 + Complex(0, 2 * sqrt_pi) * z1 * dw1 * dz1 +
-            2 * (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) /
-          ((ETA - 1) * Complex(G2, D2));
-      Complex dK = ETA * Complex(G2, D2) * dB + Complex(0, ETA * dD0) * A +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandHighX: {
-      Complex dz1 = dsqrtxy;
-      Complex dA = (x - 3) * dx / ((ETA - 1) * Complex(G2, D2) * pow3(x));
-      Complex dB = (-2 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
-                    (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x / 2 -
-                    (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) /
-                   ((ETA - 1) * Complex(G2, D2) * pow3(x));
-      Complex dK = ETA * Complex(G2, D2) * dB + Complex(0, ETA * dD0) * A +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
+  case CalcType::Full: {
+    const Complex dz1 = dsqrtxy - dsqrty;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        sqrt_pi *
+        ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
+         ((pow2(z1) - 1) * 1i * dw1 * dz1 - (pow2(z2) - 1) * 1i * dw2 * dz2 +
+          2 * w1 * z1 * dz1 - 2 * w2 * z2 * dz2) *
+             sqrty) /
+        (2 * (ETA - 1) * Complex(G2, D2) * pow2(sqrty));
+    const Complex dK = ETA * Complex(G2, D2) * dB + Complex(0, ETA * dD0) * A +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tLowZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
+          dz1) *
+            invGD -
+        (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
+    const Complex dK = ETA * Complex(G2, D2) * dB + Complex(0, ETA * dD0) * A +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tHighZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB + Complex(0, ETA * dD0) * A +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowXandHighY: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB + Complex(0, ETA * dD0) * A +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandLowX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dx / (2 * sqrtx);
+    const Complex dA = 2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) /
+                       ((ETA - 1) * Complex(G2, D2));
+    const Complex dB =
+        -(2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
+              (2 * pow2(sqrty) + x - 1) +
+          2 * sqrt_pi * w1 * dz1 + Complex(0, 2 * sqrt_pi) * z1 * dw1 * dz1 +
+          2 * (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) /
+        ((ETA - 1) * Complex(G2, D2));
+    const Complex dK = ETA * Complex(G2, D2) * dB + Complex(0, ETA * dD0) * A +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandHighX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dA = (x - 3) * dx / ((ETA - 1) * Complex(G2, D2) * pow3(x));
+    const Complex dB =
+        (-2 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
+         (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x / 2 -
+         (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) /
+        ((ETA - 1) * Complex(G2, D2) * pow3(x));
+    const Complex dK = ETA * Complex(G2, D2) * dB + Complex(0, ETA * dD0) * A +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
   }
   return {};
 }
 
 Complex HartmannTran::dFdG0(Numeric dG0) const noexcept {
-  Numeric ddeltax = (1 - ETA) * dG0;
-  Complex dx = -ddeltax / ((ETA - 1) * Complex(G2, D2));
-  Complex dsqrtxy = dx / (2 * sqrtxy);
+  const Numeric ddeltax = (1 - ETA) * dG0;
+  const Complex dx = -ddeltax / ((ETA - 1) * Complex(G2, D2));
+  const Complex dsqrtxy = dx / (2 * sqrtxy);
 
   switch (calcs) {
-    case CalcType::Full: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dsqrtxy;
-      Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
-      Complex dB =
-          sqrt_pi *
-          ((pow2(z1) - 1) * 1i * dw1 * dz1 - (pow2(z2) - 1) * 1i * dw2 * dz2 +
-           2 * w1 * z1 * dz1 - 2 * w2 * z2 * dz2) /
-          (2 * sqrty * (ETA - 1) * Complex(G2, D2));
-      Complex dK = ETA * Complex(G2, D2) * dB + ETA * A * dG0 +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tLowZ: {
-      Complex dz1 = invGD * ddeltax;
-      Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
-      Complex dB =
-          -invGD *
-          (sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
-           dz1);
-      Complex dK = ETA * Complex(G2, D2) * dB + ETA * A * dG0 +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tHighZ: {
-      Complex dz1 = invGD * ddeltax;
-      Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
-      Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
-                   invGD * dz1 / (2 * pow2(z1)) +
-                   9 * invGD * dz1 / (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB + ETA * A * dG0 +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowXandHighY: {
-      Complex dz1 = invGD * ddeltax;
-      Complex dz2 = dsqrtxy;
-      Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
-      Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
-                   invGD * dz1 / (2 * pow2(z1)) +
-                   9 * invGD * dz1 / (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB + ETA * A * dG0 +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandLowX: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dx / (2 * sqrtx);
-      Complex dA = 2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) /
-                   ((ETA - 1) * Complex(G2, D2));
-      Complex dB =
-          -(2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
-                (2 * pow2(sqrty) + x - 1) +
-            2 * sqrt_pi * w1 * dz1 + Complex(0, 2 * sqrt_pi) * z1 * dw1 * dz1 +
-            2 * (sqrt_pi * w2 * z2 - 1) * dx) /
-          ((ETA - 1) * Complex(G2, D2));
-      Complex dK = ETA * Complex(G2, D2) * dB + ETA * A * dG0 +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandHighX: {
-      Complex dz1 = dsqrtxy;
-      Complex dA = (x - 3) * dx / ((ETA - 1) * Complex(G2, D2) * pow3(x));
-      Complex dB = (-2 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) -
-                    (x - 3) * (2 * pow2(sqrty) + x - 1) * dx +
-                    (2 * x - 3) * x * dx / 2) /
-                   ((ETA - 1) * Complex(G2, D2) * pow3(x));
-      Complex dK = ETA * Complex(G2, D2) * dB + ETA * A * dG0 +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
+  case CalcType::Full: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dsqrtxy;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
+    const Complex dB =
+        sqrt_pi *
+        ((pow2(z1) - 1) * 1i * dw1 * dz1 - (pow2(z2) - 1) * 1i * dw2 * dz2 +
+         2 * w1 * z1 * dz1 - 2 * w2 * z2 * dz2) /
+        (2 * sqrty * (ETA - 1) * Complex(G2, D2));
+    const Complex dK = ETA * Complex(G2, D2) * dB + ETA * A * dG0 +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tLowZ: {
+    const Complex dz1 = invGD * ddeltax;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
+    const Complex dB =
+        -invGD *
+        (sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) - dz1);
+    const Complex dK = ETA * Complex(G2, D2) * dB + ETA * A * dG0 +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tHighZ: {
+    const Complex dz1 = invGD * ddeltax;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
+    const Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
+                       invGD * dz1 / (2 * pow2(z1)) +
+                       9 * invGD * dz1 / (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB + ETA * A * dG0 +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowXandHighY: {
+    const Complex dz1 = invGD * ddeltax;
+    const Complex dz2 = dsqrtxy;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
+    const Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
+                       invGD * dz1 / (2 * pow2(z1)) +
+                       9 * invGD * dz1 / (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB + ETA * A * dG0 +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandLowX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dx / (2 * sqrtx);
+    const Complex dA = 2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) /
+                       ((ETA - 1) * Complex(G2, D2));
+    const Complex dB =
+        -(2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
+              (2 * pow2(sqrty) + x - 1) +
+          2 * sqrt_pi * w1 * dz1 + Complex(0, 2 * sqrt_pi) * z1 * dw1 * dz1 +
+          2 * (sqrt_pi * w2 * z2 - 1) * dx) /
+        ((ETA - 1) * Complex(G2, D2));
+    const Complex dK = ETA * Complex(G2, D2) * dB + ETA * A * dG0 +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandHighX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dA = (x - 3) * dx / ((ETA - 1) * Complex(G2, D2) * pow3(x));
+    const Complex dB =
+        (-2 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) -
+         (x - 3) * (2 * pow2(sqrty) + x - 1) * dx + (2 * x - 3) * x * dx / 2) /
+        ((ETA - 1) * Complex(G2, D2) * pow3(x));
+    const Complex dK = ETA * Complex(G2, D2) * dB + ETA * A * dG0 +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
   }
   return {};
 }
 
 Complex HartmannTran::dFdD2(Numeric dD2) const noexcept {
-  Numeric dmF0 = -3 * (1 - ETA) * dD2 / 2;
-  Numeric dGD = (dmF0 / (invGD * mF0));
-  Numeric dinvGD = -dGD * pow2(invGD);
-  Complex dsqrty = (Complex(G2, D2) * dinvGD + Complex(0, invGD) * dD2) /
-                   (2 * (ETA - 1) * pow2(Complex(G2, D2)) * pow2(invGD));
-  Complex ddeltax = 1.5 * Complex(0, ETA - 1) * dD2;
-  Complex dx = (-Complex(G2, D2) * ddeltax + Complex(0, dD2) * deltax) /
-               ((ETA - 1) * pow2(Complex(G2, D2)));
-  Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
+  const Numeric dmF0 = -3 * (1 - ETA) * dD2 / 2;
+  const Numeric dGD = (dmF0 / (invGD * mF0));
+  const Numeric dinvGD = -dGD * pow2(invGD);
+  const Complex dsqrty = (Complex(G2, D2) * dinvGD + Complex(0, invGD) * dD2) /
+                         (2 * (ETA - 1) * pow2(Complex(G2, D2)) * pow2(invGD));
+  const Complex ddeltax = 1.5 * Complex(0, ETA - 1) * dD2;
+  const Complex dx = (-Complex(G2, D2) * ddeltax + Complex(0, dD2) * deltax) /
+                     ((ETA - 1) * pow2(Complex(G2, D2)));
+  const Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
 
   switch (calcs) {
-    case CalcType::Full: {
-      Complex dz1 = dsqrtxy - dsqrty;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB = (sqrt_pi * Complex(G2, D2) *
-                        ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
-                         ((pow2(z1) - 1) * 1i * dw1 * dz1 -
-                          (pow2(z2) - 1) * 1i * dw2 * dz2 + 2 * w1 * z1 * dz1 -
-                          2 * w2 * z2 * dz2) *
-                             sqrty) -
-                    1i *
-                        (sqrt_pi * (pow2(z1) - 1) * w1 -
-                         sqrt_pi * (pow2(z2) - 1) * w2 + 2 * sqrty) *
-                        sqrty * dD2) /
-                   (2 * (ETA - 1) * pow2(Complex(G2, D2)) * pow2(sqrty));
-      Complex dK = ETA * Complex(G2, D2) * dB -
-                   Complex(0, 1.5 * dD2 * ETA) * A + Complex(0, dD2 * ETA) * B +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tLowZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
-            dz1) *
-              invGD -
-          (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
-      Complex dK = ETA * Complex(G2, D2) * dB -
-                   Complex(0, 1.5 * dD2 * ETA) * A + Complex(0, dD2 * ETA) * B +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tHighZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB -
-                   Complex(0, 1.5 * dD2 * ETA) * A + Complex(0, dD2 * ETA) * B +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowXandHighY: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB -
-                   Complex(0, 1.5 * dD2 * ETA) * A + Complex(0, dD2 * ETA) * B +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandLowX: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dx / (2 * sqrtx);
-      Complex dA =
-          2 *
-          (sqrt_pi * Complex(G2, D2) * (w2 * dz2 + z2 * 1i * dw2 * dz2) -
-           1i * (sqrt_pi * w2 * z2 - 1) * dD2) /
-          ((ETA - 1) * pow2(Complex(G2, D2)));
-      Complex dB =
-          (-2 * Complex(G2, D2) *
-               (sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
-                    (2 * pow2(sqrty) + x - 1) +
-                sqrt_pi * w1 * dz1 + Complex(0, sqrt_pi) * z1 * dw1 * dz1 +
-                (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) +
-           1i *
-               (2 * sqrt_pi * w1 * z1 +
-                2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1) *
-               dD2) /
-          ((ETA - 1) * pow2(Complex(G2, D2)));
-      Complex dK = ETA * Complex(G2, D2) * dB -
-                   Complex(0, 1.5 * dD2 * ETA) * A + Complex(0, dD2 * ETA) * B +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandHighX: {
-      Complex dz1 = dsqrtxy;
-      Complex dA =
-          (Complex(G2, D2) * (x - 3) * dx + 1i * (2 * x - 3) * x * dD2 / 2) /
-          ((ETA - 1) * pow2(Complex(G2, D2)) * pow3(x));
-      Complex dB =
-          (Complex(G2, D2) *
-               (-4 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
-                (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x -
-                2 * (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) -
-           1i *
-               (2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
-                (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
-               x * dD2) /
-          (2 * (ETA - 1) * pow2(Complex(G2, D2)) * pow3(x));
-      Complex dK = ETA * Complex(G2, D2) * dB -
-                   Complex(0, 1.5 * dD2 * ETA) * A + Complex(0, dD2 * ETA) * B +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
+  case CalcType::Full: {
+    const Complex dz1 = dsqrtxy - dsqrty;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        (sqrt_pi * Complex(G2, D2) *
+             ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
+              ((pow2(z1) - 1) * 1i * dw1 * dz1 -
+               (pow2(z2) - 1) * 1i * dw2 * dz2 + 2 * w1 * z1 * dz1 -
+               2 * w2 * z2 * dz2) *
+                  sqrty) -
+         1i *
+             (sqrt_pi * (pow2(z1) - 1) * w1 - sqrt_pi * (pow2(z2) - 1) * w2 +
+              2 * sqrty) *
+             sqrty * dD2) /
+        (2 * (ETA - 1) * pow2(Complex(G2, D2)) * pow2(sqrty));
+    const Complex dK = ETA * Complex(G2, D2) * dB -
+                       Complex(0, 1.5 * dD2 * ETA) * A +
+                       Complex(0, dD2 * ETA) * B +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tLowZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
+          dz1) *
+            invGD -
+        (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
+    const Complex dK = ETA * Complex(G2, D2) * dB -
+                       Complex(0, 1.5 * dD2 * ETA) * A +
+                       Complex(0, dD2 * ETA) * B +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tHighZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB -
+                       Complex(0, 1.5 * dD2 * ETA) * A +
+                       Complex(0, dD2 * ETA) * B +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowXandHighY: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB -
+                       Complex(0, 1.5 * dD2 * ETA) * A +
+                       Complex(0, dD2 * ETA) * B +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandLowX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dx / (2 * sqrtx);
+    const Complex dA =
+        2 *
+        (sqrt_pi * Complex(G2, D2) * (w2 * dz2 + z2 * 1i * dw2 * dz2) -
+         1i * (sqrt_pi * w2 * z2 - 1) * dD2) /
+        ((ETA - 1) * pow2(Complex(G2, D2)));
+    const Complex dB =
+        (-2 * Complex(G2, D2) *
+             (sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
+                  (2 * pow2(sqrty) + x - 1) +
+              sqrt_pi * w1 * dz1 + Complex(0, sqrt_pi) * z1 * dw1 * dz1 +
+              (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) +
+         1i *
+             (2 * sqrt_pi * w1 * z1 +
+              2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1) *
+             dD2) /
+        ((ETA - 1) * pow2(Complex(G2, D2)));
+    const Complex dK = ETA * Complex(G2, D2) * dB -
+                       Complex(0, 1.5 * dD2 * ETA) * A +
+                       Complex(0, dD2 * ETA) * B +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandHighX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dA =
+        (Complex(G2, D2) * (x - 3) * dx + 1i * (2 * x - 3) * x * dD2 / 2) /
+        ((ETA - 1) * pow2(Complex(G2, D2)) * pow3(x));
+    const Complex dB =
+        (Complex(G2, D2) *
+             (-4 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
+              (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x -
+              2 * (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) -
+         1i *
+             (2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
+              (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
+             x * dD2) /
+        (2 * (ETA - 1) * pow2(Complex(G2, D2)) * pow3(x));
+    const Complex dK = ETA * Complex(G2, D2) * dB -
+                       Complex(0, 1.5 * dD2 * ETA) * A +
+                       Complex(0, dD2 * ETA) * B +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
   }
   return {};
 }
 
 Complex HartmannTran::dFdG2(Numeric dG2) const noexcept {
-  Complex dsqrty = dG2 / (2 * invGD * (ETA - 1) * pow2(Complex(G2, D2)));
-  Numeric ddeltax = 3 * (ETA - 1) * dG2 / 2;
-  Complex dx = (-Complex(G2, D2) * ddeltax + deltax * dG2) /
-               ((ETA - 1) * pow2(Complex(G2, D2)));
-  Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
+  const Complex dsqrty = dG2 / (2 * invGD * (ETA - 1) * pow2(Complex(G2, D2)));
+  const Numeric ddeltax = 3 * (ETA - 1) * dG2 / 2;
+  const Complex dx = (-Complex(G2, D2) * ddeltax + deltax * dG2) /
+                     ((ETA - 1) * pow2(Complex(G2, D2)));
+  const Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
 
   switch (calcs) {
-    case CalcType::Full: {
-      Complex dz1 = dsqrtxy - dsqrty;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
-      Complex dB = (sqrt_pi * Complex(G2, D2) *
-                        ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
-                         ((pow2(z1) - 1) * 1i * dw1 * dz1 -
-                          (pow2(z2) - 1) * 1i * dw2 * dz2 + 2 * w1 * z1 * dz1 -
-                          2 * w2 * z2 * dz2) *
-                             sqrty) -
-                    (sqrt_pi * (pow2(z1) - 1) * w1 -
-                     sqrt_pi * (pow2(z2) - 1) * w2 + 2 * sqrty) *
-                        sqrty * dG2) /
-                   (2 * (ETA - 1) * pow2(Complex(G2, D2)) * pow2(sqrty));
-      Complex dK = ETA * Complex(G2, D2) * dB - 3 * ETA * A * dG2 / 2 +
-                   ETA * B * dG2 +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tLowZ: {
-      Complex dz1 = invGD * ddeltax;
-      Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
-      Complex dB =
-          -invGD *
-          (sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
-           dz1);
-      Complex dK = ETA * Complex(G2, D2) * dB - 3 * ETA * A * dG2 / 2 +
-                   ETA * B * dG2 +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tHighZ: {
-      Complex dz1 = invGD * ddeltax;
-      Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
-      Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
-                   invGD * dz1 / (2 * pow2(z1)) +
-                   9 * invGD * dz1 / (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB - 3 * ETA * A * dG2 / 2 +
-                   ETA * B * dG2 +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowXandHighY: {
-      Complex dz1 = invGD * ddeltax;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
-      Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
-                   invGD * dz1 / (2 * pow2(z1)) +
-                   9 * invGD * dz1 / (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB - 3 * ETA * A * dG2 / 2 +
-                   ETA * B * dG2 +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandLowX: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dx / (2 * sqrtx);
-      Complex dA =
-          2 *
-          (sqrt_pi * Complex(G2, D2) * (w2 * dz2 + z2 * 1i * dw2 * dz2) -
-           (sqrt_pi * w2 * z2 - 1) * dG2) /
-          ((ETA - 1) * pow2(Complex(G2, D2)));
-      Complex dB =
-          (-2 * Complex(G2, D2) *
-               (sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
-                    (2 * pow2(sqrty) + x - 1) +
-                sqrt_pi * w1 * dz1 + Complex(0, sqrt_pi) * z1 * dw1 * dz1 +
-                (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) +
-           (2 * sqrt_pi * w1 * z1 +
-            2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1) *
-               dG2) /
-          ((ETA - 1) * pow2(Complex(G2, D2)));
-      Complex dK = ETA * Complex(G2, D2) * dB - 3 * ETA * A * dG2 / 2 +
-                   ETA * B * dG2 +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandHighX: {
-      Complex dz1 = dsqrtxy;
-      Complex dA =
-          (Complex(G2, D2) * (x - 3) * dx + (2 * x - 3) * x * dG2 / 2) /
-          ((ETA - 1) * pow2(Complex(G2, D2)) * pow3(x));
-      Complex dB =
-          (Complex(G2, D2) *
-               (-4 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
-                (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x -
-                2 * (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) -
-           (2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
-            (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
-               x * dG2) /
-          (2 * (ETA - 1) * pow2(Complex(G2, D2)) * pow3(x));
-      Complex dK = ETA * Complex(G2, D2) * dB - 3 * ETA * A * dG2 / 2 +
-                   ETA * B * dG2 +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
+  case CalcType::Full: {
+    const Complex dz1 = dsqrtxy - dsqrty;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
+    const Complex dB =
+        (sqrt_pi * Complex(G2, D2) *
+             ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
+              ((pow2(z1) - 1) * 1i * dw1 * dz1 -
+               (pow2(z2) - 1) * 1i * dw2 * dz2 + 2 * w1 * z1 * dz1 -
+               2 * w2 * z2 * dz2) *
+                  sqrty) -
+         (sqrt_pi * (pow2(z1) - 1) * w1 - sqrt_pi * (pow2(z2) - 1) * w2 +
+          2 * sqrty) *
+             sqrty * dG2) /
+        (2 * (ETA - 1) * pow2(Complex(G2, D2)) * pow2(sqrty));
+    const Complex dK = ETA * Complex(G2, D2) * dB - 3 * ETA * A * dG2 / 2 +
+                       ETA * B * dG2 +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tLowZ: {
+    const Complex dz1 = invGD * ddeltax;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
+    const Complex dB =
+        -invGD *
+        (sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) - dz1);
+    const Complex dK = ETA * Complex(G2, D2) * dB - 3 * ETA * A * dG2 / 2 +
+                       ETA * B * dG2 +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tHighZ: {
+    const Complex dz1 = invGD * ddeltax;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
+    const Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
+                       invGD * dz1 / (2 * pow2(z1)) +
+                       9 * invGD * dz1 / (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB - 3 * ETA * A * dG2 / 2 +
+                       ETA * B * dG2 +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowXandHighY: {
+    const Complex dz1 = invGD * ddeltax;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
+    const Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
+                       invGD * dz1 / (2 * pow2(z1)) +
+                       9 * invGD * dz1 / (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB - 3 * ETA * A * dG2 / 2 +
+                       ETA * B * dG2 +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandLowX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dx / (2 * sqrtx);
+    const Complex dA =
+        2 *
+        (sqrt_pi * Complex(G2, D2) * (w2 * dz2 + z2 * 1i * dw2 * dz2) -
+         (sqrt_pi * w2 * z2 - 1) * dG2) /
+        ((ETA - 1) * pow2(Complex(G2, D2)));
+    const Complex dB =
+        (-2 * Complex(G2, D2) *
+             (sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
+                  (2 * pow2(sqrty) + x - 1) +
+              sqrt_pi * w1 * dz1 + Complex(0, sqrt_pi) * z1 * dw1 * dz1 +
+              (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) +
+         (2 * sqrt_pi * w1 * z1 +
+          2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1) *
+             dG2) /
+        ((ETA - 1) * pow2(Complex(G2, D2)));
+    const Complex dK = ETA * Complex(G2, D2) * dB - 3 * ETA * A * dG2 / 2 +
+                       ETA * B * dG2 +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandHighX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dA =
+        (Complex(G2, D2) * (x - 3) * dx + (2 * x - 3) * x * dG2 / 2) /
+        ((ETA - 1) * pow2(Complex(G2, D2)) * pow3(x));
+    const Complex dB =
+        (Complex(G2, D2) *
+             (-4 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
+              (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x -
+              2 * (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) -
+         (2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
+          (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
+             x * dG2) /
+        (2 * (ETA - 1) * pow2(Complex(G2, D2)) * pow3(x));
+    const Complex dK = ETA * Complex(G2, D2) * dB - 3 * ETA * A * dG2 / 2 +
+                       ETA * B * dG2 +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
   }
   return {};
 }
 
 Complex HartmannTran::dFdFVC(Numeric dFVC) const noexcept {
-  Numeric ddeltax = dFVC;
-  Complex dx = -ddeltax / ((ETA - 1) * Complex(G2, D2));
-  Complex dsqrtxy = dx / (2 * sqrtxy);
+  const Numeric ddeltax = dFVC;
+  const Complex dx = -ddeltax / ((ETA - 1) * Complex(G2, D2));
+  const Complex dsqrtxy = dx / (2 * sqrtxy);
 
   switch (calcs) {
-    case CalcType::Full: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dsqrtxy;
-      Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
-      Complex dB =
-          sqrt_pi *
-          ((pow2(z1) - 1) * 1i * dw1 * dz1 - (pow2(z2) - 1) * 1i * dw2 * dz2 +
-           2 * w1 * z1 * dz1 - 2 * w2 * z2 * dz2) /
-          (2 * sqrty * (ETA - 1) * Complex(G2, D2));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA -
-                   A * dFVC;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tLowZ: {
-      Complex dz1 = invGD * ddeltax;
-      Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
-      Complex dB =
-          -invGD *
-          (sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
-           dz1);
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA -
-                   A * dFVC;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tHighZ: {
-      Complex dz1 = invGD * ddeltax;
-      Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
-      Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
-                   invGD * dz1 / (2 * pow2(z1)) +
-                   9 * invGD * dz1 / (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA -
-                   A * dFVC;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowXandHighY: {
-      Complex dz1 = invGD * ddeltax;
-      Complex dz2 = dsqrtxy;
-      Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
-      Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
-                   invGD * dz1 / (2 * pow2(z1)) +
-                   9 * invGD * dz1 / (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA -
-                   A * dFVC;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandLowX: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dx / (2 * sqrtx);
-      Complex dA = 2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) /
-                   ((ETA - 1) * Complex(G2, D2));
-      Complex dB =
-          -(2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
-                (2 * pow2(sqrty) + x - 1) +
-            2 * sqrt_pi * w1 * dz1 + Complex(0, 2 * sqrt_pi) * z1 * dw1 * dz1 +
-            2 * (sqrt_pi * w2 * z2 - 1) * dx) /
-          ((ETA - 1) * Complex(G2, D2));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA -
-                   A * dFVC;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandHighX: {
-      Complex dz1 = dsqrtxy;
-      Complex dA = (x - 3) * dx / ((ETA - 1) * Complex(G2, D2) * pow3(x));
-      Complex dB = (-2 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) -
-                    (x - 3) * (2 * pow2(sqrty) + x - 1) * dx +
-                    (2 * x - 3) * x * dx / 2) /
-                   ((ETA - 1) * Complex(G2, D2) * pow3(x));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA -
-                   A * dFVC;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
+  case CalcType::Full: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dsqrtxy;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
+    const Complex dB =
+        sqrt_pi *
+        ((pow2(z1) - 1) * 1i * dw1 * dz1 - (pow2(z2) - 1) * 1i * dw2 * dz2 +
+         2 * w1 * z1 * dz1 - 2 * w2 * z2 * dz2) /
+        (2 * sqrty * (ETA - 1) * Complex(G2, D2));
+    const Complex dK =
+        ETA * Complex(G2, D2) * dB +
+        (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA - A * dFVC;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tLowZ: {
+    const Complex dz1 = invGD * ddeltax;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
+    const Complex dB =
+        -invGD *
+        (sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) - dz1);
+    const Complex dK =
+        ETA * Complex(G2, D2) * dB +
+        (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA - A * dFVC;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tHighZ: {
+    const Complex dz1 = invGD * ddeltax;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * dw1 * dz1;
+    const Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
+                       invGD * dz1 / (2 * pow2(z1)) +
+                       9 * invGD * dz1 / (4 * pow4(z1));
+    const Complex dK =
+        ETA * Complex(G2, D2) * dB +
+        (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA - A * dFVC;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowXandHighY: {
+    const Complex dz1 = invGD * ddeltax;
+    const Complex dz2 = dsqrtxy;
+    const Complex dA = Complex(0, sqrt_pi * invGD) * (dw1 * dz1 - dw2 * dz2);
+    const Complex dB = Complex(0, sqrt_pi * invGD) * dw1 * dz1 -
+                       invGD * dz1 / (2 * pow2(z1)) +
+                       9 * invGD * dz1 / (4 * pow4(z1));
+    const Complex dK =
+        ETA * Complex(G2, D2) * dB +
+        (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA - A * dFVC;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandLowX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dx / (2 * sqrtx);
+    const Complex dA = 2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) /
+                       ((ETA - 1) * Complex(G2, D2));
+    const Complex dB =
+        -(2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
+              (2 * pow2(sqrty) + x - 1) +
+          2 * sqrt_pi * w1 * dz1 + Complex(0, 2 * sqrt_pi) * z1 * dw1 * dz1 +
+          2 * (sqrt_pi * w2 * z2 - 1) * dx) /
+        ((ETA - 1) * Complex(G2, D2));
+    const Complex dK =
+        ETA * Complex(G2, D2) * dB +
+        (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA - A * dFVC;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandHighX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dA = (x - 3) * dx / ((ETA - 1) * Complex(G2, D2) * pow3(x));
+    const Complex dB =
+        (-2 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) -
+         (x - 3) * (2 * pow2(sqrty) + x - 1) * dx + (2 * x - 3) * x * dx / 2) /
+        ((ETA - 1) * Complex(G2, D2) * pow3(x));
+    const Complex dK =
+        ETA * Complex(G2, D2) * dB +
+        (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA - A * dFVC;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
   }
   return {};
 }
 
 Complex HartmannTran::dFdETA(Numeric dETA) const noexcept {
-  Numeric dmF0 = -(D0 - 3 * D2 / 2) * dETA;
-  Numeric dGD = (dmF0 / (invGD * mF0));
-  Numeric dinvGD = -dGD * pow2(invGD);
-  Complex dsqrty = ((ETA - 1) * dinvGD + invGD * dETA) /
-                   (2 * Complex(G2, D2) * pow2(ETA - 1) * pow2(invGD));
-  Complex ddeltax = -dETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2);
-  Complex dx = (-(ETA - 1) * ddeltax + deltax * dETA) /
-               (Complex(G2, D2) * pow2(ETA - 1));
-  Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
+  const Numeric dmF0 = -(D0 - 3 * D2 / 2) * dETA;
+  const Numeric dGD = (dmF0 / (invGD * mF0));
+  const Numeric dinvGD = -dGD * pow2(invGD);
+  const Complex dsqrty = ((ETA - 1) * dinvGD + invGD * dETA) /
+                         (2 * Complex(G2, D2) * pow2(ETA - 1) * pow2(invGD));
+  const Complex ddeltax = -dETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2);
+  const Complex dx = (-(ETA - 1) * ddeltax + deltax * dETA) /
+                     (Complex(G2, D2) * pow2(ETA - 1));
+  const Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
 
   switch (calcs) {
-    case CalcType::Full: {
-      Complex dz1 = dsqrtxy - dsqrty;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB = (sqrt_pi *
-                        ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
-                         ((pow2(z1) - 1) * 1i * dw1 * dz1 -
-                          (pow2(z2) - 1) * 1i * dw2 * dz2 + 2 * w1 * z1 * dz1 -
-                          2 * w2 * z2 * dz2) *
-                             sqrty) *
-                        (ETA - 1) -
-                    (sqrt_pi * (pow2(z1) - 1) * w1 -
-                     sqrt_pi * (pow2(z2) - 1) * w2 + 2 * sqrty) *
-                        sqrty * dETA) /
-                   (2 * Complex(G2, D2) * pow2(ETA - 1) * pow2(sqrty));
-      Complex dK = (-FVC + Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA) * dA +
-                   Complex(G2, D2) * B * dETA + Complex(G2, D2) * ETA * dB -
-                   Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * A * dETA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tLowZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
-            dz1) *
-              invGD -
-          (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
-      Complex dK = (-FVC + Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA) * dA +
-                   Complex(G2, D2) * B * dETA + Complex(G2, D2) * ETA * dB -
-                   Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * A * dETA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tHighZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK = (-FVC + Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA) * dA +
-                   Complex(G2, D2) * B * dETA + Complex(G2, D2) * ETA * dB -
-                   Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * A * dETA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowXandHighY: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK = (-FVC + Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA) * dA +
-                   Complex(G2, D2) * B * dETA + Complex(G2, D2) * ETA * dB -
-                   Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * A * dETA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandLowX: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dx / (2 * sqrtx);
-      Complex dA = 2 *
-                   (sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) * (ETA - 1) -
-                    (sqrt_pi * w2 * z2 - 1) * dETA) /
-                   (Complex(G2, D2) * pow2(ETA - 1));
-      Complex dB =
-          (-2 * (ETA - 1) *
-               (sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
-                    (2 * pow2(sqrty) + x - 1) +
-                sqrt_pi * w1 * dz1 + Complex(0, sqrt_pi) * z1 * dw1 * dz1 +
-                (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) +
-           (2 * sqrt_pi * w1 * z1 +
-            2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1) *
-               dETA) /
-          (Complex(G2, D2) * pow2(ETA - 1));
-      Complex dK = (-FVC + Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA) * dA +
-                   Complex(G2, D2) * B * dETA + Complex(G2, D2) * ETA * dB -
-                   Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * A * dETA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandHighX: {
-      Complex dz1 = dsqrtxy;
-      Complex dA = ((ETA - 1) * (x - 3) * dx + (2 * x - 3) * x * dETA / 2) /
-                   (Complex(G2, D2) * pow2(ETA - 1) * pow3(x));
-      Complex dB =
-          (-(2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
-             (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
-               x * dETA +
-           (ETA - 1) *
-               (-4 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
-                (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x -
-                2 * (x - 3) * (2 * pow2(sqrty) + x - 1) * dx)) /
-          (2 * Complex(G2, D2) * pow2(ETA - 1) * pow3(x));
-      Complex dK = (-FVC + Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA) * dA +
-                   Complex(G2, D2) * B * dETA + Complex(G2, D2) * ETA * dB -
-                   Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * A * dETA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
+  case CalcType::Full: {
+    const Complex dz1 = dsqrtxy - dsqrty;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        (sqrt_pi *
+             ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
+              ((pow2(z1) - 1) * 1i * dw1 * dz1 -
+               (pow2(z2) - 1) * 1i * dw2 * dz2 + 2 * w1 * z1 * dz1 -
+               2 * w2 * z2 * dz2) *
+                  sqrty) *
+             (ETA - 1) -
+         (sqrt_pi * (pow2(z1) - 1) * w1 - sqrt_pi * (pow2(z2) - 1) * w2 +
+          2 * sqrty) *
+             sqrty * dETA) /
+        (2 * Complex(G2, D2) * pow2(ETA - 1) * pow2(sqrty));
+    const Complex dK =
+        (-FVC + Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA) * dA +
+        Complex(G2, D2) * B * dETA + Complex(G2, D2) * ETA * dB -
+        Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * A * dETA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tLowZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
+          dz1) *
+            invGD -
+        (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
+    const Complex dK =
+        (-FVC + Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA) * dA +
+        Complex(G2, D2) * B * dETA + Complex(G2, D2) * ETA * dB -
+        Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * A * dETA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tHighZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK =
+        (-FVC + Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA) * dA +
+        Complex(G2, D2) * B * dETA + Complex(G2, D2) * ETA * dB -
+        Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * A * dETA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowXandHighY: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK =
+        (-FVC + Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA) * dA +
+        Complex(G2, D2) * B * dETA + Complex(G2, D2) * ETA * dB -
+        Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * A * dETA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandLowX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dx / (2 * sqrtx);
+    const Complex dA = 2 *
+                       (sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) * (ETA - 1) -
+                        (sqrt_pi * w2 * z2 - 1) * dETA) /
+                       (Complex(G2, D2) * pow2(ETA - 1));
+    const Complex dB =
+        (-2 * (ETA - 1) *
+             (sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
+                  (2 * pow2(sqrty) + x - 1) +
+              sqrt_pi * w1 * dz1 + Complex(0, sqrt_pi) * z1 * dw1 * dz1 +
+              (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) +
+         (2 * sqrt_pi * w1 * z1 +
+          2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1) *
+             dETA) /
+        (Complex(G2, D2) * pow2(ETA - 1));
+    const Complex dK =
+        (-FVC + Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA) * dA +
+        Complex(G2, D2) * B * dETA + Complex(G2, D2) * ETA * dB -
+        Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * A * dETA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandHighX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dA = ((ETA - 1) * (x - 3) * dx + (2 * x - 3) * x * dETA / 2) /
+                       (Complex(G2, D2) * pow2(ETA - 1) * pow3(x));
+    const Complex dB =
+        (-(2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
+           (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
+             x * dETA +
+         (ETA - 1) *
+             (-4 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
+              (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x -
+              2 * (x - 3) * (2 * pow2(sqrty) + x - 1) * dx)) /
+        (2 * Complex(G2, D2) * pow2(ETA - 1) * pow3(x));
+    const Complex dK =
+        (-FVC + Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA) * dA +
+        Complex(G2, D2) * B * dETA + Complex(G2, D2) * ETA * dB -
+        Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * A * dETA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
   }
   return {};
 }
 
 Complex HartmannTran::dFdH(Numeric dZ) const noexcept {
-  Numeric dmF0 = dZ;
-  Numeric dGD = (dmF0 / (invGD * mF0));
-  Numeric dinvGD = -dGD * pow2(invGD);
-  Complex dsqrty = dinvGD / (2 * (ETA - 1) * Complex(G2, D2) * pow2(invGD));
-  Complex ddeltax = Complex(0, dZ);
-  Complex dx = -ddeltax / ((ETA - 1) * Complex(G2, D2));
-  Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
+  const Numeric dmF0 = dZ;
+  const Numeric dGD = (dmF0 / (invGD * mF0));
+  const Numeric dinvGD = -dGD * pow2(invGD);
+  const Complex dsqrty =
+      dinvGD / (2 * (ETA - 1) * Complex(G2, D2) * pow2(invGD));
+  const Complex ddeltax = Complex(0, dZ);
+  const Complex dx = -ddeltax / ((ETA - 1) * Complex(G2, D2));
+  const Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
 
   switch (calcs) {
-    case CalcType::Full: {
-      Complex dz1 = dsqrtxy - dsqrty;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB =
-          sqrt_pi *
-          ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
-           ((pow2(z1) - 1) * 1i * dw1 * dz1 - (pow2(z2) - 1) * 1i * dw2 * dz2 +
-            2 * w1 * z1 * dz1 - 2 * w2 * z2 * dz2) *
-               sqrty) /
-          (2 * (ETA - 1) * Complex(G2, D2) * pow2(sqrty));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tLowZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
-            dz1) *
-              invGD -
-          (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tHighZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowXandHighY: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandLowX: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dx / (2 * sqrtx);
-      Complex dA = 2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) /
-                   ((ETA - 1) * Complex(G2, D2));
-      Complex dB =
-          -(2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
-                (2 * pow2(sqrty) + x - 1) +
-            2 * sqrt_pi * w1 * dz1 + Complex(0, 2 * sqrt_pi) * z1 * dw1 * dz1 +
-            2 * (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) /
-          ((ETA - 1) * Complex(G2, D2));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandHighX: {
-      Complex dz1 = dsqrtxy;
-      Complex dA = (x - 3) * dx / ((ETA - 1) * Complex(G2, D2) * pow3(x));
-      Complex dB = (-2 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
-                    (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x / 2 -
-                    (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) /
-                   ((ETA - 1) * Complex(G2, D2) * pow3(x));
-      Complex dK = ETA * Complex(G2, D2) * dB +
-                   (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
+  case CalcType::Full: {
+    const Complex dz1 = dsqrtxy - dsqrty;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        sqrt_pi *
+        ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
+         ((pow2(z1) - 1) * 1i * dw1 * dz1 - (pow2(z2) - 1) * 1i * dw2 * dz2 +
+          2 * w1 * z1 * dz1 - 2 * w2 * z2 * dz2) *
+             sqrty) /
+        (2 * (ETA - 1) * Complex(G2, D2) * pow2(sqrty));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tLowZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
+          dz1) *
+            invGD -
+        (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tHighZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowXandHighY: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandLowX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dx / (2 * sqrtx);
+    const Complex dA = 2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) /
+                       ((ETA - 1) * Complex(G2, D2));
+    const Complex dB =
+        -(2 * sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
+              (2 * pow2(sqrty) + x - 1) +
+          2 * sqrt_pi * w1 * dz1 + Complex(0, 2 * sqrt_pi) * z1 * dw1 * dz1 +
+          2 * (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) /
+        ((ETA - 1) * Complex(G2, D2));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandHighX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dA = (x - 3) * dx / ((ETA - 1) * Complex(G2, D2) * pow3(x));
+    const Complex dB =
+        (-2 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
+         (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x / 2 -
+         (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) /
+        ((ETA - 1) * Complex(G2, D2) * pow3(x));
+    const Complex dK = ETA * Complex(G2, D2) * dB +
+                       (ETA * Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) - FVC) * dA;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
   }
   return {};
 }
 
 Complex HartmannTran::dFdVMR(const Output &d) const noexcept {
-  Numeric dmF0 = (1 - ETA) * (d.D0 - 3 * d.D2 / 2) - (D0 - 3 * D2 / 2) * d.ETA;
-  Numeric dGD = (dmF0 / (invGD * mF0));
-  Numeric dinvGD = -dGD * pow2(invGD);
-  Complex dsqrty =
+  const Numeric dmF0 =
+      (1 - ETA) * (d.D0 - 3 * d.D2 / 2) - (D0 - 3 * D2 / 2) * d.ETA;
+  const Numeric dGD = (dmF0 / (invGD * mF0));
+  const Numeric dinvGD = -dGD * pow2(invGD);
+  const Complex dsqrty =
       (Complex(G2, D2) * (ETA - 1) * dinvGD + Complex(G2, D2) * invGD * d.ETA +
        Complex(d.G2, d.D2) * (ETA - 1) * invGD) /
       (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow2(invGD));
-  Complex ddeltax = -(ETA - 1) * Complex(d.G0 - 1.5 * d.G2, d.D0 - 1.5 * d.D2) -
-                    Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * d.ETA + d.FVC;
-  Complex dx = (-Complex(G2, D2) * (ETA - 1) * ddeltax +
-                Complex(G2, D2) * deltax * d.ETA +
-                Complex(d.G2, d.D2) * (ETA - 1) * deltax) /
-               (pow2(Complex(G2, D2)) * pow2(ETA - 1));
-  Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
+  const Complex ddeltax =
+      -(ETA - 1) * Complex(d.G0 - 1.5 * d.G2, d.D0 - 1.5 * d.D2) -
+      Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * d.ETA + d.FVC;
+  const Complex dx = (-Complex(G2, D2) * (ETA - 1) * ddeltax +
+                      Complex(G2, D2) * deltax * d.ETA +
+                      Complex(d.G2, d.D2) * (ETA - 1) * deltax) /
+                     (pow2(Complex(G2, D2)) * pow2(ETA - 1));
+  const Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
 
   switch (calcs) {
-    case CalcType::Full: {
-      Complex dz1 = dsqrtxy - dsqrty;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB = (sqrt_pi * Complex(G2, D2) *
-                        ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
-                         ((pow2(z1) - 1) * 1i * dw1 * dz1 -
-                          (pow2(z2) - 1) * 1i * dw2 * dz2 + 2 * w1 * z1 * dz1 -
-                          2 * w2 * z2 * dz2) *
-                             sqrty) *
-                        (ETA - 1) -
-                    Complex(G2, D2) *
-                        (sqrt_pi * (pow2(z1) - 1) * w1 -
-                         sqrt_pi * (pow2(z2) - 1) * w2 + 2 * sqrty) *
-                        sqrty * d.ETA -
-                    Complex(d.G2, d.D2) * (ETA - 1) *
-                        (sqrt_pi * (pow2(z1) - 1) * w1 -
-                         sqrt_pi * (pow2(z2) - 1) * w2 + 2 * sqrty) *
-                        sqrty) /
-                   (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow2(sqrty));
-      Complex dK =
-          Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
-          Complex(d.G2, d.D2) * B * ETA +
-          (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
-          (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
-           Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
-              A;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tLowZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
-            dz1) *
-              invGD -
-          (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
-      Complex dK =
-          Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
-          Complex(d.G2, d.D2) * B * ETA +
-          (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
-          (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
-           Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
-              A;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tHighZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK =
-          Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
-          Complex(d.G2, d.D2) * B * ETA +
-          (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
-          (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
-           Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
-              A;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowXandHighY: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK =
-          Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
-          Complex(d.G2, d.D2) * B * ETA +
-          (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
-          (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
-           Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
-              A;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandLowX: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dx / (2 * sqrtx);
-      Complex dA = 2 *
-                   (sqrt_pi * Complex(G2, D2) *
-                        (w2 * dz2 + z2 * 1i * dw2 * dz2) * (ETA - 1) -
-                    Complex(G2, D2) * (sqrt_pi * w2 * z2 - 1) * d.ETA -
-                    Complex(d.G2, d.D2) * (sqrt_pi * w2 * z2 - 1) * (ETA - 1)) /
-                   (pow2(Complex(G2, D2)) * pow2(ETA - 1));
-      Complex dB =
-          (-2 * Complex(G2, D2) * (ETA - 1) *
-               (sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
-                    (2 * pow2(sqrty) + x - 1) +
-                sqrt_pi * w1 * dz1 + Complex(0, sqrt_pi) * z1 * dw1 * dz1 +
-                (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) +
-           Complex(G2, D2) *
-               (2 * sqrt_pi * w1 * z1 +
-                2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1) *
-               d.ETA +
-           Complex(d.G2, d.D2) * (ETA - 1) *
-               (2 * sqrt_pi * w1 * z1 +
-                2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1)) /
-          (pow2(Complex(G2, D2)) * pow2(ETA - 1));
-      Complex dK =
-          Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
-          Complex(d.G2, d.D2) * B * ETA +
-          (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
-          (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
-           Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
-              A;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandHighX: {
-      Complex dz1 = dsqrtxy;
-      Complex dA = (2 * Complex(G2, D2) * (ETA - 1) * (x - 3) * dx +
-                    Complex(G2, D2) * (2 * x - 3) * x * d.ETA +
-                    Complex(d.G2, d.D2) * (ETA - 1) * (2 * x - 3) * x) /
-                   (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow3(x));
-      Complex dB =
-          (-Complex(G2, D2) *
-               (2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
-                (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
-               x * d.ETA +
-           Complex(G2, D2) * (ETA - 1) *
-               (-4 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
-                (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x -
-                2 * (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) -
-           Complex(d.G2, d.D2) *
-               (2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
-                (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
-               (ETA - 1) * x) /
-          (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow3(x));
-      Complex dK =
-          Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
-          Complex(d.G2, d.D2) * B * ETA +
-          (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
-          (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
-           Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
-              A;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
+  case CalcType::Full: {
+    const Complex dz1 = dsqrtxy - dsqrty;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        (sqrt_pi * Complex(G2, D2) *
+             ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
+              ((pow2(z1) - 1) * 1i * dw1 * dz1 -
+               (pow2(z2) - 1) * 1i * dw2 * dz2 + 2 * w1 * z1 * dz1 -
+               2 * w2 * z2 * dz2) *
+                  sqrty) *
+             (ETA - 1) -
+         Complex(G2, D2) *
+             (sqrt_pi * (pow2(z1) - 1) * w1 - sqrt_pi * (pow2(z2) - 1) * w2 +
+              2 * sqrty) *
+             sqrty * d.ETA -
+         Complex(d.G2, d.D2) * (ETA - 1) *
+             (sqrt_pi * (pow2(z1) - 1) * w1 - sqrt_pi * (pow2(z2) - 1) * w2 +
+              2 * sqrty) *
+             sqrty) /
+        (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow2(sqrty));
+    const Complex dK =
+        Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
+        Complex(d.G2, d.D2) * B * ETA +
+        (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
+        (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
+         Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
+            A;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tLowZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
+          dz1) *
+            invGD -
+        (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
+    const Complex dK =
+        Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
+        Complex(d.G2, d.D2) * B * ETA +
+        (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
+        (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
+         Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
+            A;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tHighZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK =
+        Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
+        Complex(d.G2, d.D2) * B * ETA +
+        (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
+        (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
+         Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
+            A;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowXandHighY: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK =
+        Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
+        Complex(d.G2, d.D2) * B * ETA +
+        (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
+        (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
+         Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
+            A;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandLowX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dx / (2 * sqrtx);
+    const Complex dA =
+        2 *
+        (sqrt_pi * Complex(G2, D2) * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
+             (ETA - 1) -
+         Complex(G2, D2) * (sqrt_pi * w2 * z2 - 1) * d.ETA -
+         Complex(d.G2, d.D2) * (sqrt_pi * w2 * z2 - 1) * (ETA - 1)) /
+        (pow2(Complex(G2, D2)) * pow2(ETA - 1));
+    const Complex dB =
+        (-2 * Complex(G2, D2) * (ETA - 1) *
+             (sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
+                  (2 * pow2(sqrty) + x - 1) +
+              sqrt_pi * w1 * dz1 + Complex(0, sqrt_pi) * z1 * dw1 * dz1 +
+              (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) +
+         Complex(G2, D2) *
+             (2 * sqrt_pi * w1 * z1 +
+              2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1) *
+             d.ETA +
+         Complex(d.G2, d.D2) * (ETA - 1) *
+             (2 * sqrt_pi * w1 * z1 +
+              2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1)) /
+        (pow2(Complex(G2, D2)) * pow2(ETA - 1));
+    const Complex dK =
+        Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
+        Complex(d.G2, d.D2) * B * ETA +
+        (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
+        (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
+         Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
+            A;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandHighX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dA = (2 * Complex(G2, D2) * (ETA - 1) * (x - 3) * dx +
+                        Complex(G2, D2) * (2 * x - 3) * x * d.ETA +
+                        Complex(d.G2, d.D2) * (ETA - 1) * (2 * x - 3) * x) /
+                       (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow3(x));
+    const Complex dB =
+        (-Complex(G2, D2) *
+             (2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
+              (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
+             x * d.ETA +
+         Complex(G2, D2) * (ETA - 1) *
+             (-4 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
+              (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x -
+              2 * (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) -
+         Complex(d.G2, d.D2) *
+             (2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
+              (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
+             (ETA - 1) * x) /
+        (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow3(x));
+    const Complex dK =
+        Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
+        Complex(d.G2, d.D2) * B * ETA +
+        (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
+        (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
+         Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
+            A;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
   }
   return {};
 }
 
 Complex HartmannTran::dFdT(const Output &d, Numeric T) const noexcept {
-  Numeric dmF0 = (1 - ETA) * (d.D0 - 3 * d.D2 / 2) - (D0 - 3 * D2 / 2) * d.ETA;
-  Numeric dGD = (dmF0 / (invGD * mF0)) - invGD * invGD / (2 * T * sqrt_ln_2);
-  Numeric dinvGD = -dGD * pow2(invGD);
-  Complex dsqrty =
+  const Numeric dmF0 =
+      (1 - ETA) * (d.D0 - 3 * d.D2 / 2) - (D0 - 3 * D2 / 2) * d.ETA;
+  const Numeric dGD =
+      (dmF0 / (invGD * mF0)) - invGD * invGD / (2 * T * sqrt_ln_2);
+  const Numeric dinvGD = -dGD * pow2(invGD);
+  const Complex dsqrty =
       (Complex(G2, D2) * (ETA - 1) * dinvGD + Complex(G2, D2) * invGD * d.ETA +
        Complex(d.G2, d.D2) * (ETA - 1) * invGD) /
       (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow2(invGD));
-  Complex ddeltax = -(ETA - 1) * Complex(d.G0 - 1.5 * d.G2, d.D0 - 1.5 * d.D2) -
-                    Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * d.ETA + d.FVC;
-  Complex dx = (-Complex(G2, D2) * (ETA - 1) * ddeltax +
-                Complex(G2, D2) * deltax * d.ETA +
-                Complex(d.G2, d.D2) * (ETA - 1) * deltax) /
-               (pow2(Complex(G2, D2)) * pow2(ETA - 1));
-  Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
+  const Complex ddeltax =
+      -(ETA - 1) * Complex(d.G0 - 1.5 * d.G2, d.D0 - 1.5 * d.D2) -
+      Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * d.ETA + d.FVC;
+  const Complex dx = (-Complex(G2, D2) * (ETA - 1) * ddeltax +
+                      Complex(G2, D2) * deltax * d.ETA +
+                      Complex(d.G2, d.D2) * (ETA - 1) * deltax) /
+                     (pow2(Complex(G2, D2)) * pow2(ETA - 1));
+  const Complex dsqrtxy = (sqrty * dsqrty + dx / 2) / sqrtxy;
 
   switch (calcs) {
-    case CalcType::Full: {
-      Complex dz1 = dsqrtxy - dsqrty;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB = (sqrt_pi * Complex(G2, D2) *
-                        ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
-                         ((pow2(z1) - 1) * 1i * dw1 * dz1 -
-                          (pow2(z2) - 1) * 1i * dw2 * dz2 + 2 * w1 * z1 * dz1 -
-                          2 * w2 * z2 * dz2) *
-                             sqrty) *
-                        (ETA - 1) -
-                    Complex(G2, D2) *
-                        (sqrt_pi * (pow2(z1) - 1) * w1 -
-                         sqrt_pi * (pow2(z2) - 1) * w2 + 2 * sqrty) *
-                        sqrty * d.ETA -
-                    Complex(d.G2, d.D2) * (ETA - 1) *
-                        (sqrt_pi * (pow2(z1) - 1) * w1 -
-                         sqrt_pi * (pow2(z2) - 1) * w2 + 2 * sqrty) *
-                        sqrty) /
-                   (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow2(sqrty));
-      Complex dK =
-          Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
-          Complex(d.G2, d.D2) * B * ETA +
-          (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
-          (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
-           Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
-              A;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tLowZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
-            dz1) *
-              invGD -
-          (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
-      Complex dK =
-          Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
-          Complex(d.G2, d.D2) * B * ETA +
-          (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
-          (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
-           Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
-              A;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::Noc2tHighZ: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK =
-          Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
-          Complex(d.G2, d.D2) * B * ETA +
-          (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
-          (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
-           Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
-              A;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowXandHighY: {
-      Complex dz1 = deltax * dinvGD + invGD * ddeltax;
-      Complex dz2 = dsqrtxy + dsqrty;
-      Complex dA = sqrt_pi * ((w1 - w2) * dinvGD +
-                              (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
-      Complex dB =
-          ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
-           (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 -
-            2 * pow2(z1) * dz1 + 9 * dz1) *
-               invGD) /
-          (4 * pow4(z1));
-      Complex dK =
-          Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
-          Complex(d.G2, d.D2) * B * ETA +
-          (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
-          (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
-           Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
-              A;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandLowX: {
-      Complex dz1 = dsqrtxy;
-      Complex dz2 = dx / (2 * sqrtx);
-      Complex dA = 2 *
-                   (sqrt_pi * Complex(G2, D2) *
-                        (w2 * dz2 + z2 * 1i * dw2 * dz2) * (ETA - 1) -
-                    Complex(G2, D2) * (sqrt_pi * w2 * z2 - 1) * d.ETA -
-                    Complex(d.G2, d.D2) * (sqrt_pi * w2 * z2 - 1) * (ETA - 1)) /
-                   (pow2(Complex(G2, D2)) * pow2(ETA - 1));
-      Complex dB =
-          (-2 * Complex(G2, D2) * (ETA - 1) *
-               (sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
-                    (2 * pow2(sqrty) + x - 1) +
-                sqrt_pi * w1 * dz1 + Complex(0, sqrt_pi) * z1 * dw1 * dz1 +
-                (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) +
-           Complex(G2, D2) *
-               (2 * sqrt_pi * w1 * z1 +
-                2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1) *
-               d.ETA +
-           Complex(d.G2, d.D2) * (ETA - 1) *
-               (2 * sqrt_pi * w1 * z1 +
-                2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1)) /
-          (pow2(Complex(G2, D2)) * pow2(ETA - 1));
-      Complex dK =
-          Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
-          Complex(d.G2, d.D2) * B * ETA +
-          (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
-          (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
-           Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
-              A;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
-    case CalcType::LowYandHighX: {
-      Complex dz1 = dsqrtxy;
-      Complex dA = (2 * Complex(G2, D2) * (ETA - 1) * (x - 3) * dx +
-                    Complex(G2, D2) * (2 * x - 3) * x * d.ETA +
-                    Complex(d.G2, d.D2) * (ETA - 1) * (2 * x - 3) * x) /
-                   (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow3(x));
-      Complex dB =
-          (-Complex(G2, D2) *
-               (2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
-                (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
-               x * d.ETA +
-           Complex(G2, D2) * (ETA - 1) *
-               (-4 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
-                (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x -
-                2 * (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) -
-           Complex(d.G2, d.D2) *
-               (2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
-                (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
-               (ETA - 1) * x) /
-          (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow3(x));
-      Complex dK =
-          Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
-          Complex(d.G2, d.D2) * B * ETA +
-          (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
-          (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
-           Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
-              A;
-      return inv_pi * (-A * dK + K * dA) / pow2(K);
-    }
+  case CalcType::Full: {
+    const Complex dz1 = dsqrtxy - dsqrty;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        (sqrt_pi * Complex(G2, D2) *
+             ((-(pow2(z1) - 1) * w1 + (pow2(z2) - 1) * w2) * dsqrty +
+              ((pow2(z1) - 1) * 1i * dw1 * dz1 -
+               (pow2(z2) - 1) * 1i * dw2 * dz2 + 2 * w1 * z1 * dz1 -
+               2 * w2 * z2 * dz2) *
+                  sqrty) *
+             (ETA - 1) -
+         Complex(G2, D2) *
+             (sqrt_pi * (pow2(z1) - 1) * w1 - sqrt_pi * (pow2(z2) - 1) * w2 +
+              2 * sqrty) *
+             sqrty * d.ETA -
+         Complex(d.G2, d.D2) * (ETA - 1) *
+             (sqrt_pi * (pow2(z1) - 1) * w1 - sqrt_pi * (pow2(z2) - 1) * w2 +
+              2 * sqrty) *
+             sqrty) /
+        (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow2(sqrty));
+    const Complex dK =
+        Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
+        Complex(d.G2, d.D2) * B * ETA +
+        (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
+        (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
+         Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
+            A;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tLowZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        -(sqrt_pi * ((pow2(z1) - 1) * 1i * dw1 * dz1 + 2 * w1 * z1 * dz1) -
+          dz1) *
+            invGD -
+        (sqrt_pi * (pow2(z1) - 1) * w1 - z1) * dinvGD;
+    const Complex dK =
+        Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
+        Complex(d.G2, d.D2) * B * ETA +
+        (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
+        (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
+         Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
+            A;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::Noc2tHighZ: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dA = sqrt_pi * (Complex(0, invGD) * dw1 * dz1 + w1 * dinvGD);
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK =
+        Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
+        Complex(d.G2, d.D2) * B * ETA +
+        (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
+        (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
+         Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
+            A;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowXandHighY: {
+    const Complex dz1 = deltax * dinvGD + invGD * ddeltax;
+    const Complex dz2 = dsqrtxy + dsqrty;
+    const Complex dA =
+        sqrt_pi *
+        ((w1 - w2) * dinvGD + (Complex(0, invGD) * (dw1 * dz1 - dw2 * dz2)));
+    const Complex dB =
+        ((4 * sqrt_pi * w1 * pow3(z1) + 2 * pow2(z1) - 3) * z1 * dinvGD +
+         (Complex(0, 4 * sqrt_pi) * pow4(z1) * dw1 * dz1 - 2 * pow2(z1) * dz1 +
+          9 * dz1) *
+             invGD) /
+        (4 * pow4(z1));
+    const Complex dK =
+        Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
+        Complex(d.G2, d.D2) * B * ETA +
+        (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
+        (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
+         Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
+            A;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandLowX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dz2 = dx / (2 * sqrtx);
+    const Complex dA =
+        2 *
+        (sqrt_pi * Complex(G2, D2) * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
+             (ETA - 1) -
+         Complex(G2, D2) * (sqrt_pi * w2 * z2 - 1) * d.ETA -
+         Complex(d.G2, d.D2) * (sqrt_pi * w2 * z2 - 1) * (ETA - 1)) /
+        (pow2(Complex(G2, D2)) * pow2(ETA - 1));
+    const Complex dB =
+        (-2 * Complex(G2, D2) * (ETA - 1) *
+             (sqrt_pi * (w2 * dz2 + z2 * 1i * dw2 * dz2) *
+                  (2 * pow2(sqrty) + x - 1) +
+              sqrt_pi * w1 * dz1 + Complex(0, sqrt_pi) * z1 * dw1 * dz1 +
+              (4 * sqrty * dsqrty + dx) * (sqrt_pi * w2 * z2 - 1)) +
+         Complex(G2, D2) *
+             (2 * sqrt_pi * w1 * z1 +
+              2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1) *
+             d.ETA +
+         Complex(d.G2, d.D2) * (ETA - 1) *
+             (2 * sqrt_pi * w1 * z1 +
+              2 * (sqrt_pi * w2 * z2 - 1) * (2 * pow2(sqrty) + x - 1) - 1)) /
+        (pow2(Complex(G2, D2)) * pow2(ETA - 1));
+    const Complex dK =
+        Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
+        Complex(d.G2, d.D2) * B * ETA +
+        (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
+        (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
+         Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
+            A;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
+  case CalcType::LowYandHighX: {
+    const Complex dz1 = dsqrtxy;
+    const Complex dA = (2 * Complex(G2, D2) * (ETA - 1) * (x - 3) * dx +
+                        Complex(G2, D2) * (2 * x - 3) * x * d.ETA +
+                        Complex(d.G2, d.D2) * (ETA - 1) * (2 * x - 3) * x) /
+                       (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow3(x));
+    const Complex dB =
+        (-Complex(G2, D2) *
+             (2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
+              (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
+             x * d.ETA +
+         Complex(G2, D2) * (ETA - 1) *
+             (-4 * sqrt_pi * (w1 * dz1 + z1 * 1i * dw1 * dz1) * pow3(x) +
+              (4 * sqrty * dsqrty + dx) * (2 * x - 3) * x -
+              2 * (x - 3) * (2 * pow2(sqrty) + x - 1) * dx) -
+         Complex(d.G2, d.D2) *
+             (2 * (-2 * sqrt_pi * w1 * z1 + 1) * pow2(x) +
+              (2 * x - 3) * (2 * pow2(sqrty) + x - 1)) *
+             (ETA - 1) * x) /
+        (2 * pow2(Complex(G2, D2)) * pow2(ETA - 1) * pow3(x));
+    const Complex dK =
+        Complex(G2, D2) * B * d.ETA + Complex(G2, D2) * ETA * dB +
+        Complex(d.G2, d.D2) * B * ETA +
+        (Complex(G0 - 1.5 * G2, D0 - 1.5 * D2) * ETA - FVC) * dA +
+        (-Complex(1.5 * G2 - G0, 1.5 * D2 - D0) * d.ETA -
+         Complex(1.5 * d.G2 - d.G0, 1.5 * d.D2 - d.D0) * ETA - d.FVC) *
+            A;
+    return inv_pi * (-A * dK + K * dA) / pow2(K);
+  }
   }
   return {};
 }
@@ -1723,12 +1749,12 @@ Complex HartmannTran::operator()(Numeric f) noexcept {
 
 HartmannTran::CalcType HartmannTran::init(const Complex c2t) const noexcept {
   if (abs_squared(c2t) == 0)
-    return CalcType::Noc2tHighZ;  // nb. Value of high/low changes elsewhere
+    return CalcType::Noc2tHighZ; // nb. Value of high/low changes elsewhere
   if (abs_squared(x) <= 9e-16 * abs_squared(sqrty * sqrty))
     return CalcType::LowXandHighY;
   if ((abs_squared(sqrty * sqrty) <= 1.e-30 * abs_squared(x)) and
       abs_squared(std::sqrt(x)) <= 16.e6)
-    return CalcType::LowYandLowX;  // Weird case, untested
+    return CalcType::LowYandLowX; // Weird case, untested
   if ((abs_squared(sqrty * sqrty) <= 1.e-30 * abs_squared(x)))
     return CalcType::LowYandHighX;
   return CalcType::Full;
@@ -1740,58 +1766,57 @@ void HartmannTran::update_calcs() noexcept {
 
 void HartmannTran::calc() noexcept {
   switch (calcs) {
-    case CalcType::Full:
-      z1 = sqrtxy - sqrty;
-      z2 = sqrtxy + sqrty;
-      w1 = Faddeeva::w(1i * z1);
-      w2 = Faddeeva::w(1i * z2);
-      A = sqrt_pi * invGD * (w1 - w2);
-      B = (-1 + sqrt_pi / (2 * sqrty) * (1 - pow2(z1)) * w1 -
-           sqrt_pi / (2 * sqrty) * (1 - pow2(z2)) * w2) /
-          ((1 - ETA) * Complex(G2, D2));
-      break;
-    case CalcType::Noc2tLowZ:
-    case CalcType::Noc2tHighZ:
-      z1 = deltax * invGD;
-      w1 = Faddeeva::w(1i * z1);
-      A = sqrt_pi * invGD * w1;
-      if (abs_squared(z1) < 16e6) {
-        calcs = CalcType::Noc2tLowZ;
-        B = sqrt_pi * invGD * ((1 - pow2(z1)) * w1 + z1 / sqrt_pi);
-      } else {
-        calcs = CalcType::Noc2tHighZ;
-        B = invGD * (sqrt_pi * w1 + 1 / z1 / 2 - 3 / pow3(z1) / 4);
-      }
-      break;
-    case CalcType::LowXandHighY:
-      z1 = deltax * invGD;
-      z2 = sqrtxy + sqrty;
-      w1 = Faddeeva::w(1i * z1);
-      w2 = Faddeeva::w(1i * z2);
-      A = sqrt_pi * invGD * (w1 - w2);
+  case CalcType::Full:
+    z1 = sqrtxy - sqrty;
+    z2 = sqrtxy + sqrty;
+    w1 = Faddeeva::w(1i * z1);
+    w2 = Faddeeva::w(1i * z2);
+    A = sqrt_pi * invGD * (w1 - w2);
+    B = (-1 + sqrt_pi / (2 * sqrty) * (1 - pow2(z1)) * w1 -
+         sqrt_pi / (2 * sqrty) * (1 - pow2(z2)) * w2) /
+        ((1 - ETA) * Complex(G2, D2));
+    break;
+  case CalcType::Noc2tLowZ:
+  case CalcType::Noc2tHighZ:
+    z1 = deltax * invGD;
+    w1 = Faddeeva::w(1i * z1);
+    A = sqrt_pi * invGD * w1;
+    if (abs_squared(z1) < 16e6) {
+      calcs = CalcType::Noc2tLowZ;
+      B = sqrt_pi * invGD * ((1 - pow2(z1)) * w1 + z1 / sqrt_pi);
+    } else {
+      calcs = CalcType::Noc2tHighZ;
       B = invGD * (sqrt_pi * w1 + 1 / z1 / 2 - 3 / pow3(z1) / 4);
-      break;
-    case CalcType::LowYandLowX:
-      sqrtx = std::sqrt(x);
-      z1 = sqrtxy;
-      z2 = sqrtx;
-      w1 = Faddeeva::w(1i * z1);
-      w2 = Faddeeva::w(1i * z2);
-      A = (2 * sqrt_pi / ((1 - ETA) * Complex(G2, D2))) *
-          (inv_sqrt_pi - z2 * w2);
-      B = (1 / ((1 - ETA) * Complex(G2, D2))) *
-          (-1 +
-           2 * sqrt_pi * (1 - x - 2 * sqrty * sqrty) * (1 / sqrt_pi - z2 * w2) +
-           2 * sqrt_pi * z1 * w1);
-      break;
-    case CalcType::LowYandHighX:
-      z1 = sqrtxy;
-      w1 = Faddeeva::w(1i * z1);
-      A = (1 / ((1 - ETA) * Complex(G2, D2))) * (1 / x - 3 / pow2(x) / 2);
-      B = (1 / ((1 - ETA) * Complex(G2, D2))) *
-          (-1 + (1 - x - 2 * sqrty * sqrty) * (1 / x - 3 / pow2(x) / 2) +
-           2 * sqrt_pi * z1 * w1);
-      break;
+    }
+    break;
+  case CalcType::LowXandHighY:
+    z1 = deltax * invGD;
+    z2 = sqrtxy + sqrty;
+    w1 = Faddeeva::w(1i * z1);
+    w2 = Faddeeva::w(1i * z2);
+    A = sqrt_pi * invGD * (w1 - w2);
+    B = invGD * (sqrt_pi * w1 + 1 / z1 / 2 - 3 / pow3(z1) / 4);
+    break;
+  case CalcType::LowYandLowX:
+    sqrtx = std::sqrt(x);
+    z1 = sqrtxy;
+    z2 = sqrtx;
+    w1 = Faddeeva::w(1i * z1);
+    w2 = Faddeeva::w(1i * z2);
+    A = (2 * sqrt_pi / ((1 - ETA) * Complex(G2, D2))) * (inv_sqrt_pi - z2 * w2);
+    B = (1 / ((1 - ETA) * Complex(G2, D2))) *
+        (-1 +
+         2 * sqrt_pi * (1 - x - 2 * sqrty * sqrty) * (1 / sqrt_pi - z2 * w2) +
+         2 * sqrt_pi * z1 * w1);
+    break;
+  case CalcType::LowYandHighX:
+    z1 = sqrtxy;
+    w1 = Faddeeva::w(1i * z1);
+    A = (1 / ((1 - ETA) * Complex(G2, D2))) * (1 / x - 3 / pow2(x) / 2);
+    B = (1 / ((1 - ETA) * Complex(G2, D2))) *
+        (-1 + (1 - x - 2 * sqrty * sqrty) * (1 / x - 3 / pow2(x) / 2) +
+         2 * sqrt_pi * z1 * w1);
+    break;
   }
 
   dw1 = 2i * (inv_sqrt_pi - z1 * w1);
@@ -1802,8 +1827,7 @@ void HartmannTran::calc() noexcept {
 }
 
 VanVleckHuber::VanVleckHuber(Numeric F0, Numeric T) noexcept
-    : c1(Constant::h / (2.0 * Constant::k * T)),
-      tanh_c1f0(std::tanh(c1 * F0)),
+    : c1(Constant::h / (2.0 * Constant::k * T)), tanh_c1f0(std::tanh(c1 * F0)),
       inv_denom(1.0 / (F0 * tanh_c1f0)) {}
 
 Numeric VanVleckHuber::dNdT(Numeric T, Numeric f) const noexcept {
@@ -1861,16 +1885,15 @@ Numeric RosenkranzQuadratic::operator()(Numeric f) noexcept {
 
 Numeric SimpleFrequencyScaling::dNdT(Numeric t_ [[maybe_unused]],
                                      Numeric f) const ARTS_NOEXCEPT {
-  ARTS_ASSERT(
-      t_ == T,
-      "Temperature is stored internally in SimpleFrequencyScaling\n"
-      "but for interface reasons this function nevertheless takes temprature as an input\n"
-      "For some reason, the two temperatures disagree, so regardless, you have encountered\n"
-      "a path of the code that should never be encountered.  The two temperatures are: ",
-      T,
-      " and ",
-      t_,
-      " K")
+  ARTS_ASSERT(t_ == T,
+              "Temperature is stored internally in SimpleFrequencyScaling\n"
+              "but for interface reasons this function nevertheless takes "
+              "temprature as an input\n"
+              "For some reason, the two temperatures disagree, so regardless, "
+              "you have encountered\n"
+              "a path of the code that should never be encountered.  The two "
+              "temperatures are: ",
+              T, " and ", t_, " K")
 
   return -N * Constant::h * F0 * expF0 / (Constant::k * t_ * t_ * expm1F0) +
          Constant::h * f * f *
@@ -1891,26 +1914,11 @@ Numeric SimpleFrequencyScaling::operator()(Numeric f) noexcept {
 }
 
 LocalThermodynamicEquilibrium::LocalThermodynamicEquilibrium(
-    Numeric I0,
-    Numeric T0,
-    Numeric T,
-    Numeric F0,
-    Numeric E0,
-    Numeric QT,
-    Numeric QT0,
-    Numeric dQTdT,
-    Numeric r,
-    Numeric drdSELFVMR,
+    Numeric I0, Numeric T0, Numeric T, Numeric F0, Numeric E0, Numeric QT,
+    Numeric QT0, Numeric dQTdT, Numeric r, Numeric drdSELFVMR,
     const Numeric drdT) noexcept
     : LocalThermodynamicEquilibrium(
-          I0,
-          r,
-          drdSELFVMR,
-          drdT,
-          QT0,
-          QT,
-          dQTdT,
-          boltzman_ratio(T, T0, E0),
+          I0, r, drdSELFVMR, drdT, QT0, QT, dQTdT, boltzman_ratio(T, T0, E0),
           dboltzman_ratio_dT_div_boltzmann_ratio(T, E0),
           stimulated_relative_emission(F0, T0, T),
           dstimulated_relative_emission_dT(F0, T0, T),
@@ -1919,21 +1927,14 @@ LocalThermodynamicEquilibrium::LocalThermodynamicEquilibrium(
 struct FullNonLocalThermodynamicEquilibriumInitialization {
   Numeric k, dkdF0, dkdr1, dkdr2, e, dedF0, dedr2, B, dBdT, dBdF0;
 
-  FullNonLocalThermodynamicEquilibriumInitialization(Numeric F0,
-                                                     Numeric A21,
-                                                     Numeric T,
-                                                     Numeric r1,
-                                                     Numeric r2,
-                                                     Numeric c2,
+  FullNonLocalThermodynamicEquilibriumInitialization(Numeric F0, Numeric A21,
+                                                     Numeric T, Numeric r1,
+                                                     Numeric r2, Numeric c2,
                                                      Numeric c3,
                                                      Numeric x) noexcept
-      : k(c3 * (r1 * x - r2) * (A21 / c2)),
-        dkdF0(-2.0 * k / F0),
-        dkdr1(c3 * x * (A21 / c2)),
-        dkdr2(-c3 * (A21 / c2)),
-        e(c3 * r2 * A21),
-        dedF0(e / F0),
-        dedr2(c3 * A21),
+      : k(c3 * (r1 * x - r2) * (A21 / c2)), dkdF0(-2.0 * k / F0),
+        dkdr1(c3 * x * (A21 / c2)), dkdr2(-c3 * (A21 / c2)), e(c3 * r2 * A21),
+        dedF0(e / F0), dedr2(c3 * A21),
         B(2 * Constant::h / Math::pow2(Constant::c) * Math::pow3(F0) /
           std::expm1((Constant::h / Constant::k * F0) / T)),
         dBdT(Math::pow2(B) * Math::pow2(Constant::c) *
@@ -1943,59 +1944,30 @@ struct FullNonLocalThermodynamicEquilibriumInitialization {
                                std::exp((Constant::h / Constant::k * F0) / T) /
                                (2 * Constant::k * T * Math::pow3(F0))) {}
 
-  constexpr FullNonLocalThermodynamicEquilibrium operator()(
-      Numeric r, Numeric drdSELFVMR, Numeric drdT) &&noexcept {
-    return FullNonLocalThermodynamicEquilibrium(r,
-                                                drdSELFVMR,
-                                                drdT,
-                                                k,
-                                                dkdF0,
-                                                dkdr1,
-                                                dkdr2,
-                                                e,
-                                                dedF0,
-                                                dedr2,
-                                                B,
-                                                dBdT,
-                                                dBdF0);
+  constexpr FullNonLocalThermodynamicEquilibrium
+  operator()(Numeric r, Numeric drdSELFVMR, Numeric drdT) &&noexcept {
+    return {r, drdSELFVMR, drdT,  k, dkdF0, dkdr1, dkdr2,
+            e, dedF0,      dedr2, B, dBdT,  dBdF0};
   }
 };
 
 FullNonLocalThermodynamicEquilibrium::FullNonLocalThermodynamicEquilibrium(
-    Numeric F0,
-    Numeric A21,
-    Numeric T,
-    Numeric g1,
-    Numeric g2,
-    Numeric r1,
-    Numeric r2,
-    Numeric r,
-    Numeric drdSELFVMR,
-    Numeric drdT) noexcept
+    Numeric F0, Numeric A21, Numeric T, Numeric g1, Numeric g2, Numeric r1,
+    Numeric r2, Numeric r, Numeric drdSELFVMR, Numeric drdT) noexcept
     : FullNonLocalThermodynamicEquilibrium(
           FullNonLocalThermodynamicEquilibriumInitialization(
-              F0, A21, T, r1, r2, c0 * F0 * F0 * F0, c1 * F0, g2 / g1)(
-              r, drdSELFVMR, drdT)) {}
+              F0, A21, T, r1, r2, c0 * F0 * F0 * F0, c1 * F0,
+              g2 / g1)(r, drdSELFVMR, drdT)) {}
 
 struct VibrationalTemperaturesNonLocalThermodynamicEquilibriumInitializer {
   Numeric K1, dK1dT, K2, dK2dT, dK2dF0, K3, dK3dT, dK3dF0, dK3dTl, dK3dTu, K4,
       dK4dT, dK4dTu, B, dBdT, dBdF0;
 
   VibrationalTemperaturesNonLocalThermodynamicEquilibriumInitializer(
-      Numeric T,
-      Numeric T0,
-      Numeric F0,
-      Numeric E0,
-      Numeric Tl,
-      Numeric Evl,
-      Numeric Tu,
-      Numeric Evu,
-      Numeric gamma,
-      Numeric gamma_ref,
-      Numeric r_low,
+      Numeric T, Numeric T0, Numeric F0, Numeric E0, Numeric Tl, Numeric Evl,
+      Numeric Tu, Numeric Evu, Numeric gamma, Numeric gamma_ref, Numeric r_low,
       Numeric r_upp) noexcept
-      : K1(boltzman_ratio(T, T0, E0)),
-        dK1dT(dboltzman_ratio_dT(K1, T, E0)),
+      : K1(boltzman_ratio(T, T0, E0)), dK1dT(dboltzman_ratio_dT(K1, T, E0)),
         K2(stimulated_relative_emission(gamma, gamma_ref)),
         dK2dT(dstimulated_relative_emission_dT(gamma, gamma_ref, F0, T)),
         dK2dF0(dstimulated_relative_emission_dF0(gamma, gamma_ref, T, T0)),
@@ -2004,8 +1976,7 @@ struct VibrationalTemperaturesNonLocalThermodynamicEquilibriumInitializer {
         dK3dF0(dabsorption_nlte_rate_dF0(gamma, T, K4, r_low)),
         dK3dTl(dabsorption_nlte_rate_dTl(gamma, T, Tl, Evl, r_low)),
         dK3dTu(dabsorption_nlte_rate_dTu(gamma, T, Tu, Evu, K4)),
-        K4(boltzman_ratio(Tu, T, Evu)),
-        dK4dT(dboltzman_ratio_dT(K4, T, Evu)),
+        K4(boltzman_ratio(Tu, T, Evu)), dK4dT(dboltzman_ratio_dT(K4, T, Evu)),
         dK4dTu(dboltzman_ratio_dT(K4, Tu, Evu)),
         B(2 * Constant::h / Math::pow2(Constant::c) * Math::pow3(F0) /
           std::expm1((Constant::h / Constant::k * F0) / T)),
@@ -2016,143 +1987,97 @@ struct VibrationalTemperaturesNonLocalThermodynamicEquilibriumInitializer {
                                std::exp((Constant::h / Constant::k * F0) / T) /
                                (2 * Constant::k * T * Math::pow3(F0))) {}
 
-  constexpr VibrationalTemperaturesNonLocalThermodynamicEquilibrium operator()(
-      Numeric I0,
-      Numeric QT0,
-      Numeric QT,
-      Numeric dQTdT,
-      Numeric r,
-      Numeric drdSELFVMR,
-      Numeric drdT) &&noexcept {
-    return VibrationalTemperaturesNonLocalThermodynamicEquilibrium(I0,
-                                                                   QT0,
-                                                                   QT,
-                                                                   dQTdT,
-                                                                   r,
-                                                                   drdSELFVMR,
-                                                                   drdT,
-                                                                   K1,
-                                                                   dK1dT,
-                                                                   K2,
-                                                                   dK2dT,
-                                                                   dK2dF0,
-                                                                   K3,
-                                                                   dK3dT,
-                                                                   dK3dF0,
-                                                                   dK3dTl,
-                                                                   dK3dTu,
-                                                                   K4,
-                                                                   dK4dT,
-                                                                   dK4dTu,
-                                                                   B,
-                                                                   dBdT,
-                                                                   dBdF0);
+  constexpr VibrationalTemperaturesNonLocalThermodynamicEquilibrium
+  operator()(Numeric I0, Numeric QT0, Numeric QT, Numeric dQTdT, Numeric r,
+             Numeric drdSELFVMR, Numeric drdT) &&noexcept {
+    return {I0,     QT0, QT,    dQTdT,  r,  drdSELFVMR, drdT,   K1,
+            dK1dT,  K2,  dK2dT, dK2dF0, K3, dK3dT,      dK3dF0, dK3dTl,
+            dK3dTu, K4,  dK4dT, dK4dTu, B,  dBdT,       dBdF0};
   }
 };
 
 VibrationalTemperaturesNonLocalThermodynamicEquilibrium::
     VibrationalTemperaturesNonLocalThermodynamicEquilibrium(
-        Numeric I0,
-        Numeric T0,
-        Numeric T,
-        Numeric Tl,
-        Numeric Tu,
-        Numeric F0,
-        Numeric E0,
-        Numeric Evl,
-        Numeric Evu,
-        Numeric QT,
-        Numeric QT0,
-        Numeric dQTdT,
-        Numeric r,
-        Numeric drdSELFVMR,
-        Numeric drdT) noexcept
+        Numeric I0, Numeric T0, Numeric T, Numeric Tl, Numeric Tu, Numeric F0,
+        Numeric E0, Numeric Evl, Numeric Evu, Numeric QT, Numeric QT0,
+        Numeric dQTdT, Numeric r, Numeric drdSELFVMR, Numeric drdT) noexcept
     : VibrationalTemperaturesNonLocalThermodynamicEquilibrium(
           VibrationalTemperaturesNonLocalThermodynamicEquilibriumInitializer(
-              T,
-              T0,
-              F0,
-              E0,
-              Tl,
-              Evl,
-              Tu,
-              Evu,
-              stimulated_emission(T, F0),
-              stimulated_emission(T0, F0),
-              boltzman_ratio(Tl, T, Evl),
-              boltzman_ratio(Tu, T, Evu))(
-              I0, QT0, QT, dQTdT, r, drdSELFVMR, drdT)) {}
+              T, T0, F0, E0, Tl, Evl, Tu, Evu, stimulated_emission(T, F0),
+              stimulated_emission(T0, F0), boltzman_ratio(Tl, T, Evl),
+              boltzman_ratio(Tu, T, Evu))(I0, QT0, QT, dQTdT, r, drdSELFVMR,
+                                          drdT)) {}
 
-#define CutInternalDerivativesImpl(X, Y)                                      \
-  else if (deriv == Jacobian::Line::Shape##X##Y) {                            \
-    const Numeric d = value.n;                                                \
-    const Complex dFm = std::conj(ls_mirr.dFd##X(d) - ls_mirr_cut.dFd##X(d)); \
-    const Complex dFls = ls.dFd##X(d) - ls_cut.dFd##X(d) + dFm;               \
-    com.dF[com.jac_pos(iv, ij)] += S * LM * dFls;                             \
-    if (do_nlte) {                                                            \
-      com.dN[com.jac_pos(iv, ij)] += DS * LM * dFls;                          \
-    }                                                                         \
+#define CutInternalDerivativesImpl(X, Y)                                       \
+  else if (deriv == Jacobian::Line::Shape##X##Y) {                             \
+    const Numeric d = value.n;                                                 \
+    const Complex dFm = std::conj(ls_mirr.dFd##X(d) - ls_mirr_cut.dFd##X(d));  \
+    const Complex dFls = ls.dFd##X(d) - ls_cut.dFd##X(d) + dFm;                \
+    com.dF[com.jac_pos(iv, ij)] += S * LM * dFls;                              \
+    if (do_nlte) {                                                             \
+      com.dN[com.jac_pos(iv, ij)] += DS * LM * dFls;                           \
+    }                                                                          \
   }
 
-#define CutInternalDerivatives(X)                                     \
-  CutInternalDerivativesImpl(X, X0) CutInternalDerivativesImpl(X, X1) \
+#define CutInternalDerivatives(X)                                              \
+  CutInternalDerivativesImpl(X, X0) CutInternalDerivativesImpl(X, X1)          \
       CutInternalDerivativesImpl(X, X2) CutInternalDerivativesImpl(X, X3)
 
-#define InternalDerivativesImpl(X, Y)                 \
-  else if (deriv == Jacobian::Line::Shape##X##Y) {    \
-    const Numeric d = value.n;                        \
-    const Complex dFm = std::conj(ls_mirr.dFd##X(d)); \
-    const Complex dFls = ls.dFd##X(d) + dFm;          \
-    com.dF[com.jac_pos(iv, ij)] += S * LM * dFls;     \
-    if (do_nlte) {                                    \
-      com.dN[com.jac_pos(iv, ij)] += DS * LM * dFls;  \
-    }                                                 \
+#define InternalDerivativesImpl(X, Y)                                          \
+  else if (deriv == Jacobian::Line::Shape##X##Y) {                             \
+    const Numeric d = value.n;                                                 \
+    const Complex dFm = std::conj(ls_mirr.dFd##X(d));                          \
+    const Complex dFls = ls.dFd##X(d) + dFm;                                   \
+    com.dF[com.jac_pos(iv, ij)] += S * LM * dFls;                              \
+    if (do_nlte) {                                                             \
+      com.dN[com.jac_pos(iv, ij)] += DS * LM * dFls;                           \
+    }                                                                          \
   }
 
-#define InternalDerivatives(X)                                  \
-  InternalDerivativesImpl(X, X0) InternalDerivativesImpl(X, X1) \
+#define InternalDerivatives(X)                                                 \
+  InternalDerivativesImpl(X, X0) InternalDerivativesImpl(X, X1)                \
       InternalDerivativesImpl(X, X2) InternalDerivativesImpl(X, X3)
 
-#define InternalDerivativesSetupImpl(X, Y)                               \
-  else if (deriv == Jacobian::Line::Shape##X##Y) {                       \
-    const Index pos =                                                    \
-        band.BroadeningSpeciesPosition(deriv.Target().species_id);       \
-    if (pos >= 0) {                                                      \
-      derivs[ij].value.n =                                               \
-          band.lines[i].lineshape.d##X##_d##Y(T, band.T0, P, pos, vmrs); \
-    } else {                                                             \
-      derivs[ij].value.n = 0;                                            \
-    }                                                                    \
+#define InternalDerivativesSetupImpl(X, Y)                                     \
+  else if (deriv == Jacobian::Line::Shape##X##Y) {                             \
+    const Index pos =                                                          \
+        band.BroadeningSpeciesPosition(deriv.Target().species_id);             \
+    if (pos >= 0) {                                                            \
+      derivs[ij].value.n =                                                     \
+          band.lines[i].lineshape.d##X##_d##Y(T, band.T0, P, pos, vmrs);       \
+    } else {                                                                   \
+      derivs[ij].value.n = 0;                                                  \
+    }                                                                          \
   }
 
-#define InternalDerivativesSetup(X)                                       \
-  InternalDerivativesSetupImpl(X, X0) InternalDerivativesSetupImpl(X, X1) \
+#define InternalDerivativesSetup(X)                                            \
+  InternalDerivativesSetupImpl(X, X0) InternalDerivativesSetupImpl(X, X1)      \
       InternalDerivativesSetupImpl(X, X2) InternalDerivativesSetupImpl(X, X3)
 
-#define InternalDerivativesGImpl(X)                  \
-  else if (deriv == Jacobian::Line::ShapeG##X) {     \
-    const Numeric dLM = value.n;                     \
-    com.dF[com.jac_pos(iv, ij)] += dLM * S * Fls;    \
-    if (do_nlte) {                                   \
-      com.dN[com.jac_pos(iv, ij)] += dLM * DS * Fls; \
-    }                                                \
+#define InternalDerivativesGImpl(X)                                            \
+  else if (deriv == Jacobian::Line::ShapeG##X) {                               \
+    const Numeric dLM = value.n;                                               \
+    com.dF[com.jac_pos(iv, ij)] += dLM * S * Fls;                              \
+    if (do_nlte) {                                                             \
+      com.dN[com.jac_pos(iv, ij)] += dLM * DS * Fls;                           \
+    }                                                                          \
   }
 
-#define InternalDerivativesG                                \
-  InternalDerivativesGImpl(X0) InternalDerivativesGImpl(X1) \
+#define InternalDerivativesG                                                   \
+  InternalDerivativesGImpl(X0) InternalDerivativesGImpl(X1)                    \
       InternalDerivativesGImpl(X2) InternalDerivativesGImpl(X3)
 
-#define InternalDerivativesYImpl(X)                  \
-  else if (deriv == Jacobian::Line::ShapeY##X) {     \
-    const Complex dLM = Complex(0, -value.n);        \
-    com.dF[com.jac_pos(iv, ij)] += dLM * S * Fls;    \
-    if (do_nlte) {                                   \
-      com.dN[com.jac_pos(iv, ij)] += dLM * DS * Fls; \
-    }                                                \
+#define InternalDerivativesYImpl(X)                                            \
+  else if (deriv == Jacobian::Line::ShapeY##X) {                               \
+    const Complex dLM = Complex(0, -value.n);                                  \
+    com.dF[com.jac_pos(iv, ij)] += dLM * S * Fls;                              \
+    if (do_nlte) {                                                             \
+      com.dN[com.jac_pos(iv, ij)] += dLM * DS * Fls;                           \
+    }                                                                          \
   }
 
-#define InternalDerivativesY                                \
-  InternalDerivativesYImpl(X0) InternalDerivativesYImpl(X1) \
+#define InternalDerivativesY                                                   \
+  InternalDerivativesYImpl(X0) InternalDerivativesYImpl(X1)                    \
       InternalDerivativesYImpl(X2) InternalDerivativesYImpl(X3)
 
 //! Struct to keep the cutoff limited range values
@@ -2171,8 +2096,7 @@ struct CutoffRange {
  * @param[in] f_grid As WSV, must be sorted
  * @return out so that the Range above can be formed
  */
-CutoffRange limited_range(const Numeric fl,
-                          const Numeric fu,
+CutoffRange limited_range(const Numeric fl, const Numeric fu,
                           const Vector &f_grid) ARTS_NOEXCEPT {
   ARTS_ASSERT(fu > fl);
   const Numeric *it0 = f_grid.get_c_array();
@@ -2189,13 +2113,9 @@ struct SparseLimitRange {
   Index start_upp, size_upp;
 };
 
-SparseLimitRange linear_sparse_limited_range(const Numeric flc,
-                                             const Numeric fuc,
-                                             const Numeric fls,
-                                             const Numeric fus,
-                                             const Vector &f_grid,
-                                             const Vector &sparse_f_grid)
-    ARTS_NOEXCEPT {
+SparseLimitRange linear_sparse_limited_range(
+    const Numeric flc, const Numeric fuc, const Numeric fls, const Numeric fus,
+    const Vector &f_grid, const Vector &sparse_f_grid) ARTS_NOEXCEPT {
   ARTS_ASSERT(fls > flc);
   ARTS_ASSERT(fus > fls);
   ARTS_ASSERT(fuc > fus);
@@ -2206,25 +2126,29 @@ SparseLimitRange linear_sparse_limited_range(const Numeric flc,
   const Numeric *it0s = sparse_f_grid.get_c_array();
   const Numeric *itns = it0s + nvs;
   const Numeric *itlc =
-      std::lower_bound(it0s, itns, std::nextafter(flc, fuc));  // lower cutoff
+      std::lower_bound(it0s, itns, std::nextafter(flc, fuc)); // lower cutoff
   const Numeric *ituc =
-      std::upper_bound(itlc, itns, std::nextafter(fuc, flc));  // upper cutoff
-  const Numeric *itls = std::upper_bound(itlc, ituc, fls);     // lower sparse
-  const Numeric *itus = std::lower_bound(itls, ituc, fus);     // upper sparse
+      std::upper_bound(itlc, itns, std::nextafter(fuc, flc)); // upper cutoff
+  const Numeric *itls = std::upper_bound(itlc, ituc, fls);    // lower sparse
+  const Numeric *itus = std::lower_bound(itls, ituc, fus);    // upper sparse
 
   /* Start and size of sparse adjusted to the 2-grid
-   * 
+   *
    * The interface to the dense grid is altered slightly so that
    * a complete set-of-2 quadratic interopolation points becomes
    * a guarantee.  Their start/end points ignore this restriction
    * but have been defined to not contain anything extra
    */
-  Index beg_lr = std::distance(it0s, itlc); /*while (beg_lr % 2) --beg_lr;*/
+  Index const beg_lr =
+      std::distance(it0s, itlc); /*while (beg_lr % 2) --beg_lr;*/
   Index end_lr = std::distance(it0s, itls);
-  while (end_lr % 2) --end_lr;
+  while (end_lr % 2)
+    --end_lr;
   Index beg_ur = std::distance(it0s, itus);
-  while (beg_ur % 2) ++beg_ur;
-  Index end_ur = std::distance(it0s, ituc); /*while (end_ur % 2) ++end_ur;*/
+  while (beg_ur % 2)
+    ++beg_ur;
+  Index const end_ur =
+      std::distance(it0s, ituc); /*while (end_ur % 2) ++end_ur;*/
 
   // Find new limits
   const Numeric fl =
@@ -2235,9 +2159,9 @@ SparseLimitRange linear_sparse_limited_range(const Numeric flc,
   // Find bounds in dense
   const Numeric *it0 = f_grid.get_c_array();
   const Numeric *itn = it0 + f_grid.size();
-  const Numeric *itl = std::lower_bound(it0, itn, fl);  // include boundary
+  const Numeric *itl = std::lower_bound(it0, itn, fl); // include boundary
   const Numeric *itu =
-      std::upper_bound(itl, itn, std::nextafter(fu, fl));  // dismiss boundary
+      std::upper_bound(itl, itn, std::nextafter(fu, fl)); // dismiss boundary
 
   return {std::distance(it0, itl),
           std::distance(itl, itu),
@@ -2247,13 +2171,9 @@ SparseLimitRange linear_sparse_limited_range(const Numeric flc,
           end_ur - beg_ur};
 }
 
-SparseLimitRange quad_sparse_limited_range(const Numeric flc,
-                                           const Numeric fuc,
-                                           const Numeric fls,
-                                           const Numeric fus,
-                                           const Vector &f_grid,
-                                           const Vector &sparse_f_grid)
-    ARTS_NOEXCEPT {
+SparseLimitRange quad_sparse_limited_range(
+    const Numeric flc, const Numeric fuc, const Numeric fls, const Numeric fus,
+    const Vector &f_grid, const Vector &sparse_f_grid) ARTS_NOEXCEPT {
   ARTS_ASSERT(fls > flc);
   ARTS_ASSERT(fus > fls);
   ARTS_ASSERT(fuc > fus);
@@ -2265,22 +2185,22 @@ SparseLimitRange quad_sparse_limited_range(const Numeric flc,
   const Numeric *const it0s = sparse_f_grid.get_c_array();
   const Numeric *const itns = it0s + nvs;
   const Numeric *itlc =
-      std::lower_bound(it0s, itns, std::nextafter(flc, fuc));  // lower cutoff
+      std::lower_bound(it0s, itns, std::nextafter(flc, fuc)); // lower cutoff
   const Numeric *ituc =
-      std::upper_bound(itlc, itns, std::nextafter(fuc, flc));  // upper cutoff
+      std::upper_bound(itlc, itns, std::nextafter(fuc, flc)); // upper cutoff
   const Numeric *itls =
-      std::upper_bound(itlc, ituc, std::nextafter(fls, flc));  // lower sparse
+      std::upper_bound(itlc, ituc, std::nextafter(fls, flc)); // lower sparse
   const Numeric *itus =
-      std::lower_bound(itls, ituc, std::nextafter(fus, fuc));  // upper sparse
+      std::lower_bound(itls, ituc, std::nextafter(fus, fuc)); // upper sparse
 
   /* Start and size of sparse adjusted to the 3-grid
-   * 
+   *
    * The interface to the dense grid is altered slightly so that
    * a complete set-of-3 quadratic interpolation points becomes
    * a guarantee.  Their end points are modified to contain
    * only set-of-3.  If the range is not modified correctly,
    * you risk having negative interpolation out of your range.
-   * 
+   *
    * To avoid negative absorption entirely, the range between
    * the true cutoff and the outer-most sparse grid point must
    * have at least two values.  If they have only one value,
@@ -2288,10 +2208,14 @@ SparseLimitRange quad_sparse_limited_range(const Numeric flc,
    * in the outer range.  So there's a small range that has to
    * be ignored
    */
-  while (std::distance(it0s, itls) % 3) --itls;
-  while (std::distance(itlc, itls) % 3 == 1) ++itlc;  // skip some cutoff
-  while (std::distance(it0s, itus) % 3) ++itus;
-  while (std::distance(itus, ituc) % 3 == 1) --ituc;  // skip some cutoff
+  while (std::distance(it0s, itls) % 3)
+    --itls;
+  while (std::distance(itlc, itls) % 3 == 1)
+    ++itlc; // skip some cutoff
+  while (std::distance(it0s, itus) % 3)
+    ++itus;
+  while (std::distance(itus, ituc) % 3 == 1)
+    --ituc; // skip some cutoff
 
   // Find bounds in dense
   const Numeric *const it0 = f_grid.get_c_array();
@@ -2300,25 +2224,22 @@ SparseLimitRange quad_sparse_limited_range(const Numeric flc,
   const Numeric *itu;
 
   if (itls not_eq itns) {
-    itl = std::lower_bound(it0, itn, *itls);  // include boundary
+    itl = std::lower_bound(it0, itn, *itls); // include boundary
   } else {
-    itl = std::lower_bound(it0, itn, flc);  // include boundary
+    itl = std::lower_bound(it0, itn, flc); // include boundary
   }
 
   if (itus not_eq itns and itl not_eq itn) {
-    itu = std::upper_bound(
-        itl, itn, std::nextafter(*itus, *itl));  // dismiss boundary
+    itu = std::upper_bound(itl, itn,
+                           std::nextafter(*itus, *itl)); // dismiss boundary
   } else {
-    itu = std::lower_bound(
-        itl, itn, std::nextafter(fuc, flc));  // include boundary
+    itu = std::lower_bound(itl, itn,
+                           std::nextafter(fuc, flc)); // include boundary
   }
 
-  return {std::distance(it0, itl),
-          std::distance(itl, itu),
-          std::distance(it0s, itlc),
-          std::distance(itlc, itls),
-          std::distance(it0s, itus),
-          std::distance(itus, ituc)};
+  return {std::distance(it0, itl),   std::distance(itl, itu),
+          std::distance(it0s, itlc), std::distance(itlc, itls),
+          std::distance(it0s, itus), std::distance(itus, ituc)};
 }
 
 /** Data struct for keeping derivative keys and values
@@ -2345,9 +2266,8 @@ using ArrayOfDerivatives = Array<Derivatives>;
 Index active_nelem(const ArrayOfDerivatives &derivs) noexcept {
   return std::distance(
       derivs.cbegin(),
-      std::find_if(derivs.cbegin(), derivs.cend(), [](auto &deriv) {
-        return deriv.deriv == nullptr;
-      }));
+      std::find_if(derivs.cbegin(), derivs.cend(),
+                   [](auto &deriv) { return deriv.deriv == nullptr; }));
 }
 
 struct ComputeValues {
@@ -2366,43 +2286,24 @@ struct ComputeValues {
     return jac_size * iv + ij;
   }
 
-  ComputeValues(ComplexVector &F_,
-                ComplexMatrix &dF_,
-                ComplexVector &N_,
-                ComplexMatrix &dN_,
-                const Vector &f_grid,
-                const Index start,
-                const Index nv,
-                const ArrayOfDerivatives &derivs_,
+  ComputeValues(ComplexVector &F_, ComplexMatrix &dF_, ComplexVector &N_,
+                ComplexMatrix &dN_, const Vector &f_grid, const Index start,
+                const Index nv, const ArrayOfDerivatives &derivs_,
                 const bool do_nlte_) noexcept
       : F(F_.get_c_array() + start),
         dF(dF_.get_c_array() + start * derivs_.size()),
         N(N_.get_c_array() + start),
         dN(dN_.get_c_array() + start * derivs_.size()),
-        f(f_grid.get_c_array() + start),
-        size(nv),
-        derivs(derivs_),
-        jac_size(derivs_.size()),
-        max_jac_size(active_nelem(derivs)),
+        f(f_grid.get_c_array() + start), size(nv), derivs(derivs_),
+        jac_size(derivs_.size()), max_jac_size(active_nelem(derivs)),
         do_nlte(do_nlte_) {}
 
-  ComputeValues(Complex &F_,
-                std::vector<Complex> &dF_,
-                Complex &N_,
-                std::vector<Complex> &dN_,
-                const Numeric &f_lim,
-                const ArrayOfDerivatives &derivs_,
-                const bool do_nlte_) noexcept
-      : F(&F_),
-        dF(dF_.data()),
-        N(&N_),
-        dN(dN_.data()),
-        f(&f_lim),
-        size(1),
-        derivs(derivs_),
-        jac_size(derivs.nelem()),
-        max_jac_size(active_nelem(derivs)),
-        do_nlte(do_nlte_) {}
+  ComputeValues(Complex &F_, std::vector<Complex> &dF_, Complex &N_,
+                std::vector<Complex> &dN_, const Numeric &f_lim,
+                const ArrayOfDerivatives &derivs_, const bool do_nlte_) noexcept
+      : F(&F_), dF(dF_.data()), N(&N_), dN(dN_.data()), f(&f_lim), size(1),
+        derivs(derivs_), jac_size(derivs.nelem()),
+        max_jac_size(active_nelem(derivs)), do_nlte(do_nlte_) {}
 
   ComputeValues &operator-=(const ComputeValues &cut) ARTS_NOEXCEPT {
     ARTS_ASSERT(cut.size == 1, "Not a cutoff limit")
@@ -2482,57 +2383,51 @@ Complex Calculator::operator()(Numeric f) noexcept {
   return std::visit([f](auto &&LS) { return LS(f); }, ls);
 }
 
-Calculator::Calculator(const Type type,
-                       const Numeric F0,
-                       const Output &X,
-                       const Numeric DC,
-                       const Numeric DZ,
+Calculator::Calculator(const Type type, const Numeric F0, const Output &X,
+                       const Numeric DC, const Numeric DZ,
                        bool manually_mirrored) noexcept
     : ls(Noshape{}) {
   if (not manually_mirrored) {
     switch (type) {
-      case Type::DP:
-        ls = Doppler(F0, DC, DZ);
-        break;
-      case Type::LP:
-        ls = Lorentz(F0, X);
-        break;
-      case Type::VP:
-        ls = Voigt(F0, X, DC, DZ);
-        break;
-      case Type::SDVP:
-        ls = SpeedDependentVoigt(F0, X, DC, DZ);
-        break;
-      case Type::HTP:
-        ls = HartmannTran(F0, X, DC, DZ);
-        break;
-      case Type::FINAL: { /*leave last*/
-      }
+    case Type::DP:
+      ls = Doppler(F0, DC, DZ);
+      break;
+    case Type::LP:
+      ls = Lorentz(F0, X);
+      break;
+    case Type::VP:
+      ls = Voigt(F0, X, DC, DZ);
+      break;
+    case Type::SDVP:
+      ls = SpeedDependentVoigt(F0, X, DC, DZ);
+      break;
+    case Type::HTP:
+      ls = HartmannTran(F0, X, DC, DZ);
+      break;
+    case Type::FINAL: { /*leave last*/
+    }
     }
   }
 }
 
-Calculator::Calculator(const Absorption::MirroringType mirror,
-                       const Type type,
-                       const Numeric F0,
-                       const Output &X,
-                       const Numeric DC,
+Calculator::Calculator(const Absorption::MirroringType mirror, const Type type,
+                       const Numeric F0, const Output &X, const Numeric DC,
                        const Numeric DZ)
     : ls(Noshape{}) {
   switch (mirror) {
-    case Absorption::MirroringType::Lorentz:
-      ls = Lorentz(-F0, mirroredOutput(X));
-      break;
-    case Absorption::MirroringType::SameAsLineShape:
-      *this = {type, -F0, mirroredOutput(X), -DC, -DZ, false};
-      break;
-    case Absorption::MirroringType::Manual:
-      *this = {type, F0, mirroredOutput(X), -DC, -DZ, false};
-      break;
-    case Absorption::MirroringType::None:
-      break;
-    case Absorption::MirroringType::FINAL: { /*leave last*/
-    }
+  case Absorption::MirroringType::Lorentz:
+    ls = Lorentz(-F0, mirroredOutput(X));
+    break;
+  case Absorption::MirroringType::SameAsLineShape:
+    *this = {type, -F0, mirroredOutput(X), -DC, -DZ, false};
+    break;
+  case Absorption::MirroringType::Manual:
+    *this = {type, F0, mirroredOutput(X), -DC, -DZ, false};
+    break;
+  case Absorption::MirroringType::None:
+    break;
+  case Absorption::MirroringType::FINAL: { /*leave last*/
+  }
   }
 }
 
@@ -2553,26 +2448,25 @@ Numeric Normalizer::operator()(Numeric f) noexcept {
 }
 
 Normalizer::Normalizer(const Absorption::NormalizationType type,
-                       const Numeric F0,
-                       const Numeric T) noexcept
+                       const Numeric F0, const Numeric T) noexcept
     : ls_norm(Nonorm{}) {
   switch (type) {
-    case Absorption::NormalizationType::None:
-      break;
-    case Absorption::NormalizationType::RQ:
-      ls_norm = RosenkranzQuadratic(F0, T);
-      break;
-    case Absorption::NormalizationType::VVH:
-      ls_norm = VanVleckHuber(F0, T);
-      break;
-    case Absorption::NormalizationType::VVW:
-      ls_norm = VanVleckWeisskopf(F0);
-      break;
-    case Absorption::NormalizationType::SFS:
-      ls_norm = SimpleFrequencyScaling(F0, T);
-      break;
-    case Absorption::NormalizationType::FINAL: { /*leave last*/
-    }
+  case Absorption::NormalizationType::None:
+    break;
+  case Absorption::NormalizationType::RQ:
+    ls_norm = RosenkranzQuadratic(F0, T);
+    break;
+  case Absorption::NormalizationType::VVH:
+    ls_norm = VanVleckHuber(F0, T);
+    break;
+  case Absorption::NormalizationType::VVW:
+    ls_norm = VanVleckWeisskopf(F0);
+    break;
+  case Absorption::NormalizationType::SFS:
+    ls_norm = SimpleFrequencyScaling(F0, T);
+    break;
+  case Absorption::NormalizationType::FINAL: { /*leave last*/
+  }
   }
 }
 
@@ -2632,71 +2526,37 @@ Numeric IntensityCalculator::dNdSELFVMR() const noexcept {
   return std::visit([](auto &&LS) { return LS.dNdSELFVMR(); }, ls_str);
 }
 
-IntensityCalculator::IntensityCalculator(const Numeric T,
-                                         const Numeric QT,
-                                         const Numeric QT0,
-                                         const Numeric dQTdT,
-                                         const Numeric r,
-                                         const Numeric drdSELFVMR,
-                                         const Numeric drdT,
-                                         const EnergyLevelMap &nlte,
-                                         const Absorption::Lines &band,
-                                         const Index line_index) noexcept
+IntensityCalculator::IntensityCalculator(
+    const Numeric T, const Numeric QT, const Numeric QT0, const Numeric dQTdT,
+    const Numeric r, const Numeric drdSELFVMR, const Numeric drdT,
+    const EnergyLevelMap &nlte, const Absorption::Lines &band,
+    const Index line_index) noexcept
     : ls_str(Nostrength{}) {
   const auto &line = band.lines[line_index];
   switch (band.population) {
-    case Absorption::PopulationType::ByHITRANFullRelmat:
-    case Absorption::PopulationType::ByHITRANRosenkranzRelmat:
-    case Absorption::PopulationType::ByMakarovFullRelmat:
-    case Absorption::PopulationType::ByRovibLinearDipoleLineMixing:
-    case Absorption::PopulationType::LTE:
-      ls_str = LocalThermodynamicEquilibrium(line.I0,
-                                             band.T0,
-                                             T,
-                                             line.F0,
-                                             line.E0,
-                                             QT,
-                                             QT0,
-                                             dQTdT,
-                                             r,
-                                             drdSELFVMR,
-                                             drdT);
-      break;
-    case Absorption::PopulationType::NLTE: {
-      const auto [r_low, r_upp] = nlte.get_ratio_params(band, line_index);
-      ls_str = FullNonLocalThermodynamicEquilibrium(line.F0,
-                                                    line.A,
-                                                    T,
-                                                    line.glow,
-                                                    line.gupp,
-                                                    r_low,
-                                                    r_upp,
-                                                    r,
-                                                    drdSELFVMR,
-                                                    drdT);
-    } break;
-    case Absorption::PopulationType::VibTemps: {
-      const auto [E_low, E_upp, T_low, T_upp] =
-          nlte.get_vibtemp_params(band, T);
-      ls_str =
-          VibrationalTemperaturesNonLocalThermodynamicEquilibrium(line.I0,
-                                                                  band.T0,
-                                                                  T,
-                                                                  T_low,
-                                                                  T_upp,
-                                                                  line.F0,
-                                                                  line.E0,
-                                                                  E_low,
-                                                                  E_upp,
-                                                                  QT,
-                                                                  QT0,
-                                                                  dQTdT,
-                                                                  r,
-                                                                  drdSELFVMR,
-                                                                  drdT);
-    } break;
-    case Absorption::PopulationType::FINAL: { /*leave last*/
-    }
+  case Absorption::PopulationType::ByHITRANFullRelmat:
+  case Absorption::PopulationType::ByHITRANRosenkranzRelmat:
+  case Absorption::PopulationType::ByMakarovFullRelmat:
+  case Absorption::PopulationType::ByRovibLinearDipoleLineMixing:
+  case Absorption::PopulationType::LTE:
+    ls_str =
+        LocalThermodynamicEquilibrium(line.I0, band.T0, T, line.F0, line.E0, QT,
+                                      QT0, dQTdT, r, drdSELFVMR, drdT);
+    break;
+  case Absorption::PopulationType::NLTE: {
+    const auto [r_low, r_upp] = nlte.get_ratio_params(band, line_index);
+    ls_str = FullNonLocalThermodynamicEquilibrium(line.F0, line.A, T, line.glow,
+                                                  line.gupp, r_low, r_upp, r,
+                                                  drdSELFVMR, drdT);
+  } break;
+  case Absorption::PopulationType::VibTemps: {
+    const auto [E_low, E_upp, T_low, T_upp] = nlte.get_vibtemp_params(band, T);
+    ls_str = VibrationalTemperaturesNonLocalThermodynamicEquilibrium(
+        line.I0, band.T0, T, T_low, T_upp, line.F0, line.E0, E_low, E_upp, QT,
+        QT0, dQTdT, r, drdSELFVMR, drdT);
+  } break;
+  case Absorption::PopulationType::FINAL: { /*leave last*/
+  }
   }
 }
 
@@ -2762,22 +2622,18 @@ IntensityCalculator::IntensityCalculator(const Numeric T,
  * @param[in] ls The line shape calculator. \f$ F_i \f$
  * @param[in] ls_mirr The mirrored line shape calculator. \f$ F^M_i \f$
  */
-void cutoff_frequency_loop(ComputeValues &com,
-                           Calculator &ls,
-                           Calculator &ls_mirr,
-                           Normalizer &ls_norm,
+void cutoff_frequency_loop(ComputeValues &com, Calculator &ls,
+                           Calculator &ls_mirr, Normalizer &ls_norm,
                            const Calculator &ls_cut,
                            const Calculator &ls_mirr_cut,
                            const IntensityCalculator &ls_str,
-                           const ArrayOfDerivatives &derivs, 
-                           const Complex LM,
-                           const Numeric &T, 
-                           const Numeric &dfdH,
-                           const Numeric &Sz, 
+                           const ArrayOfDerivatives &derivs, const Complex LM,
+                           const Numeric &T, const Numeric &dfdH,
+                           const Numeric &Sz,
                            const Species::Species self_species) ARTS_NOEXCEPT {
   const Index nv = com.size;
   const bool do_nlte = com.do_nlte;
-  
+
   const Numeric Si = ls_str.S();
   const Numeric DNi = ls_str.N();
 
@@ -2793,24 +2649,27 @@ void cutoff_frequency_loop(ComputeValues &com,
     if (do_nlte) {
       com.N[iv] += DS * LM * Fls;
     }
-    
-    for (const auto& [lt, value, ij, deriv_ptr]: derivs) {
-      if (not deriv_ptr) break;
-      const auto& deriv = *deriv_ptr;
+
+    for (const auto &[lt, value, ij, deriv_ptr] : derivs) {
+      if (not deriv_ptr)
+        break;
+      const auto &deriv = *deriv_ptr;
 
       if (deriv == Jacobian::Atm::Temperature) {
         const auto &dXdT = value.o;
         const Numeric dSn = ls_norm.dNdT(T, f);
         const Numeric dSi = ls_str.dSdT();
         const Complex dLM(dXdT.G, -dXdT.Y);
-        const Complex dFm = std::conj(ls_mirr.dFdT(mirroredOutput(dXdT), T) - ls_mirr_cut.dFdT(mirroredOutput(dXdT), T));
+        const Complex dFm =
+            std::conj(ls_mirr.dFdT(mirroredOutput(dXdT), T) -
+                      ls_mirr_cut.dFdT(mirroredOutput(dXdT), T));
         const Complex dFls = ls.dFdT(dXdT, T) - ls_cut.dFdT(dXdT, T) + dFm;
         com.dF[com.jac_pos(iv, ij)] +=
             S * (LM * dFls + dLM * Fls) + Sz * (dSn * Si + Sn * dSi) * LM * Fls;
         if (do_nlte) {
           const Numeric dDSi = ls_str.dNdT();
           com.dN[com.jac_pos(iv, ij)] += DS * (LM * dFls + dLM * Fls) +
-                        Sz * (dSn * Si + Sn * dDSi) * LM * Fls;
+                                         Sz * (dSn * Si + Sn * dDSi) * LM * Fls;
         }
       } else if (deriv.is_wind()) {
         const Complex dFm = std::conj(ls_mirr.dFdf() - ls_mirr_cut.dFdf());
@@ -2822,7 +2681,8 @@ void cutoff_frequency_loop(ComputeValues &com,
           com.dN[com.jac_pos(iv, ij)] += DS * LM * dFls + dDS * LM * Fls;
         }
       } else if (deriv.is_mag()) {
-        const Complex dFm = std::conj(ls_mirr.dFdH(-dfdH) - ls_mirr_cut.dFdH(-dfdH));
+        const Complex dFm =
+            std::conj(ls_mirr.dFdH(-dfdH) - ls_mirr_cut.dFdH(-dfdH));
         const Complex dFls = ls.dFdH(dfdH) - ls_cut.dFdH(dfdH) + dFm;
         com.dF[com.jac_pos(iv, ij)] += S * LM * dFls;
         if (do_nlte) {
@@ -2831,12 +2691,15 @@ void cutoff_frequency_loop(ComputeValues &com,
       } else if (deriv == Jacobian::Special::ArrayOfSpeciesTagVMR) {
         com.dF[com.jac_pos(iv, ij)] += Sz * Sn * ls_str.dSdSELFVMR() * LM * Fls;
         if (do_nlte) {
-          com.dN[com.jac_pos(iv, ij)] += Sz * Sn * ls_str.dNdSELFVMR() * LM * Fls;
+          com.dN[com.jac_pos(iv, ij)] +=
+              Sz * Sn * ls_str.dNdSELFVMR() * LM * Fls;
         }
       } else if (deriv.Target().needQuantumIdentity()) {
         if (deriv == Jacobian::Line::VMR) {
           const auto &dXdVMR = value.o;
-          const Complex dFm = std::conj(ls_mirr.dFdVMR(mirroredOutput(dXdVMR)) - ls_mirr_cut.dFdVMR(mirroredOutput(dXdVMR)));
+          const Complex dFm =
+              std::conj(ls_mirr.dFdVMR(mirroredOutput(dXdVMR)) -
+                        ls_mirr_cut.dFdVMR(mirroredOutput(dXdVMR)));
           const Complex dLM(dXdVMR.G, -dXdVMR.Y);
           const Complex dFls = ls.dFdVMR(dXdVMR) - ls_cut.dFdVMR(dXdVMR) + dFm;
           com.dF[com.jac_pos(iv, ij)] += S * LM * dFls + dLM * S * Fls;
@@ -2853,7 +2716,8 @@ void cutoff_frequency_loop(ComputeValues &com,
           if (lt == Quantum::Number::StateMatchType::Full) {
             if (deriv == Jacobian::Line::Center) {
               const Numeric d = ls_norm.dNdF0() * Si + ls_str.dSdF0() * Sn;
-              const Complex dFm = std::conj(ls_mirr.dFdF0() - ls_mirr_cut.dFdF0());
+              const Complex dFm =
+                  std::conj(ls_mirr.dFdF0() - ls_mirr_cut.dFdF0());
               const Complex dFls = ls.dFdF0() - ls_cut.dFdF0() + dFm;
               const Numeric dS = Sz * d;
               com.dF[com.jac_pos(iv, ij)] += S * LM * dFls + dS * LM * Fls;
@@ -2871,21 +2735,17 @@ void cutoff_frequency_loop(ComputeValues &com,
               }
             }
             // All line shape derivatives
-            CutInternalDerivatives(G0)
-            CutInternalDerivatives(D0)
-            CutInternalDerivatives(G2)
-            CutInternalDerivatives(D2)
-            CutInternalDerivatives(ETA)
-            CutInternalDerivatives(FVC)
-            InternalDerivativesY
-            InternalDerivativesG
-            CutInternalDerivatives(DV)
+            CutInternalDerivatives(G0) CutInternalDerivatives(D0)
+                CutInternalDerivatives(G2) CutInternalDerivatives(D2)
+                    CutInternalDerivatives(ETA) CutInternalDerivatives(FVC)
+                        InternalDerivativesY InternalDerivativesG
+                        CutInternalDerivatives(DV)
           } else if (lt == Quantum::Number::StateMatchType::Level) {
             if (deriv == Jacobian::Line::NLTE) {
               if (lt.upp) {
                 const Numeric dS = Sz * Sn * ls_str.dSdNLTEu();
                 com.dF[com.jac_pos(iv, ij)] += dS * LM * Fls;
-                
+
                 if (do_nlte) {
                   const Numeric DdS = Sz * Sn * ls_str.dNdNLTEu();
                   com.dN[com.jac_pos(iv, ij)] += DdS * LM * Fls;
@@ -2895,7 +2755,7 @@ void cutoff_frequency_loop(ComputeValues &com,
               if (lt.low) {
                 const Numeric dS = Sz * Sn * ls_str.dSdNLTEl();
                 com.dF[com.jac_pos(iv, ij)] += dS * LM * Fls;
-                
+
                 if (do_nlte) {
                   const Numeric DdS = Sz * Sn * ls_str.dNdNLTEl();
                   com.dN[com.jac_pos(iv, ij)] += DdS * LM * Fls;
@@ -2970,20 +2830,14 @@ void cutoff_frequency_loop(ComputeValues &com,
  * @param[in] ls The line shape calculator. \f$ F_i \f$
  * @param[in] ls_mirr The mirrored line shape calculator. \f$ F^M_i \f$
  */
-void frequency_loop(ComputeValues &com,
-                    Calculator &ls,
-                    Calculator &ls_mirr,
-                    Normalizer &ls_norm,
-                    const IntensityCalculator &ls_str, 
-                    const ArrayOfDerivatives &derivs, 
-                    const Complex LM,
-                    const Numeric &T, 
-                    const Numeric &dfdH,
-                    const Numeric &Sz, 
+void frequency_loop(ComputeValues &com, Calculator &ls, Calculator &ls_mirr,
+                    Normalizer &ls_norm, const IntensityCalculator &ls_str,
+                    const ArrayOfDerivatives &derivs, const Complex LM,
+                    const Numeric &T, const Numeric &dfdH, const Numeric &Sz,
                     const Species::Species self_species) ARTS_NOEXCEPT {
   const Index nv = com.size;
   const bool do_nlte = com.do_nlte;
-  
+
   const Numeric Si = ls_str.S();
   const Numeric DNi = ls_str.N();
 
@@ -2999,10 +2853,11 @@ void frequency_loop(ComputeValues &com,
     if (do_nlte) {
       com.N[iv] += DS * LM * Fls;
     }
-    
-    for (const auto& [lt, value, ij, deriv_ptr]: derivs) {
-      if (not deriv_ptr) break;
-      const auto& deriv = *deriv_ptr;
+
+    for (const auto &[lt, value, ij, deriv_ptr] : derivs) {
+      if (not deriv_ptr)
+        break;
+      const auto &deriv = *deriv_ptr;
 
       if (deriv == Jacobian::Atm::Temperature) {
         const auto &dXdT = value.o;
@@ -3016,7 +2871,7 @@ void frequency_loop(ComputeValues &com,
         if (do_nlte) {
           const Numeric dDSi = ls_str.dNdT();
           com.dN[com.jac_pos(iv, ij)] += DS * (LM * dFls + dLM * Fls) +
-                        Sz * (dSn * Si + Sn * dDSi) * LM * Fls;
+                                         Sz * (dSn * Si + Sn * dDSi) * LM * Fls;
         }
       } else if (deriv.is_wind()) {
         const Complex dFm = std::conj(ls_mirr.dFdf());
@@ -3037,7 +2892,8 @@ void frequency_loop(ComputeValues &com,
       } else if (deriv == Jacobian::Special::ArrayOfSpeciesTagVMR) {
         com.dF[com.jac_pos(iv, ij)] += Sz * Sn * ls_str.dSdSELFVMR() * LM * Fls;
         if (do_nlte) {
-              com.dN[com.jac_pos(iv, ij)] += Sz * Sn * ls_str.dNdSELFVMR() * LM * Fls;
+          com.dN[com.jac_pos(iv, ij)] +=
+              Sz * Sn * ls_str.dNdSELFVMR() * LM * Fls;
         }
       } else if (deriv.Target().needQuantumIdentity()) {
         if (deriv == Jacobian::Line::VMR) {
@@ -3077,21 +2933,17 @@ void frequency_loop(ComputeValues &com,
               }
             }
             // All line shape derivatives
-            InternalDerivatives(G0)
-            InternalDerivatives(D0)
-            InternalDerivatives(G2)
-            InternalDerivatives(D2)
-            InternalDerivatives(ETA)
-            InternalDerivatives(FVC)
-            InternalDerivativesY
-            InternalDerivativesG
-            InternalDerivatives(DV)
+            InternalDerivatives(G0) InternalDerivatives(D0)
+                InternalDerivatives(G2) InternalDerivatives(D2)
+                    InternalDerivatives(ETA) InternalDerivatives(FVC)
+                        InternalDerivativesY InternalDerivativesG
+                        InternalDerivatives(DV)
           } else if (lt == Quantum::Number::StateMatchType::Level) {
             if (deriv == Jacobian::Line::NLTE) {
               if (lt.upp) {
                 const Numeric dS = Sz * Sn * ls_str.dSdNLTEu();
                 com.dF[com.jac_pos(iv, ij)] += dS * LM * Fls;
-                
+
                 if (do_nlte) {
                   const Numeric DdS = Sz * Sn * ls_str.dNdNLTEu();
                   com.dN[com.jac_pos(iv, ij)] += DdS * LM * Fls;
@@ -3101,7 +2953,7 @@ void frequency_loop(ComputeValues &com,
               if (lt.low) {
                 const Numeric dS = Sz * Sn * ls_str.dSdNLTEl();
                 com.dF[com.jac_pos(iv, ij)] += dS * LM * Fls;
-                
+
                 if (do_nlte) {
                   const Numeric DdS = Sz * Sn * ls_str.dNdNLTEl();
                   com.dN[com.jac_pos(iv, ij)] += DdS * LM * Fls;
@@ -3153,19 +3005,13 @@ void frequency_loop(ComputeValues &com,
  * @param[in] ls_norm The normalization calculator. \f$ S_n \f$
  * @param[in] derivs A list of pre-computed derivative values and keys
  */
-void cutoff_loop_sparse_linear(ComputeData &com,
-                               ComputeData &sparse_com,
-                               Normalizer ls_norm,
-                               const IntensityCalculator ls_str,
-                               const AbsorptionLines &band,
-                               const ArrayOfDerivatives &derivs,
-                               const Output X,
-                               const Numeric &T,
-                               const Numeric &H,
-                               const Numeric &sparse_lim,
-                               const Numeric &DC,
-                               const Index i,
-                               const Zeeman::Polarization zeeman_polarization) ARTS_NOEXCEPT {
+void cutoff_loop_sparse_linear(
+    ComputeData &com, ComputeData &sparse_com, Normalizer ls_norm,
+    const IntensityCalculator ls_str, const AbsorptionLines &band,
+    const ArrayOfDerivatives &derivs, const Output X, const Numeric &T,
+    const Numeric &H, const Numeric &sparse_lim, const Numeric &DC,
+    const Index i,
+    const Zeeman::Polarization zeeman_polarization) ARTS_NOEXCEPT {
   // Basic settings
   const bool do_nlte = ls_str.do_nlte();
   const bool do_cutoff = band.cutoff not_eq Absorption::CutoffType::None;
@@ -3175,141 +3021,153 @@ void cutoff_loop_sparse_linear(ComputeData &com,
   const Numeric fls = band.lines[i].F0 - sparse_lim;
 
   // Find sparse and dense ranges
-  const auto [dense_start, dense_size,
-              sparse_low_start, sparse_low_size,
-              sparse_upp_start, sparse_upp_size] = linear_sparse_limited_range(fl, fu, fls, fus,
-                                                                               com.f_grid,
-                                                                               sparse_com.f_grid);
-  if ((dense_size + sparse_low_size + sparse_upp_size) == 0) return;
-  
-  // Get the compute data view
-  ComputeValues comval(com.F, com.dF, com.N, com.dN, com.f_grid, dense_start, dense_size, derivs, do_nlte);
-  
-  // Get views of the sparse data
-  ComputeValues sparse_low_range(sparse_com.F, sparse_com.dF, sparse_com.N, sparse_com.dN, sparse_com.f_grid, sparse_low_start, sparse_low_size, derivs, do_nlte);
-  ComputeValues sparse_upp_range(sparse_com.F, sparse_com.dF, sparse_com.N, sparse_com.dN, sparse_com.f_grid, sparse_upp_start, sparse_upp_size, derivs, do_nlte);
-  
-  const Index nz = band.ZeemanCount(i, zeeman_polarization) ;
-  for (Index iz = 0; iz < nz; iz++) {
-    const Numeric dfdH = band.ZeemanSplitting(i, zeeman_polarization, iz);
-    const Numeric Sz = band.ZeemanStrength(i, zeeman_polarization, iz);
-    const Complex LM = Complex(1 + X.G, -X.Y);
-    Calculator ls(band.lineshapetype, band.lines[i].F0, X, DC, dfdH * H, band.mirroring == Absorption::MirroringType::Manual);
-    Calculator ls_mirr(band.mirroring, band.lineshapetype, band.lines[i].F0, X, DC, dfdH * H);
-    
-    if (do_cutoff) {
-      // Initialize and set the cutoff values
-      Calculator ls_cut = ls;
-      Calculator ls_mirr_cut = ls_mirr;
-      ls_cut(fu);
-      ls_mirr_cut(fu);
-      
-      cutoff_frequency_loop(comval, ls, ls_mirr, ls_norm, ls_cut, ls_mirr_cut, ls_str,
-                     derivs, LM, T, dfdH, Sz, band.Species());
-      
-      if (sparse_low_size) {
-        cutoff_frequency_loop(sparse_low_range, ls, ls_mirr, ls_norm, ls_cut, ls_mirr_cut, ls_str,
-                       derivs, LM, T, dfdH, Sz, band.Species());
-      }
-      
-      if (sparse_upp_size) {
-        cutoff_frequency_loop(sparse_upp_range, ls, ls_mirr, ls_norm, ls_cut, ls_mirr_cut, ls_str,
-                       derivs, LM, T, dfdH, Sz, band.Species());
-      }
-      
-    } else {
-      frequency_loop(comval, ls, ls_mirr, ls_norm, ls_str,
-                    derivs, LM, T, dfdH, Sz, band.Species());
-      
-      if (sparse_low_size) {
-        frequency_loop(sparse_low_range, ls, ls_mirr, ls_norm, ls_str,
-                      derivs, LM, T, dfdH, Sz, band.Species());
-      }
-      
-      if (sparse_upp_size) {
-        frequency_loop(sparse_upp_range, ls, ls_mirr, ls_norm, ls_str,
-                      derivs, LM, T, dfdH, Sz, band.Species());
-      }
-    }
-  }
-}
+  const auto [dense_start, dense_size, sparse_low_start, sparse_low_size,
+              sparse_upp_start, sparse_upp_size] =
+      linear_sparse_limited_range(fl, fu, fls, fus, com.f_grid,
+                                  sparse_com.f_grid);
+  if ((dense_size + sparse_low_size + sparse_upp_size) == 0)
+    return;
 
-void cutoff_loop_sparse_triple(ComputeData &com,
-                               ComputeData &sparse_com,
-                               Normalizer ls_norm,
-                               const IntensityCalculator ls_str,
-                               const AbsorptionLines &band,
-                               const ArrayOfDerivatives &derivs,
-                               const Output X,
-                               const Numeric &T,
-                               const Numeric &H,
-                               const Numeric &sparse_lim,
-                               const Numeric &DC,
-                               const Index i,
-                               const Zeeman::Polarization zeeman_polarization) ARTS_NOEXCEPT {
-  // Basic settings
-  const bool do_nlte = ls_str.do_nlte();
-  const bool do_cutoff = band.cutoff not_eq Absorption::CutoffType::None;
-  const Numeric fu = band.CutoffFreq(i, X.D0);
-  const Numeric fl = band.CutoffFreqMinus(i, X.D0);
-  const Numeric fus = band.lines[i].F0 + sparse_lim;
-  const Numeric fls = band.lines[i].F0 - sparse_lim;
-
-  // Find sparse and dense ranges
-  const auto [dense_start, dense_size,
-              sparse_low_start, sparse_low_size,
-              sparse_upp_start, sparse_upp_size] = quad_sparse_limited_range(fl, fu, fls, fus,
-                                                                             com.f_grid,
-                                                                             sparse_com.f_grid);
-  if ((dense_size + sparse_low_size + sparse_upp_size) == 0) return;
-  
   // Get the compute data view
-  ComputeValues comval(com.F, com.dF, com.N, com.dN, com.f_grid, dense_start, dense_size, derivs, do_nlte);
-  
+  ComputeValues comval(com.F, com.dF, com.N, com.dN, com.f_grid, dense_start,
+                       dense_size, derivs, do_nlte);
+
   // Get views of the sparse data
-  ComputeValues sparse_low_range(sparse_com.F, sparse_com.dF, sparse_com.N, sparse_com.dN, sparse_com.f_grid, sparse_low_start, sparse_low_size, derivs, do_nlte);
-  ComputeValues sparse_upp_range(sparse_com.F, sparse_com.dF, sparse_com.N, sparse_com.dN, sparse_com.f_grid, sparse_upp_start, sparse_upp_size, derivs, do_nlte);
-  
+  ComputeValues sparse_low_range(
+      sparse_com.F, sparse_com.dF, sparse_com.N, sparse_com.dN,
+      sparse_com.f_grid, sparse_low_start, sparse_low_size, derivs, do_nlte);
+  ComputeValues sparse_upp_range(
+      sparse_com.F, sparse_com.dF, sparse_com.N, sparse_com.dN,
+      sparse_com.f_grid, sparse_upp_start, sparse_upp_size, derivs, do_nlte);
+
   const Index nz = band.ZeemanCount(i, zeeman_polarization);
   for (Index iz = 0; iz < nz; iz++) {
     const Numeric dfdH = band.ZeemanSplitting(i, zeeman_polarization, iz);
     const Numeric Sz = band.ZeemanStrength(i, zeeman_polarization, iz);
     const Complex LM = Complex(1 + X.G, -X.Y);
-    Calculator ls(band.lineshapetype, band.lines[i].F0, X, DC, dfdH * H, band.mirroring == Absorption::MirroringType::Manual);
-    Calculator ls_mirr(band.mirroring, band.lineshapetype, band.lines[i].F0, X, DC, dfdH * H);
-    
+    Calculator ls(band.lineshapetype, band.lines[i].F0, X, DC, dfdH * H,
+                  band.mirroring == Absorption::MirroringType::Manual);
+    Calculator ls_mirr(band.mirroring, band.lineshapetype, band.lines[i].F0, X,
+                       DC, dfdH * H);
+
     if (do_cutoff) {
       // Initialize and set the cutoff values
       Calculator ls_cut = ls;
       Calculator ls_mirr_cut = ls_mirr;
       ls_cut(fu);
       ls_mirr_cut(fu);
-      
-      cutoff_frequency_loop(comval, ls, ls_mirr, ls_norm, ls_cut, ls_mirr_cut, ls_str,
-                            derivs, LM, T, dfdH, Sz, band.Species());
-      
+
+      cutoff_frequency_loop(comval, ls, ls_mirr, ls_norm, ls_cut, ls_mirr_cut,
+                            ls_str, derivs, LM, T, dfdH, Sz, band.Species());
+
       if (sparse_low_size) {
-        cutoff_frequency_loop(sparse_low_range, ls, ls_mirr, ls_norm, ls_cut, ls_mirr_cut, ls_str,
-                              derivs, LM, T, dfdH, Sz, band.Species());
+        cutoff_frequency_loop(sparse_low_range, ls, ls_mirr, ls_norm, ls_cut,
+                              ls_mirr_cut, ls_str, derivs, LM, T, dfdH, Sz,
+                              band.Species());
       }
-      
+
       if (sparse_upp_size) {
-        cutoff_frequency_loop(sparse_upp_range, ls, ls_mirr, ls_norm, ls_cut, ls_mirr_cut, ls_str,
-                              derivs, LM, T, dfdH, Sz, band.Species());
+        cutoff_frequency_loop(sparse_upp_range, ls, ls_mirr, ls_norm, ls_cut,
+                              ls_mirr_cut, ls_str, derivs, LM, T, dfdH, Sz,
+                              band.Species());
       }
-      
+
     } else {
-      frequency_loop(comval, ls, ls_mirr, ls_norm, ls_str,
-                     derivs, LM, T, dfdH, Sz, band.Species());
-      
+      frequency_loop(comval, ls, ls_mirr, ls_norm, ls_str, derivs, LM, T, dfdH,
+                     Sz, band.Species());
+
       if (sparse_low_size) {
-        frequency_loop(sparse_low_range, ls, ls_mirr, ls_norm, ls_str,
-                       derivs, LM, T, dfdH, Sz, band.Species());
+        frequency_loop(sparse_low_range, ls, ls_mirr, ls_norm, ls_str, derivs,
+                       LM, T, dfdH, Sz, band.Species());
       }
-      
+
       if (sparse_upp_size) {
-        frequency_loop(sparse_upp_range, ls, ls_mirr, ls_norm, ls_str,
-                       derivs, LM, T, dfdH, Sz, band.Species());
+        frequency_loop(sparse_upp_range, ls, ls_mirr, ls_norm, ls_str, derivs,
+                       LM, T, dfdH, Sz, band.Species());
+      }
+    }
+  }
+}
+
+void cutoff_loop_sparse_triple(
+    ComputeData &com, ComputeData &sparse_com, Normalizer ls_norm,
+    const IntensityCalculator ls_str, const AbsorptionLines &band,
+    const ArrayOfDerivatives &derivs, const Output X, const Numeric &T,
+    const Numeric &H, const Numeric &sparse_lim, const Numeric &DC,
+    const Index i,
+    const Zeeman::Polarization zeeman_polarization) ARTS_NOEXCEPT {
+  // Basic settings
+  const bool do_nlte = ls_str.do_nlte();
+  const bool do_cutoff = band.cutoff not_eq Absorption::CutoffType::None;
+  const Numeric fu = band.CutoffFreq(i, X.D0);
+  const Numeric fl = band.CutoffFreqMinus(i, X.D0);
+  const Numeric fus = band.lines[i].F0 + sparse_lim;
+  const Numeric fls = band.lines[i].F0 - sparse_lim;
+
+  // Find sparse and dense ranges
+  const auto [dense_start, dense_size, sparse_low_start, sparse_low_size,
+              sparse_upp_start, sparse_upp_size] =
+      quad_sparse_limited_range(fl, fu, fls, fus, com.f_grid,
+                                sparse_com.f_grid);
+  if ((dense_size + sparse_low_size + sparse_upp_size) == 0)
+    return;
+
+  // Get the compute data view
+  ComputeValues comval(com.F, com.dF, com.N, com.dN, com.f_grid, dense_start,
+                       dense_size, derivs, do_nlte);
+
+  // Get views of the sparse data
+  ComputeValues sparse_low_range(
+      sparse_com.F, sparse_com.dF, sparse_com.N, sparse_com.dN,
+      sparse_com.f_grid, sparse_low_start, sparse_low_size, derivs, do_nlte);
+  ComputeValues sparse_upp_range(
+      sparse_com.F, sparse_com.dF, sparse_com.N, sparse_com.dN,
+      sparse_com.f_grid, sparse_upp_start, sparse_upp_size, derivs, do_nlte);
+
+  const Index nz = band.ZeemanCount(i, zeeman_polarization);
+  for (Index iz = 0; iz < nz; iz++) {
+    const Numeric dfdH = band.ZeemanSplitting(i, zeeman_polarization, iz);
+    const Numeric Sz = band.ZeemanStrength(i, zeeman_polarization, iz);
+    const Complex LM = Complex(1 + X.G, -X.Y);
+    Calculator ls(band.lineshapetype, band.lines[i].F0, X, DC, dfdH * H,
+                  band.mirroring == Absorption::MirroringType::Manual);
+    Calculator ls_mirr(band.mirroring, band.lineshapetype, band.lines[i].F0, X,
+                       DC, dfdH * H);
+
+    if (do_cutoff) {
+      // Initialize and set the cutoff values
+      Calculator ls_cut = ls;
+      Calculator ls_mirr_cut = ls_mirr;
+      ls_cut(fu);
+      ls_mirr_cut(fu);
+
+      cutoff_frequency_loop(comval, ls, ls_mirr, ls_norm, ls_cut, ls_mirr_cut,
+                            ls_str, derivs, LM, T, dfdH, Sz, band.Species());
+
+      if (sparse_low_size) {
+        cutoff_frequency_loop(sparse_low_range, ls, ls_mirr, ls_norm, ls_cut,
+                              ls_mirr_cut, ls_str, derivs, LM, T, dfdH, Sz,
+                              band.Species());
+      }
+
+      if (sparse_upp_size) {
+        cutoff_frequency_loop(sparse_upp_range, ls, ls_mirr, ls_norm, ls_cut,
+                              ls_mirr_cut, ls_str, derivs, LM, T, dfdH, Sz,
+                              band.Species());
+      }
+
+    } else {
+      frequency_loop(comval, ls, ls_mirr, ls_norm, ls_str, derivs, LM, T, dfdH,
+                     Sz, band.Species());
+
+      if (sparse_low_size) {
+        frequency_loop(sparse_low_range, ls, ls_mirr, ls_norm, ls_str, derivs,
+                       LM, T, dfdH, Sz, band.Species());
+      }
+
+      if (sparse_upp_size) {
+        frequency_loop(sparse_upp_range, ls, ls_mirr, ls_norm, ls_str, derivs,
+                       LM, T, dfdH, Sz, band.Species());
       }
     }
   }
@@ -3353,15 +3211,10 @@ void cutoff_loop_sparse_triple(ComputeData &com,
  * @param[in] ls_norm The normalization calculator. \f$ S_n \f$
  * @param[in] derivs A list of pre-computed derivative values and keys
  */
-void cutoff_loop(ComputeData &com,
-                 Normalizer ls_norm,
-                 const IntensityCalculator ls_str,
-                 const AbsorptionLines &band,
-                 const ArrayOfDerivatives &derivs,
-                 const Output X,
-                 const Numeric &T,
-                 const Numeric &H,
-                 const Numeric &DC,
+void cutoff_loop(ComputeData &com, Normalizer ls_norm,
+                 const IntensityCalculator ls_str, const AbsorptionLines &band,
+                 const ArrayOfDerivatives &derivs, const Output X,
+                 const Numeric &T, const Numeric &H, const Numeric &DC,
                  const Index i,
                  const Zeeman::Polarization zeeman_polarization) ARTS_NOEXCEPT {
   // Basic settings
@@ -3372,32 +3225,36 @@ void cutoff_loop(ComputeData &com,
 
   // Only for the cutoff-range
   const auto [cutstart, cutsize] = limited_range(fl, fu, com.f_grid);
-  if (not cutsize) return;
-  
+  if (not cutsize)
+    return;
+
   // Get the compute data view
-  ComputeValues comval(com.F, com.dF, com.N, com.dN, com.f_grid, cutstart, cutsize, derivs, do_nlte);
-  
+  ComputeValues comval(com.F, com.dF, com.N, com.dN, com.f_grid, cutstart,
+                       cutsize, derivs, do_nlte);
+
   const Index nz = band.ZeemanCount(i, zeeman_polarization);
   for (Index iz = 0; iz < nz; iz++) {
     const Numeric dfdH = band.ZeemanSplitting(i, zeeman_polarization, iz);
     const Numeric Sz = band.ZeemanStrength(i, zeeman_polarization, iz);
     const Complex LM = Complex(1 + X.G, -X.Y);
-    Calculator ls(band.lineshapetype, band.lines[i].F0, X, DC, dfdH * H, band.mirroring == Absorption::MirroringType::Manual);
-    Calculator ls_mirr(band.mirroring, band.lineshapetype, band.lines[i].F0, X, DC, dfdH * H);
-    
+    Calculator ls(band.lineshapetype, band.lines[i].F0, X, DC, dfdH * H,
+                  band.mirroring == Absorption::MirroringType::Manual);
+    Calculator ls_mirr(band.mirroring, band.lineshapetype, band.lines[i].F0, X,
+                       DC, dfdH * H);
+
     if (do_cutoff) {
       // Initialize and set the cutoff values
       Calculator ls_cut = ls;
       Calculator ls_mirr_cut = ls_mirr;
       ls_cut(fu);
       ls_mirr_cut(fu);
-      
-      cutoff_frequency_loop(comval, ls, ls_mirr, ls_norm, ls_cut, ls_mirr_cut, ls_str,
-                            derivs, LM, T, dfdH, Sz, band.Species());
-      
+
+      cutoff_frequency_loop(comval, ls, ls_mirr, ls_norm, ls_cut, ls_mirr_cut,
+                            ls_str, derivs, LM, T, dfdH, Sz, band.Species());
+
     } else {
-      frequency_loop(comval, ls, ls_mirr, ls_norm, ls_str,
-                     derivs, LM, T, dfdH, Sz, band.Species());
+      frequency_loop(comval, ls, ls_mirr, ls_norm, ls_str, derivs, LM, T, dfdH,
+                     Sz, band.Species());
     }
   }
 }
@@ -3433,28 +3290,19 @@ void cutoff_loop(ComputeData &com,
  * @param[in] dQTdT The derivative of the partition function at the temperature
  * wrt temperature
  */
-void line_loop(ComputeData &com,
-               ComputeData &sparse_com,
+void line_loop(ComputeData &com, ComputeData &sparse_com,
                const AbsorptionLines &band,
                const ArrayOfRetrievalQuantity &jacobian_quantities,
-               const EnergyLevelMap &nlte,
-               const Vector &vmrs,
-               const ArrayOfSpeciesTag& self_tag,
-               const Numeric &P,
-               const Numeric &T,
-               const Numeric &H,
-               const Numeric &sparse_lim,
-               const Numeric QT,
-               const Numeric QT0,
-               const Numeric dQTdT,
-               const Numeric r,
-               const Numeric drdSELFVMR,
-               const Numeric drdT,
+               const EnergyLevelMap &nlte, const Vector &vmrs,
+               const ArrayOfSpeciesTag &self_tag, const Numeric &P,
+               const Numeric &T, const Numeric &H, const Numeric &sparse_lim,
+               const Numeric QT, const Numeric QT0, const Numeric dQTdT,
+               const Numeric r, const Numeric drdSELFVMR, const Numeric drdT,
                const Zeeman::Polarization zeeman_polarization,
                const Options::LblSpeedup speedup_type) ARTS_NOEXCEPT {
   const Index nj = jacobian_quantities.nelem();
   const Index nl = band.NumLines();
-  
+
   // Derivatives are allocated ahead of all loops
   ArrayOfDerivatives derivs(nj);
 
@@ -3464,82 +3312,84 @@ void line_loop(ComputeData &com,
   for (Index i = 0; i < nl; i++) {
     // Pre-compute the derivatives
     for (Index ij = 0; ij < nj; ij++) {
-      const auto& deriv = jacobian_quantities[ij];
+      const auto &deriv = jacobian_quantities[ij];
       derivs[ij].jac_pos = -1;
       derivs[ij].deriv = nullptr;
-      
-      if (not deriv.propmattype()) continue;
+
+      if (not deriv.propmattype())
+        continue;
       derivs[ij].jac_pos = ij;
       derivs[ij].deriv = &deriv;
 
       if (deriv == Jacobian::Atm::Temperature) {
         derivs[ij].value.o = band.ShapeParameters_dT(i, T, P, vmrs);
       } else if (deriv == Jacobian::Special::ArrayOfSpeciesTagVMR) {
-        if (not (deriv == self_tag)) {  // Remove if its not good
+        if (not(deriv == self_tag)) { // Remove if its not good
           derivs[ij].jac_pos = -1;
           derivs[ij].deriv = nullptr;
         }
       } else if (deriv.Target().needQuantumIdentity()) {
         if (deriv == Jacobian::Line::VMR) {
-          derivs[ij].value.o = band.ShapeParameters_dVMR(i, T, P, deriv.QuantumIdentity());
+          derivs[ij].value.o =
+              band.ShapeParameters_dVMR(i, T, P, deriv.QuantumIdentity());
         } else {
-          auto &lt =
-              derivs[ij].target = {deriv.Target().qid, band.lines[i].localquanta, band.quantumidentity};
+          auto &lt = derivs[ij].target = {deriv.Target().qid,
+                                          band.lines[i].localquanta,
+                                          band.quantumidentity};
           if (lt == Quantum::Number::StateMatchType::Full) {
-            if constexpr (false) {/*skip so the rest can be a else-if block*/}
+            if constexpr (false) { /*skip so the rest can be a else-if block*/
+            }
             // All line shape derivatives
-            InternalDerivativesSetup(G0)
-            InternalDerivativesSetup(D0)
-            InternalDerivativesSetup(G2)
-            InternalDerivativesSetup(D2)
-            InternalDerivativesSetup(ETA)
-            InternalDerivativesSetup(FVC)
-            InternalDerivativesSetup(Y)
-            InternalDerivativesSetup(G)
-            InternalDerivativesSetup(DV)
+            InternalDerivativesSetup(G0) InternalDerivativesSetup(D0)
+                InternalDerivativesSetup(G2) InternalDerivativesSetup(D2)
+                    InternalDerivativesSetup(ETA) InternalDerivativesSetup(FVC)
+                        InternalDerivativesSetup(Y) InternalDerivativesSetup(G)
+                            InternalDerivativesSetup(DV)
           }
         }
       }
     }
-    std::remove_if(derivs.begin(), derivs.end(), [](Derivatives& dd) { return dd.deriv == nullptr; });
+    std::remove_if(derivs.begin(), derivs.end(),
+                   [](Derivatives &dd) { return dd.deriv == nullptr; });
 
     // Call cut off loop with or without sparsity
     switch (speedup_type) {
-      case Options::LblSpeedup::None:
-        cutoff_loop(com,
-                    Normalizer(band.normalization, band.lines[i].F0, T),
-                    IntensityCalculator(T, QT, QT0, dQTdT, r, drdSELFVMR, drdT, nlte, band, i),
-                    band, derivs, band.ShapeParameters(i, T, P, vmrs), T, H,
-                    DC, i, zeeman_polarization);
-        break;
-      case Options::LblSpeedup::QuadraticIndependent:
-        cutoff_loop_sparse_triple(com, sparse_com,
-                    Normalizer(band.normalization, band.lines[i].F0, T),
-                    IntensityCalculator(T, QT, QT0, dQTdT, r, drdSELFVMR, drdT, nlte, band, i),
-                    band, derivs, band.ShapeParameters(i, T, P, vmrs), T, H, sparse_lim,
-                    DC, i, zeeman_polarization);
-        break;
-      case Options::LblSpeedup::LinearIndependent:
-        cutoff_loop_sparse_linear(com, sparse_com,
-                                  Normalizer(band.normalization, band.lines[i].F0, T),
-                                  IntensityCalculator(T, QT, QT0, dQTdT, r, drdSELFVMR, drdT, nlte, band, i),
-                                  band, derivs, band.ShapeParameters(i, T, P, vmrs), T, H, sparse_lim,
-                                  DC, i, zeeman_polarization);
-        break;
-      case Options::LblSpeedup::FINAL: { /* Leave last */ }
+    case Options::LblSpeedup::None:
+      cutoff_loop(com, Normalizer(band.normalization, band.lines[i].F0, T),
+                  IntensityCalculator(T, QT, QT0, dQTdT, r, drdSELFVMR, drdT,
+                                      nlte, band, i),
+                  band, derivs, band.ShapeParameters(i, T, P, vmrs), T, H, DC,
+                  i, zeeman_polarization);
+      break;
+    case Options::LblSpeedup::QuadraticIndependent:
+      cutoff_loop_sparse_triple(
+          com, sparse_com, Normalizer(band.normalization, band.lines[i].F0, T),
+          IntensityCalculator(T, QT, QT0, dQTdT, r, drdSELFVMR, drdT, nlte,
+                              band, i),
+          band, derivs, band.ShapeParameters(i, T, P, vmrs), T, H, sparse_lim,
+          DC, i, zeeman_polarization);
+      break;
+    case Options::LblSpeedup::LinearIndependent:
+      cutoff_loop_sparse_linear(
+          com, sparse_com, Normalizer(band.normalization, band.lines[i].F0, T),
+          IntensityCalculator(T, QT, QT0, dQTdT, r, drdSELFVMR, drdT, nlte,
+                              band, i),
+          band, derivs, band.ShapeParameters(i, T, P, vmrs), T, H, sparse_lim,
+          DC, i, zeeman_polarization);
+      break;
+    case Options::LblSpeedup::FINAL: { /* Leave last */
+    }
     }
   }
 }
 
-void compute(ComputeData &com,
-             ComputeData &sparse_com,
+void compute(ComputeData &com, ComputeData &sparse_com,
              const AbsorptionLines &band,
              const ArrayOfRetrievalQuantity &jacobian_quantities,
-             const EnergyLevelMap &nlte,
-             const Vector &vmrs,
-             const ArrayOfSpeciesTag& self_tag,
-             const Numeric& self_vmr, const Numeric &isot_ratio, const Numeric &P, const Numeric &T, const Numeric &H,
-             const Numeric &sparse_lim,
+             const EnergyLevelMap &nlte, const Vector &vmrs,
+             const ArrayOfSpeciesTag &self_tag, const Numeric &self_vmr,
+             const Numeric &isot_ratio, const Numeric &P, const Numeric &T,
+             const Numeric &H, const Numeric &sparse_lim,
              const Zeeman::Polarization zeeman_polarization,
              const Options::LblSpeedup speedup_type,
              const bool robust) ARTS_NOEXCEPT {
@@ -3555,45 +3405,57 @@ void compute(ComputeData &com,
                          "a detailed debugger to find out why.")
   ARTS_ASSERT(com.F.size() == nv, "F is wrong size.  Size is (", com.F.size(),
               ") but should be: (", nv, ')')
-  ARTS_ASSERT(not com.do_nlte or com.N.size() == nv, "N is wrong size.  Size is (",
-              com.N.size(), ") but should be (", nv, ')')
+  ARTS_ASSERT(not com.do_nlte or com.N.size() == nv,
+              "N is wrong size.  Size is (", com.N.size(), ") but should be (",
+              nv, ')')
   ARTS_ASSERT(nj == 0 or (com.dF.nrows() == nv and com.dF.ncols() == nj),
-              "dF is wrong size.  Size is (", com.dF.nrows(), " x ", com.dF.ncols(),
-              ") but should be: (", nv, " x ", nj, ")")
-  ARTS_ASSERT(nj == 0 or not com.do_nlte or (com.dN.nrows() == nv and com.dN.ncols() == nj),
-              "dN is wrong size.  Size is (", com.dN.nrows(), " x ", com.dN.ncols(),
-              ") but should be: (", nv, " x ", nj, ")")
-  ARTS_ASSERT((sparse_lim > 0 and sparse_com.f_grid.size() > 1) or (sparse_lim == 0), "Sparse limit is either 0, or the sparse frequency grid has to have upper and lower values")
+              "dF is wrong size.  Size is (", com.dF.nrows(), " x ",
+              com.dF.ncols(), ") but should be: (", nv, " x ", nj, ")")
+  ARTS_ASSERT(nj == 0 or not com.do_nlte or
+                  (com.dN.nrows() == nv and com.dN.ncols() == nj),
+              "dN is wrong size.  Size is (", com.dN.nrows(), " x ",
+              com.dN.ncols(), ") but should be: (", nv, " x ", nj, ")")
+  ARTS_ASSERT((sparse_lim > 0 and sparse_com.f_grid.size() > 1) or
+                  (sparse_lim == 0),
+              "Sparse limit is either 0, or the sparse frequency grid has to "
+              "have upper and lower values")
 
   // Early return test
-  if (nv == 0 or nl == 0 or (Absorption::relaxationtype_relmat(band.population) and band.DoLineMixing(P))) {
+  if (nv == 0 or nl == 0 or
+      (Absorption::relaxationtype_relmat(band.population) and
+       band.DoLineMixing(P))) {
     return; // No line-by-line computations required/wanted
   }
-  
+
   const Numeric dnumdensdVMR = isot_ratio * number_density(P, T);
 
   if (robust and band.DoLineMixing(P) and band.AnyLinemixing()) {
     ComputeData com_safe(com.f_grid, jacobian_quantities, com.do_nlte);
-    ComputeData sparse_com_safe(sparse_com.f_grid, jacobian_quantities, sparse_com.do_nlte);
+    ComputeData sparse_com_safe(sparse_com.f_grid, jacobian_quantities,
+                                sparse_com.do_nlte);
 
-    line_loop(com_safe, sparse_com_safe, band, jacobian_quantities, nlte, vmrs, self_tag, P, T, H, sparse_lim,
+    line_loop(com_safe, sparse_com_safe, band, jacobian_quantities, nlte, vmrs,
+              self_tag, P, T, H, sparse_lim,
               single_partition_function(T, band.Isotopologue()),
               single_partition_function(band.T0, band.Isotopologue()),
               dsingle_partition_function_dT(T, band.Isotopologue()),
-              self_vmr * dnumdensdVMR, dnumdensdVMR, self_vmr * isot_ratio * dnumber_density_dt(P, T),
+              self_vmr * dnumdensdVMR, dnumdensdVMR,
+              self_vmr * isot_ratio * dnumber_density_dt(P, T),
               zeeman_polarization, speedup_type);
-    
+
     com_safe.enforce_positive_absorption();
     sparse_com_safe.enforce_positive_absorption();
 
     com += com_safe;
     sparse_com += sparse_com_safe;
   } else {
-    line_loop(com, sparse_com, band, jacobian_quantities, nlte, vmrs, self_tag, P, T, H, sparse_lim,
+    line_loop(com, sparse_com, band, jacobian_quantities, nlte, vmrs, self_tag,
+              P, T, H, sparse_lim,
               single_partition_function(T, band.Isotopologue()),
               single_partition_function(band.T0, band.Isotopologue()),
               dsingle_partition_function_dT(T, band.Isotopologue()),
-              self_vmr * dnumdensdVMR, dnumdensdVMR, self_vmr * isot_ratio * dnumber_density_dt(P, T),
+              self_vmr * dnumdensdVMR, dnumdensdVMR,
+              self_vmr * isot_ratio * dnumber_density_dt(P, T),
               zeeman_polarization, speedup_type);
   }
 }
@@ -3639,7 +3501,8 @@ bool good_linear_sparse_f_grid(const Vector &f_grid_dense,
   const Index nf_sparse = f_grid_sparse.nelem();
   const Index nf_dense = f_grid_dense.nelem();
 
-  if (nf_sparse == 1) return false;
+  if (nf_sparse == 1)
+    return false;
 
   if (nf_sparse and nf_dense)
     return f_grid_dense[0] >= f_grid_sparse[0] and
@@ -3681,10 +3544,10 @@ void ComputeData::interp_add_even(const ComputeData &sparse) ARTS_NOEXCEPT {
 
   ARTS_ASSERT(do_nlte == sparse.do_nlte, "Must have the same NLTE status")
   ARTS_ASSERT(sparse_nv > 1, "Must have at least two sparse grid-points")
-  ARTS_ASSERT(
-      nv == 0 or (f_grid[0] == sparse.f_grid[0] and
-                  f_grid[nv - 1] >= sparse.f_grid[sparse_nv - 1]),
-      "If there are any dense frequency points, then the sparse frequency points must fully cover them")
+  ARTS_ASSERT(nv == 0 or (f_grid[0] == sparse.f_grid[0] and
+                          f_grid[nv - 1] >= sparse.f_grid[sparse_nv - 1]),
+              "If there are any dense frequency points, then the sparse "
+              "frequency points must fully cover them")
   ARTS_ASSERT(not(sparse_nv % 2), "Must be multiple of to")
 
   Index sparse_iv = 0;
@@ -3727,10 +3590,10 @@ void ComputeData::interp_add_triplequad(const ComputeData &sparse)
 
   ARTS_ASSERT(do_nlte == sparse.do_nlte, "Must have the same NLTE status")
   ARTS_ASSERT(sparse_nv > 2, "Must have at least three sparse grid-points")
-  ARTS_ASSERT(
-      nv == 0 or (f_grid[0] == sparse.f_grid[0] and
-                  f_grid[nv - 1] >= sparse.f_grid[sparse_nv - 1]),
-      "If there are any dense frequency points, then the sparse frequency points must fully cover them")
+  ARTS_ASSERT(nv == 0 or (f_grid[0] == sparse.f_grid[0] and
+                          f_grid[nv - 1] >= sparse.f_grid[sparse_nv - 1]),
+              "If there are any dense frequency points, then the sparse "
+              "frequency points must fully cover them")
   ARTS_ASSERT(not(sparse_nv % 3), "Must be multiple of three")
 
   Index sparse_iv = 0;
@@ -3746,30 +3609,22 @@ void ComputeData::interp_add_triplequad(const ComputeData &sparse)
       f0 = sparse.f_grid[sparse_iv];
       inv = 1.0 / Math::pow2(f1 - f0);
     }
-    ARTS_ASSERT(f_grid[iv] >= f0 and
-                    (f_grid[iv] < f2 or
-                     (f2 == f_grid[iv] and sparse_iv == sparse_nv - 3)),
-                "Out of range frequency grid.  Must be caught earlier.\n"
-                "The sparse range is from: ",
-                f0,
-                " to ",
-                f2,
-                " with ",
-                f1,
-                " as the half-way grid point.\n"
-                "The dense frequency is ",
-                f_grid[iv],
-                " and the indices are: sparse_iv=",
-                sparse_iv,
-                "; iv=",
-                iv)
+    ARTS_ASSERT(
+        f_grid[iv] >= f0 and (f_grid[iv] < f2 or (f2 == f_grid[iv] and
+                                                  sparse_iv == sparse_nv - 3)),
+        "Out of range frequency grid.  Must be caught earlier.\n"
+        "The sparse range is from: ",
+        f0, " to ", f2, " with ", f1,
+        " as the half-way grid point.\n"
+        "The dense frequency is ",
+        f_grid[iv], " and the indices are: sparse_iv=", sparse_iv, "; iv=", iv)
 
     const Numeric xm0 = f_grid[iv] - f0;
     const Numeric xm1 = f_grid[iv] - f1;
     const Numeric xm2 = f_grid[iv] - f2;
-    const Numeric l0 = 0.5 * xm1 * xm2 * inv;  // --
-    const Numeric l1 = -xm0 * xm2 * inv;       // +-
-    const Numeric l2 = 0.5 * xm0 * xm1 * inv;  // ++
+    const Numeric l0 = 0.5 * xm1 * xm2 * inv; // --
+    const Numeric l1 = -xm0 * xm2 * inv;      // +-
+    const Numeric l2 = 0.5 * xm0 * xm1 * inv; // ++
 
     F[iv] += l0 * sparse.F[sparse_iv] + l1 * sparse.F[sparse_iv + 1] +
              l2 * sparse.F[sparse_iv + 2];
@@ -3789,4 +3644,4 @@ void ComputeData::interp_add_triplequad(const ComputeData &sparse)
     }
   }
 }
-}  // namespace LineShape
+} // namespace LineShape

--- a/src/lineshapemodel.h
+++ b/src/lineshapemodel.h
@@ -472,9 +472,9 @@ constexpr std::string_view shapetype2metadatastring(Type type) noexcept {
       return "The line shape type is the speed-dependent Voigt profile.\n";
     case Type::HTP:
       return "The line shape type is the Hartmann-Tran profile.\n";
-    case Type::FINAL:
-      return "There's an error.\n";
+    case Type::FINAL: {}
   }
+  return "There's an error.\n";
 }
 #pragma GCC diagnostic pop
 
@@ -807,7 +807,7 @@ class Model {
                            Jacobian::Line deriv) const noexcept;
 
   /** Number of species in Model */
-  [[nodiscard]] Index nelem() const { return Index(mdata.size()); }
+  [[nodiscard]] Index nelem() const noexcept { return Index(mdata.size()); }
   
   /** Number of species in Model */
   [[nodiscard]] Index size() const { return Index(mdata.size()); }
@@ -979,6 +979,7 @@ constexpr Index temperaturemodel2legacynelem(TemperatureModel type) noexcept {
       return 4;
     case TemperatureModel::FINAL: break;
   }
+  return -1;
 }
 #pragma GCC diagnostic pop
 
@@ -1022,6 +1023,7 @@ constexpr Index typelm2nelem(LegacyLineMixingData::TypeLM type) {
     case TypeLM::LM_BYBAND:  // The band class
       return 1;
   }
+  return -1;
 }
 #pragma GCC diagnostic pop
 
@@ -1065,6 +1067,7 @@ constexpr Index typepb2nelem(LegacyPressureBroadeningData::TypePB type)  {
     case TypePB::PB_PLANETARY_BROADENING:
       return 20;
   }
+  return -1;
 }
 #pragma GCC diagnostic pop
 

--- a/src/matpackI.cc
+++ b/src/matpackI.cc
@@ -365,7 +365,7 @@ Vector& Vector::operator=(const Vector& v) {
   return *this;
 }
 
-Vector& Vector::operator=(Vector&& v) noexcept {
+Vector& Vector::operator=(Vector&& v) ARTS_NOEXCEPT {
   if (this != &v) {
     delete[] mdata;
     mdata = v.mdata;
@@ -965,7 +965,7 @@ Matrix& Matrix::operator=(const Matrix& m) {
 }
 
 //! Move assignment operator from another matrix.
-Matrix& Matrix::operator=(Matrix&& m) noexcept {
+Matrix& Matrix::operator=(Matrix&& m) ARTS_NOEXCEPT {
   if (this != &m) {
     delete[] mdata;
     mdata = m.mdata;

--- a/src/matpackI.h
+++ b/src/matpackI.h
@@ -991,7 +991,7 @@ class Vector : public VectorView {
   Vector& operator=(const Vector& v);
 
   //! Move assignment from another Vector.
-  Vector& operator=(Vector&& v) noexcept;
+  Vector& operator=(Vector&& v) ARTS_NOEXCEPT;
 
   //! Assignment from an initializatoin list.
   Vector& operator=(std::initializer_list<Numeric> v);
@@ -1308,7 +1308,7 @@ class Matrix : public MatrixView {
 
   // Assignment operators:
   Matrix& operator=(const Matrix& m);
-  Matrix& operator=(Matrix&& m) noexcept;
+  Matrix& operator=(Matrix&& m) ARTS_NOEXCEPT;
   Matrix& operator=(Numeric x);
   Matrix& operator=(const ConstVectorView& v);
 

--- a/src/matpackI.h
+++ b/src/matpackI.h
@@ -255,7 +255,7 @@ class Range {
     // mstride:   Resulting stride (old*new)
 
     // Get the previous final element:
-    Index prev_fin = p.mstart + (p.mextent - 1) * p.mstride;
+    Index const prev_fin = p.mstart + (p.mextent - 1) * p.mstride;
 
     // Resulting start must be >= previous start:
     ARTS_ASSERT(p.mstart <= mstart);
@@ -689,17 +689,17 @@ class VectorView : public ConstVectorView {
   // Typedef for compatibility with STL
   using iterator = Iterator1D;
 
+#define GETFUN(n) *(mdata + mrange.mstart + n * mrange.mstride)
   /** Plain Index operator. */
   Numeric& operator[](Index n) ARTS_NOEXCEPT {  // Check if index is valid:
     ARTS_ASSERT(0 <= n);
     ARTS_ASSERT(n < mrange.mextent);
-    return get(n);
+    return GETFUN(n);
   }
 
   /** Get element implementation without assertions. */
-  Numeric& get(Index n) ARTS_NOEXCEPT {
-    return *(mdata + mrange.mstart + n * mrange.mstride);
-  }
+  Numeric& get(Index n) ARTS_NOEXCEPT { return GETFUN(n); }
+#undef GETFUN
 
   /** Index operator for subrange. We have to also account for the case,
     that *this is already a subrange of a Vector. This allows correct
@@ -1190,6 +1190,8 @@ class MatrixView : public ConstMatrixView {
   // Typedef for compatibility with STL
   using iterator = Iterator2D;
 
+#define GETFUN(r, c) \
+  *(mdata + mrr.mstart + r * mrr.mstride + mcr.mstart + c * mcr.mstride)
   // Index Operators:
   /** Plain index operator. */
   Numeric& operator()(Index r,
@@ -1199,14 +1201,12 @@ class MatrixView : public ConstMatrixView {
     ARTS_ASSERT(r < mrr.mextent);
     ARTS_ASSERT(c < mcr.mextent);
 
-    return get(r, c);
+    return GETFUN(r, c);
   }
 
   /** Get element implementation without assertions. */
-  Numeric& get(Index r, Index c) ARTS_NOEXCEPT {
-    return *(mdata + mrr.mstart + r * mrr.mstride + mcr.mstart +
-             c * mcr.mstride);
-  }
+  Numeric& get(Index r, Index c) ARTS_NOEXCEPT { return GETFUN(r, c); }
+#undef GETFUN
 
   MatrixView operator()(const Range& r, const Range& c) ARTS_NOEXCEPT;
   VectorView operator()(const Range& r, Index c) ARTS_NOEXCEPT;

--- a/src/matpackIII.cc
+++ b/src/matpackIII.cc
@@ -633,7 +633,7 @@ Tensor3& Tensor3::operator=(const Tensor3& x) {
 }
 
 //! Move assignment operator from another tensor.
-Tensor3& Tensor3::operator=(Tensor3&& x) noexcept {
+Tensor3& Tensor3::operator=(Tensor3&& x) ARTS_NOEXCEPT {
   if (this != &x) {
     delete[] mdata;
     mdata = x.mdata;

--- a/src/matpackIII.h
+++ b/src/matpackIII.h
@@ -267,6 +267,9 @@ class Tensor3View : public ConstTensor3View {
   VectorView operator()(Index p, const Range& r, Index c);
   VectorView operator()(const Range& p, Index r, Index c);
 
+#define GETFUN(p, r, c)                                                   \
+  *(mdata + mpr.mstart + p * mpr.mstride + mrr.mstart + r * mrr.mstride + \
+    mcr.mstart + c * mcr.mstride)
   /** Plain non-const index operator. */
   Numeric& operator()(Index p, Index r, Index c) {
     // Check if indices are valid:
@@ -277,14 +280,12 @@ class Tensor3View : public ConstTensor3View {
     ARTS_ASSERT(r < mrr.mextent);
     ARTS_ASSERT(c < mcr.mextent);
 
-    return get(p, r, c);
+    return GETFUN(p, r, c);
   }
 
   /** Get element implementation without assertions. */
-  Numeric& get(Index p, Index r, Index c) {
-    return *(mdata + mpr.mstart + p * mpr.mstride + mrr.mstart +
-             r * mrr.mstride + mcr.mstart + c * mcr.mstride);
-  }
+  Numeric& get(Index p, Index r, Index c) { return GETFUN(p, r, c); }
+#undef GETFUN
 
   // Conversion to a plain C-array
   [[nodiscard]] const Numeric* get_c_array() const ARTS_NOEXCEPT;

--- a/src/matpackIII.h
+++ b/src/matpackIII.h
@@ -376,7 +376,7 @@ class Tensor3 : public Tensor3View {
 
   // Assignment operators:
   Tensor3& operator=(const Tensor3& x);
-  Tensor3& operator=(Tensor3&& x) noexcept;
+  Tensor3& operator=(Tensor3&& x) ARTS_NOEXCEPT;
   Tensor3& operator=(Numeric x);
 
   // Resize function:

--- a/src/matpackIV.cc
+++ b/src/matpackIV.cc
@@ -1024,7 +1024,7 @@ Tensor4& Tensor4::operator=(const Tensor4& x) {
 }
 
 //! Move assignment operator from another tensor.
-Tensor4& Tensor4::operator=(Tensor4&& x) noexcept {
+Tensor4& Tensor4::operator=(Tensor4&& x) ARTS_NOEXCEPT {
   if (this != &x) {
     delete[] mdata;
     mdata = x.mdata;

--- a/src/matpackIV.h
+++ b/src/matpackIV.h
@@ -337,6 +337,9 @@ class Tensor4View : public ConstTensor4View {
   VectorView operator()(Index b, Index p, const Range& r, Index c);
   VectorView operator()(Index b, Index p, Index r, const Range& c);
 
+#define GETFUN(b, p, r, c)                                                \
+  *(mdata + mbr.mstart + b * mbr.mstride + mpr.mstart + p * mpr.mstride + \
+    mrr.mstart + r * mrr.mstride + mcr.mstart + c * mcr.mstride)
   /** Plain non-const index operator. */
   Numeric& operator()(Index b,
                       Index p,
@@ -351,15 +354,14 @@ class Tensor4View : public ConstTensor4View {
     ARTS_ASSERT(r < mrr.mextent);
     ARTS_ASSERT(c < mcr.mextent);
 
-    return get(b, p, r, c);
+    return GETFUN(b, p, r, c);
   }
 
   /** Get element implementation without assertions. */
   Numeric& get(Index b, Index p, Index r, Index c) {
-    return *(mdata + mbr.mstart + b * mbr.mstride + mpr.mstart +
-             p * mpr.mstride + mrr.mstart + r * mrr.mstride + mcr.mstart +
-             c * mcr.mstride);
+    return GETFUN(b, p, r, c);
   }
+#undef GETFUN
 
   // Conversion to a plain C-array
   [[nodiscard]] const Numeric* get_c_array() const ARTS_NOEXCEPT;

--- a/src/matpackIV.h
+++ b/src/matpackIV.h
@@ -464,7 +464,7 @@ class Tensor4 : public Tensor4View {
 
   // Assignment operators:
   Tensor4& operator=(const Tensor4& x);
-  Tensor4& operator=(Tensor4&& x) noexcept;
+  Tensor4& operator=(Tensor4&& x) ARTS_NOEXCEPT;
   Tensor4& operator=(Numeric x);
 
   // Resize function:

--- a/src/matpackV.cc
+++ b/src/matpackV.cc
@@ -1709,7 +1709,7 @@ Tensor5& Tensor5::operator=(const Tensor5& x) {
 }
 
 //! Move assignment operator from another tensor.
-Tensor5& Tensor5::operator=(Tensor5&& x) noexcept {
+Tensor5& Tensor5::operator=(Tensor5&& x) ARTS_NOEXCEPT {
   if (this != &x) {
     delete[] mdata;
     mdata = x.mdata;

--- a/src/matpackV.h
+++ b/src/matpackV.h
@@ -554,7 +554,7 @@ class Tensor5 : public Tensor5View {
 
   // Assignment operators:
   Tensor5& operator=(const Tensor5& x);
-  Tensor5& operator=(Tensor5&& x) noexcept;
+  Tensor5& operator=(Tensor5&& x) ARTS_NOEXCEPT;
   Tensor5& operator=(Numeric x);
 
   // Resize function:

--- a/src/matpackV.h
+++ b/src/matpackV.h
@@ -419,6 +419,10 @@ class Tensor5View : public ConstTensor5View {
   VectorView operator()(Index s, Index b, Index p, const Range& r, Index c);
   VectorView operator()(Index s, Index b, Index p, Index r, const Range& c);
 
+#define GETFUN(s, b, p, r, c)                                                  \
+  *(mdata + msr.mstart + s * msr.mstride + mbr.mstart + b * mbr.mstride +      \
+    mpr.mstart + p * mpr.mstride + mrr.mstart + r * mrr.mstride + mcr.mstart + \
+    c * mcr.mstride)
   /** Plain const index operator. */
   Numeric& operator()(Index s,
                       Index b,
@@ -436,15 +440,14 @@ class Tensor5View : public ConstTensor5View {
     ARTS_ASSERT(r < mrr.mextent);
     ARTS_ASSERT(c < mcr.mextent);
 
-    return get(s, b, p, r, c);
+    return GETFUN(s, b, p, r, c);
   }
 
   /** Get element implementation without assertions. */
   Numeric& get(Index s, Index b, Index p, Index r, Index c) {
-    return *(mdata + msr.mstart + s * msr.mstride + mbr.mstart +
-             b * mbr.mstride + mpr.mstart + p * mpr.mstride + mrr.mstart +
-             r * mrr.mstride + mcr.mstart + c * mcr.mstride);
+    return GETFUN(s, b, p, r, c);
   }
+#undef GETFUN
 
   // Conversion to a plain C-array
   [[nodiscard]] const Numeric* get_c_array() const ARTS_NOEXCEPT;

--- a/src/matpackVI.cc
+++ b/src/matpackVI.cc
@@ -2139,7 +2139,7 @@ Tensor6& Tensor6::operator=(const Tensor6& x) {
 }
 
 //! Move assignment operator from another tensor.
-Tensor6& Tensor6::operator=(Tensor6&& x) noexcept {
+Tensor6& Tensor6::operator=(Tensor6&& x) ARTS_NOEXCEPT {
   if (this != &x) {
     delete[] mdata;
     mdata = x.mdata;

--- a/src/matpackVI.h
+++ b/src/matpackVI.h
@@ -1141,7 +1141,7 @@ class Tensor6 : public Tensor6View {
 
   // Assignment operators:
   Tensor6& operator=(const Tensor6& x);
-  Tensor6& operator=(Tensor6&& x) noexcept;
+  Tensor6& operator=(Tensor6&& x) ARTS_NOEXCEPT;
   Tensor6& operator=(Numeric x);
 
   // Resize function:

--- a/src/matpackVI.h
+++ b/src/matpackVI.h
@@ -1012,6 +1012,9 @@ class Tensor6View : public ConstTensor6View {
   VectorView operator()(
       const Range& v, Index s, Index b, Index p, Index r, Index c);
 
+#define GETFUN(v, s, b, p, r, c)                                        \
+  *(mdata + OFFSET(v) + OFFSET(s) + OFFSET(b) + OFFSET(p) + OFFSET(r) + \
+    OFFSET(c))
   // Result scalar (1 combination)
   // IIIIII
   Numeric& operator()(Index v, Index s, Index b, Index p, Index r, Index c) {
@@ -1021,14 +1024,14 @@ class Tensor6View : public ConstTensor6View {
     CHECK(p);
     CHECK(r);
     CHECK(c);
-    return get(v, s, b, p, r, c);
+    return GETFUN(v, s, b, p, r, c);
   }
 
   /** Get element implementation without assertions. */
   Numeric& get(Index v, Index s, Index b, Index p, Index r, Index c) {
-    return *(mdata + OFFSET(v) + OFFSET(s) + OFFSET(b) + OFFSET(p) + OFFSET(r) +
-             OFFSET(c));
+    return GETFUN(v, s, b, p, r, c);
   }
+#undef GETFUN
 
   // Conversion to a plain C-array
   [[nodiscard]] const Numeric* get_c_array() const ARTS_NOEXCEPT;

--- a/src/matpackVII.cc
+++ b/src/matpackVII.cc
@@ -5449,7 +5449,7 @@ Tensor7& Tensor7::operator=(const Tensor7& x) {
 }
 
 //! Copy assignment operator from another tensor.
-Tensor7& Tensor7::operator=(Tensor7&& x) noexcept {
+Tensor7& Tensor7::operator=(Tensor7&& x) ARTS_NOEXCEPT {
   if (this != &x) {
     delete[] mdata;
     mdata = x.mdata;

--- a/src/matpackVII.h
+++ b/src/matpackVII.h
@@ -2419,7 +2419,7 @@ class Tensor7 : public Tensor7View {
 
   // Assignment operators:
   Tensor7& operator=(const Tensor7& x);
-  Tensor7& operator=(Tensor7&& x) noexcept;
+  Tensor7& operator=(Tensor7&& x) ARTS_NOEXCEPT;
   Tensor7& operator=(Numeric x);
 
   // Resize function:

--- a/src/matpackVII.h
+++ b/src/matpackVII.h
@@ -2309,6 +2309,9 @@ class Tensor7View : public ConstTensor7View {
   VectorView operator()(
       const Range& l, Index v, Index s, Index b, Index p, Index r, Index c);
 
+#define GETFUN(l, v, s, b, p, r, c)                                     \
+  *(mdata + OFFSET(l) + OFFSET(v) + OFFSET(s) + OFFSET(b) + OFFSET(p) + \
+    OFFSET(r) + OFFSET(c))
   // Result scalar (1 combination)
   // |||||||
   Numeric& operator()(
@@ -2320,14 +2323,14 @@ class Tensor7View : public ConstTensor7View {
     CHECK(p);
     CHECK(r);
     CHECK(c);
-    return get(l, v, s, b, p, r, c);
+    return GETFUN(l, v, s, b, p, r, c);
   }
 
   /** Get element implementation without assertions. */
   Numeric& get(Index l, Index v, Index s, Index b, Index p, Index r, Index c) {
-    return *(mdata + OFFSET(l) + OFFSET(v) + OFFSET(s) + OFFSET(b) + OFFSET(p) +
-             OFFSET(r) + OFFSET(c));
+    return GETFUN(l, v, s, b, p, r, c);
   }
+#undef GETFUN
 
   // Conversion to a plain C-array
   [[nodiscard]] const Numeric* get_c_array() const ARTS_NOEXCEPT;

--- a/src/matpack_complex.h
+++ b/src/matpack_complex.h
@@ -627,7 +627,7 @@ class ComplexVector : public ComplexVectorView {
     return *this;
   }
 
-  ComplexVector& operator=(ComplexVector&& v) noexcept {
+  ComplexVector& operator=(ComplexVector&& v) ARTS_NOEXCEPT {
     if (this != &v) {
       delete[] mdata;
       mdata = v.mdata;

--- a/src/matpack_complex.h
+++ b/src/matpack_complex.h
@@ -796,6 +796,8 @@ class ComplexMatrixView : public ConstComplexMatrixView {
   // Typedef for compatibility with STL
   using iterator = ComplexIterator2D;
 
+#define GETFUN(r, c) \
+  *(mdata + mrr.mstart + r * mrr.mstride + mcr.mstart + c * mcr.mstride)
   // Index Operators:
   /** Plain index operator. */
   Complex& operator()(Index r, Index c) {  // Check if indices are valid:
@@ -804,14 +806,12 @@ class ComplexMatrixView : public ConstComplexMatrixView {
     ARTS_ASSERT(r < mrr.mextent);
     ARTS_ASSERT(c < mcr.mextent);
 
-    return get(r, c);
+    return GETFUN(r, c);
   }
 
   /** Get element implementation without assertions. */
-  Complex& get(Index r, Index c) {
-    return *(mdata + mrr.mstart + r * mrr.mstride + mcr.mstart +
-             c * mcr.mstride);
-  }
+  Complex& get(Index r, Index c) { return GETFUN(r, c); }
+#undef GETFUN
 
   /** Get element implementation without assertions. */
   Numeric& get_real(Index r, Index c) {

--- a/src/nlte.cc
+++ b/src/nlte.cc
@@ -266,7 +266,7 @@ void nlte_positions_in_statistical_equilibrium_matrix(
 }
 
 Index find_first_unique_in_lower(const ArrayOfIndex& upper,
-                                 const ArrayOfIndex& lower) noexcept {
+                                 const ArrayOfIndex& lower) ARTS_NOEXCEPT {
   for (const Index& l : lower) {
     if (std::find(upper.cbegin(), upper.cend(), l) == upper.cend())
       return l;

--- a/src/nlte.h
+++ b/src/nlte.h
@@ -184,7 +184,7 @@ void nlte_positions_in_statistical_equilibrium_matrix(
  * @return Index Pos of unique element or len-1
  */
 Index find_first_unique_in_lower(const ArrayOfIndex& upper,
-                                 const ArrayOfIndex& lower) noexcept;
+                                 const ArrayOfIndex& lower) ARTS_NOEXCEPT;
 
 /** Checks that a WSV is OK or throws a run-time error
  * 

--- a/src/propagationmatrix.cc
+++ b/src/propagationmatrix.cc
@@ -27,6 +27,7 @@
  */
 
 #include "propagationmatrix.h"
+#include <limits>
 #include "arts_omp.h"
 #include "lin_alg.h"
 
@@ -1948,8 +1949,6 @@ void PropagationMatrix::MatrixAtPosition(MatrixView ret,
   }
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wreturn-type"
 Numeric PropagationMatrix::operator()(const Index iv,
                                       const Index is1,
                                       const Index is2,
@@ -2030,8 +2029,8 @@ Numeric PropagationMatrix::operator()(const Index iv,
     default:
       ARTS_ASSERT(false, "out of bounds");
   }
+  return std::numeric_limits<Numeric>::quiet_NaN();
 }
-#pragma GCC diagnostic pop
 
 // Needs to be implemented in this file!!!
 std::ostream& operator<<(std::ostream& os, const PropagationMatrix& pm) {

--- a/src/quantum_numbers.cc
+++ b/src/quantum_numbers.cc
@@ -301,7 +301,7 @@ bool ValueList::perpendicular(const ValueList& that) const ARTS_NOEXCEPT {
   return true;
 }
 
-CheckMatch ValueList::check_match(const ValueList& other) const noexcept {
+CheckMatch ValueList::check_match(const ValueList& other) const ARTS_NOEXCEPT {
   CheckMatch status = {CheckValue::Full, CheckValue::Full};
 
   for (Type const t : enumtyps::TypeTypes) {

--- a/src/quantum_numbers.h
+++ b/src/quantum_numbers.h
@@ -950,7 +950,7 @@ class ValueList {
   void finalize();
 
   //! Return number of quantum numbers
-  [[nodiscard]] Index nelem() const { return values.nelem(); }
+  [[nodiscard]] Index nelem() const ARTS_NOEXCEPT { return values.nelem(); }
 
   //! Finds whether two ValueList describe completely different sets of quantum numbers (e.g., local vs global)
   [[nodiscard]] bool perpendicular(const ValueList& that) const ARTS_NOEXCEPT;
@@ -990,7 +990,7 @@ class ValueList {
   void set(Index i, std::string_view upp, std::string_view low);
 
   //! Returns upper and lower matching status
-  [[nodiscard]] CheckMatch check_match(const ValueList& other) const noexcept;
+  [[nodiscard]] CheckMatch check_match(const ValueList& other) const ARTS_NOEXCEPT;
 
   //! ouptut stream if all values
   friend std::ostream& operator<<(std::ostream& os, const ValueList& vl);

--- a/src/template_partfun.h
+++ b/src/template_partfun.h
@@ -43,7 +43,7 @@ Numeric linterp(const std::array<Numeric, N>& Tg,
 }
 
 template <Derivatives deriv, std::size_t N> constexpr
-Numeric polynom(const std::array<Numeric, N>& coeffs, const Numeric T) noexcept {
+Numeric polynom(const std::array<Numeric, N>& coeffs, const Numeric T) {
   static_assert(N > 0);
   
   Numeric result = 0.;


### PR DESCRIPTION
By compiling with cppcheck enabled in cmake, I spotted several errors or quality of implementation issues in matpack and artscore.

I cannot compile pyarts with this option enabled because lineshape.cc, linescaling.cc, partfun.cc, and species_tags.cc takes too long to test (several hours).  I will see if I can work around this issue somehow...