### PR TITLE
Force Python 3.10 for now on macOS runners

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -119,6 +119,11 @@ jobs:
         with:
           fetch-depth: 10
 
+      - uses: actions/setup-python@v4
+        if: runner.os == 'macOS'
+        with:
+          python-version: '3.10'
+
       - name: Setup (Linux)
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
Some macOS CI runners switched to Python 3.11 which causes an installation failure of the netCDF4 package because it is not available as a wheel in PyPi yet.