### PR TITLE
Fix auto_partfun.h not found

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -311,6 +311,8 @@ add_library (artscore STATIC
   ${NETCDF_CC_FILES}
         m_fluxes.cc)
 add_dependencies (artscore auto_version_cc species)
+target_link_libraries(artscore auto_partfun)
+
 if (ENABLE_PCH)
   target_precompile_headers(artscore PRIVATE pch_artscore.h)
 endif()

--- a/src/partfun/CMakeLists.txt
+++ b/src/partfun/CMakeLists.txt
@@ -16,7 +16,7 @@ add_custom_command(OUTPUT auto_partfun.h ${partfun_cpp_files}
                    COMMAND partfun_generator ${partfun_xml_files}
                    DEPENDS partfun_generator)
 
-add_library(auto_partfun STATIC ${partfun_cpp_files} xml_io_partfun.cc)
+add_library(auto_partfun STATIC ${partfun_cpp_files} auto_partfun.h xml_io_partfun.cc)
 target_include_directories(auto_partfun PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 if (IPO_SUPPORTED)


### PR DESCRIPTION
Workaround for auto_partfun.h include path not properly added to artscore in some configurations.