### PR TITLE
More NetCDF fixes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -157,7 +157,7 @@ jobs:
           if [ "${{ matrix.libcxx }}" = "yes" ]; then
             sudo apt-get install -y libc++-${{ matrix.version }}-dev libc++abi-${{ matrix.version }}-dev
           fi
-          sudo apt-get install -y python3-minimal python3-pip python3-setuptools zlib1g-dev libopenblas-dev libglew-dev libglfw3-dev
+          sudo apt-get install -y python3-minimal python3-pip python3-setuptools zlib1g-dev libopenblas-dev libglew-dev libglfw3-dev libnetcdf-dev
           sudo pip3 install docutils lark-parser matplotlib netCDF4 numpy pytest scipy xarray
 
           if [ "${{ matrix.doc }}" = "yes" ]; then
@@ -194,14 +194,14 @@ jobs:
             echo "USEFORTRAN=0" >> $GITHUB_ENV
           fi
 
-          brew install glew glfw
+          brew install glew glfw netcdf
 
       - name: Configure (Linux / macOS)
         if: runner.os == 'Linux' || runner.os == 'macOS'
         run: |
           mkdir cmake-build
           cd cmake-build
-          cmake -DCMAKE_BUILD_TYPE=${{ matrix.buildtype }} -DENABLE_PCH=1 -DENABLE_GUI=1 -DNUM_PYARTS_WSM=2 -DNUM_PYARTS_WSV=1 -DNUM_PYARTS_WSC=1 -DNUM_PYARTS_WSG=1 -DENABLE_FORTRAN=$USEFORTRAN ${{ matrix.cmakeflags }} ..
+          cmake -DCMAKE_BUILD_TYPE=${{ matrix.buildtype }} -DENABLE_PCH=1 -DENABLE_GUI=1 -DNUM_PYARTS_WSM=2 -DNUM_PYARTS_WSV=1 -DNUM_PYARTS_WSC=1 -DNUM_PYARTS_WSG=1 -DENABLE_FORTRAN=$USEFORTRAN -DENABLE_NETCDF=1 ${{ matrix.cmakeflags }} ..
 
       - name: Build (Linux)
         if: runner.os == 'Linux' && matrix.arts == 'yes'

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -16217,7 +16217,7 @@ where N>=0 and the species name is something line "H2O".
       OUT(),
       GOUT("out"),
       GOUT_TYPE("Vector, Matrix, Tensor3, Tensor4, Tensor5, ArrayOfVector,"
-                "ArrayOfMatrix, GasAbsLookup"),
+                "ArrayOfIndex, ArrayOfMatrix, GasAbsLookup"),
       GOUT_DESC("Variable to be read."),
       IN(),
       GIN("filename"),
@@ -22333,7 +22333,7 @@ where N>=0 and the species name is something line "H2O".
       IN(),
       GIN("in", "filename"),
       GIN_TYPE("Vector, Matrix, Tensor3, Tensor4, Tensor5, ArrayOfVector,"
-               "ArrayOfMatrix, GasAbsLookup",
+               "ArrayOfIndex, ArrayOfMatrix, GasAbsLookup",
                "String"),
       GIN_DEFAULT(NODEF, ""),
       GIN_DESC("Variable to be saved.", "Name of the NetCDF file."),

--- a/src/nc_io.cc
+++ b/src/nc_io.cc
@@ -44,13 +44,13 @@
 //! Gives the default filename for the NetCDF formats.
 /*!
  The default name is only used if the filename is empty.
- 
+
  \param filename filename
  \param varname variable name
- 
+
  \author Oliver Lemke
 */
-void nca_filename(String& filename, const String& varname) {
+void nca_filename(String &filename, const String &varname) {
   if ("" == filename) {
     extern const String out_basename;
     filename = out_basename + "." + varname + ".nc";
@@ -60,16 +60,15 @@ void nca_filename(String& filename, const String& varname) {
 //! Gives the default filename, with file index, for the NetCDF formats.
 /*!
  The default name is only used if the filename is empty.
- 
+
  \param[out] filename   filename
  \param[in]  file_index Index appended to the filename
  \param[in]  varname    variable name
- 
+
  \author Oliver Lemke
 */
-void nca_filename_with_index(String& filename,
-                             const Index& file_index,
-                             const String& varname) {
+void nca_filename_with_index(String &filename, const Index &file_index,
+                             const String &varname) {
   if ("" == filename) {
     extern const String out_basename;
     ostringstream os;
@@ -87,13 +86,12 @@ void nca_filename_with_index(String& filename,
  \param[in]  filename    NetCDF filename
  \param[out] type        Input variable
  \param[in]  verbosity   Verbosity
- 
+
  \author Oliver Lemke
 */
 template <typename T>
-void nca_read_from_file(const String& filename,
-                        T& type,
-                        const Verbosity& verbosity) {
+void nca_read_from_file(const String &filename, T &type,
+                        const Verbosity &verbosity) {
   CREATE_OUT2;
 
   String efilename = expand_path(filename);
@@ -111,7 +109,7 @@ void nca_read_from_file(const String& filename,
 
     try {
       nca_read_from_file(ncid, type, verbosity);
-    } catch (const std::runtime_error& e) {
+    } catch (const std::runtime_error &e) {
       ostringstream os;
       os << "Error reading file: " << efilename << endl;
       os << e.what() << endl;
@@ -127,13 +125,12 @@ void nca_read_from_file(const String& filename,
  \param[in]  filename    NetCDF filename
  \param[in]  type        Output variable
  \param[in]  verbosity   Verbosity
- 
+
  \author Oliver Lemke
 */
 template <typename T>
-void nca_write_to_file(const String& filename,
-                       const T& type,
-                       const Verbosity& verbosity) {
+void nca_write_to_file(const String &filename, const T &type,
+                       const Verbosity &verbosity) {
   CREATE_OUT2;
 
   String efilename = add_basedir(filename);
@@ -143,7 +140,7 @@ void nca_write_to_file(const String& filename,
 #pragma omp critical(netcdf__critical_region)
   {
     int ncid;
-    if (nc_create(efilename.c_str(), NC_CLOBBER, &ncid)) {
+    if (nc_create(efilename.c_str(), NC_CLOBBER | NC_NETCDF4, &ncid)) {
       ostringstream os;
       os << "Error writing file: " << efilename << endl;
       throw runtime_error(os.str());
@@ -151,7 +148,7 @@ void nca_write_to_file(const String& filename,
 
     try {
       nca_write_to_file(ncid, type, verbosity);
-    } catch (const std::runtime_error& e) {
+    } catch (const std::runtime_error &e) {
       ostringstream os;
       os << "Error writing file: " << efilename << endl;
       os << e.what() << endl;
@@ -163,58 +160,52 @@ void nca_write_to_file(const String& filename,
 }
 
 //! Define NetCDF dimension.
-/** 
+/**
  \param[in]  ncid   NetCDF file descriptor
  \param[in]  name   Dimension name
  \param[in]  nelem  Dimension size
  \param[out] ncdim  NetCDF dimension handle
- 
+
  \author Oliver Lemke
  */
-void nca_def_dim(const int ncid,
-                 const String& name,
-                 const Index nelem,
-                 int* ncdim) {
+void nca_def_dim(const int ncid, const String &name, const Index nelem,
+                 int *ncdim) {
   int retval;
   if ((retval = nc_def_dim(ncid, name.c_str(), nelem, ncdim)))
     nca_error(retval, "nc_def_dim");
 }
 
 //! Define NetCDF variable.
-/** 
+/**
  \param[in]  ncid   NetCDF file descriptor
  \param[in]  name   Variable name in NetCDF file
  \param[in]  type   NetCDF type
  \param[in]  ndims  Number of dimensions
  \param[in]  dims   Pointer to dimensions
  \param[out] varid  NetCDF variable handle
- 
+
  \author Oliver Lemke
  */
-void nca_def_var(const int ncid,
-                 const String& name,
-                 const nc_type type,
-                 const int ndims,
-                 const int* dims,
-                 int* varid) {
+void nca_def_var(const int ncid, const String &name, const nc_type type,
+                 const int ndims, const int *dims, int *varid) {
   int retval;
   if ((retval = nc_def_var(ncid, name.c_str(), type, ndims, dims, varid)))
     nca_error(retval, "nc_def_var");
 }
 
 //! Define NetCDF dimensions and variable for an ArrayOfIndex.
-/** 
+/**
  \param[in]  ncid   NetCDF file descriptor
  \param[in]  name   Variable name in NetCDF file
  \param[in]  a      ArrayOfIndex
  \returns Variable handle
- 
+
  \author Oliver Lemke
  */
-int nca_def_ArrayOfIndex(const int ncid,
-                         const String& name,
-                         const ArrayOfIndex& a) {
-  int ncdims[1], varid;
+int nca_def_ArrayOfIndex(const int ncid, const String &name,
+                         const ArrayOfIndex &a) {
+  std::array<int, 1> ncdims;
+  int varid;
   if (a.nelem()) {
     nca_def_dim(ncid, name + "_nelem", a.nelem(), &ncdims[0]);
     nca_def_var(ncid, name, NC_INT, 1, &ncdims[0], &varid);
@@ -225,16 +216,17 @@ int nca_def_ArrayOfIndex(const int ncid,
 }
 
 //! Define NetCDF dimensions and variable for a Vector.
-/** 
+/**
  \param[in]  ncid   NetCDF file descriptor
  \param[in]  name   Variable name in NetCDF file
  \param[in]  v      Vector
  \returns Variable handle
- 
+
  \author Oliver Lemke
  */
-int nca_def_Vector(const int ncid, const String& name, const Vector& v) {
-  int ncdims[1], varid;
+int nca_def_Vector(const int ncid, const String &name, const Vector &v) {
+  std::array<int, 1> ncdims;
+  int varid;
   if (v.nelem()) {
     nca_def_dim(ncid, name + "_nelem", v.nelem(), &ncdims[0]);
     nca_def_var(ncid, name, NC_DOUBLE, 1, &ncdims[0], &varid);
@@ -245,16 +237,17 @@ int nca_def_Vector(const int ncid, const String& name, const Vector& v) {
 }
 
 //! Define NetCDF dimensions and variable for a Matrix.
-/** 
+/**
  \param[in]  ncid   NetCDF file descriptor
  \param[in]  name   Variable name in NetCDF file
  \param[in]  m      Matrix
  \returns Variable handle
- 
+
  \author Oliver Lemke
  */
-int nca_def_Matrix(const int ncid, const String& name, const Matrix& m) {
-  int ncdims[2], varid;
+int nca_def_Matrix(const int ncid, const String &name, const Matrix &m) {
+  std::array<int, 2> ncdims;
+  int varid;
   if (m.nrows() && m.ncols()) {
     nca_def_dim(ncid, name + "_nrows", m.nrows(), &ncdims[0]);
     nca_def_dim(ncid, name + "_ncols", m.ncols(), &ncdims[1]);
@@ -266,16 +259,17 @@ int nca_def_Matrix(const int ncid, const String& name, const Matrix& m) {
 }
 
 //! Define NetCDF dimensions and variable for a Tensor4.
-/** 
+/**
  \param[in]  ncid   NetCDF file descriptor
  \param[in]  name   Variable name in NetCDF file
  \param[in]  t      Tensor4
  \returns Variable handle
- 
+
  \author Oliver Lemke
  */
-int nca_def_Tensor4(const int ncid, const String& name, const Tensor4& t) {
-  int ncdims[4], varid;
+int nca_def_Tensor4(const int ncid, const String &name, const Tensor4 &t) {
+  std::array<int, 4> ncdims;
+  int varid;
   if (t.nbooks() && t.npages() && t.nrows() && t.ncols()) {
     nca_def_dim(ncid, name + "_nbooks", t.nbooks(), &ncdims[0]);
     nca_def_dim(ncid, name + "_npages", t.npages(), &ncdims[1]);
@@ -289,15 +283,15 @@ int nca_def_Tensor4(const int ncid, const String& name, const Tensor4& t) {
 }
 
 //! Read a dimension from NetCDF file.
-/** 
+/**
  \param[in]  ncid     NetCDF file descriptor
  \param[in]  name     Dimension name in NetCDF file
- \param[in]  noerror  Return 0 instead of throwing an exception if dimension does not exist in file
- \returns Dimension size
- 
+ \param[in]  noerror  Return 0 instead of throwing an exception if dimension
+ does not exist in file \returns Dimension size
+
  \author Oliver Lemke
  */
-Index nc_get_dim(const int ncid, const String& name, const bool noerror) {
+Index nc_get_dim(const int ncid, const String &name, const bool noerror) {
   int retval, dimid;
   size_t ndim;
   if ((retval = nc_inq_dimid(ncid, name.c_str(), &dimid))) {
@@ -317,14 +311,14 @@ Index nc_get_dim(const int ncid, const String& name, const bool noerror) {
 }
 
 //! Read variable of type int from NetCDF file.
-/** 
+/**
  \param[in]  ncid   NetCDF file descriptor
  \param[in]  name   Variable name in NetCDF file
  \param[out] data   Data read from file
- 
+
  \author Oliver Lemke
  */
-void nca_get_data_int(const int ncid, const String& name, int* data) {
+void nca_get_data(const int ncid, const String &name, int *data) {
   int retval, varid;
   if ((retval = nc_inq_varid(ncid, name.c_str(), &varid)))
     nca_error(retval, "nc_inq_varid(" + name + ")");
@@ -333,14 +327,14 @@ void nca_get_data_int(const int ncid, const String& name, int* data) {
 }
 
 //! Read variable of type long from NetCDF file.
-/** 
+/**
  \param[in]  ncid   NetCDF file descriptor
  \param[in]  name   Variable name in NetCDF file
  \param[out] data   Data read from file
- 
+
  \author Oliver Lemke
  */
-void nca_get_data_long(const int ncid, const String& name, long* data) {
+void nca_get_data(const int ncid, const String &name, long *data) {
   int retval, varid;
   if ((retval = nc_inq_varid(ncid, name.c_str(), &varid)))
     nca_error(retval, "nc_inq_varid(" + name + ")");
@@ -349,14 +343,14 @@ void nca_get_data_long(const int ncid, const String& name, long* data) {
 }
 
 //! Read variable of type long long from NetCDF file.
-/** 
+/**
  \param[in]  ncid   NetCDF file descriptor
  \param[in]  name   Variable name in NetCDF file
  \param[out] data   Data read from file
- 
+
  \author Oliver Lemke
  */
-void nca_get_data_longlong(const int ncid, const String& name, long long* data) {
+void nca_get_data(const int ncid, const String &name, long long *data) {
   int retval, varid;
   if ((retval = nc_inq_varid(ncid, name.c_str(), &varid)))
     nca_error(retval, "nc_inq_varid(" + name + ")");
@@ -365,14 +359,14 @@ void nca_get_data_longlong(const int ncid, const String& name, long long* data) 
 }
 
 //! Read variable of type double from NetCDF file.
-/** 
+/**
  \param[in]  ncid   NetCDF file descriptor
  \param[in]  name   Variable name in NetCDF file
  \param[out] data   Data read from file
- 
+
  \author Oliver Lemke
  */
-void nca_get_data_double(const int ncid, const String& name, Numeric* data) {
+void nca_get_data(const int ncid, const String &name, Numeric *data) {
   int retval, varid;
   if ((retval = nc_inq_varid(ncid, name.c_str(), &varid)))
     nca_error(retval, "nc_inq_varid(" + name + ")");
@@ -381,18 +375,15 @@ void nca_get_data_double(const int ncid, const String& name, Numeric* data) {
 }
 
 //! Read variable of type array of double from NetCDF file.
-/** 
+/**
  \param[in]  ncid   NetCDF file descriptor
  \param[in]  name   Variable name in NetCDF file
  \param[out] data   Data read from file
- 
+
  \author Oliver Lemke
  */
-void nca_get_dataa_double(const int ncid,
-                          const String& name,
-                          size_t start,
-                          size_t count,
-                          Numeric* data) {
+void nca_get_data(const int ncid, const String &name, size_t start,
+                  size_t count, Numeric *data) {
   int retval, varid;
   if ((retval = nc_inq_varid(ncid, name.c_str(), &varid)))
     nca_error(retval, "nc_inq_varid(" + name + ")");
@@ -401,14 +392,14 @@ void nca_get_dataa_double(const int ncid,
 }
 
 //! Read variable of type array of char from NetCDF file.
-/** 
+/**
  \param[in]  ncid   NetCDF file descriptor
  \param[in]  name   Variable name in NetCDF file
  \param[out] data   Data read from file
- 
+
  \author Oliver Lemke
  */
-void nca_get_data_text(const int ncid, const String& name, char* data) {
+void nca_get_data(const int ncid, const String &name, char *data) {
   int retval, varid;
   if ((retval = nc_inq_varid(ncid, name.c_str(), &varid)))
     nca_error(retval, "nc_inq_varid(" + name + ")");
@@ -417,56 +408,48 @@ void nca_get_data_text(const int ncid, const String& name, char* data) {
 }
 
 //! Read variable of type ArrayOfIndex from NetCDF file.
-/** 
+/**
  \param[in]  ncid     NetCDF file descriptor
  \param[in]  name     Variable name in NetCDF file
  \param[out] aoi      Data read from file
- \param[in]  noerror  Return empty variable instead of throwing an exception if variable
-                      does not exist in file
- 
+ \param[in]  noerror  Return empty variable instead of throwing an exception if
+ variable does not exist in file
+
  \author Oliver Lemke
  */
-void nca_get_data_ArrayOfIndex(const int ncid,
-                               const String& name,
-                               ArrayOfIndex& aoi,
-                               const bool noerror) {
+void nca_get_data(const int ncid, const String &name, ArrayOfIndex &aoi,
+                  const bool noerror) {
   Index nelem = nc_get_dim(ncid, name + "_nelem", noerror);
   aoi.resize(nelem);
   if (nelem) {
-    Index* ind_arr = new Index[nelem];
-    nca_get_data_longlong(ncid, name, ind_arr);
-    Index i = 0;
-    for (ArrayOfIndex::iterator it = aoi.begin(); it != aoi.end(); it++, i++)
-      *it = ind_arr[i];
+    nca_get_data(ncid, name, aoi.data());
   }
 }
 
 //! Read variable of type ArrayOfArrayOfSpeciesTag from NetCDF file.
-/** 
+/**
  \param[in]  ncid     NetCDF file descriptor
  \param[in]  name     Variable name in NetCDF file
  \param[out] aast     Data read from file
- \param[in]  noerror  Return empty variable instead of throwing an exception if variable
-                      does not exist in file
- 
+ \param[in]  noerror  Return empty variable instead of throwing an exception if
+ variable does not exist in file
+
  \author Oliver Lemke
  */
-void nca_get_data_ArrayOfArrayOfSpeciesTag(const int ncid,
-                                           const String& name,
-                                           ArrayOfArrayOfSpeciesTag& aast,
-                                           const bool noerror) {
+void nca_get_data(const int ncid, const String &name,
+                  ArrayOfArrayOfSpeciesTag &aast, const bool noerror) {
   ArrayOfIndex species_count;
-  nca_get_data_ArrayOfIndex(ncid, name + "_count", species_count, noerror);
+  nca_get_data(ncid, name + "_count", species_count, noerror);
   aast.resize(species_count.nelem());
   if (species_count.nelem()) {
     Index species_strings_nelem =
         nc_get_dim(ncid, name + "_strings_nelem", noerror);
     Index species_strings_length =
         nc_get_dim(ncid, name + "_strings_length", noerror);
-    char* species_strings =
+    char *species_strings =
         new char[species_strings_nelem * species_strings_length];
     if (species_count.nelem())
-      nca_get_data_text(ncid, name + "_strings", species_strings);
+      nca_get_data(ncid, name + "_strings", species_strings);
 
     Index si = 0;
     for (Index i = 0; i < species_count.nelem(); i++) {
@@ -482,160 +465,180 @@ void nca_get_data_ArrayOfArrayOfSpeciesTag(const int ncid,
 }
 
 //! Read variable of type Vector from NetCDF file.
-/** 
+/**
  \param[in]  ncid     NetCDF file descriptor
  \param[in]  name     Variable name in NetCDF file
  \param[out] v        Data read from file
- \param[in]  noerror  Return empty variable instead of throwing an exception if variable
-                      does not exist in file
- 
+ \param[in]  noerror  Return empty variable instead of throwing an exception if
+ variable does not exist in file
+
  \author Oliver Lemke
  */
-void nca_get_data_Vector(const int ncid,
-                         const String& name,
-                         Vector& v,
-                         const bool noerror) {
+void nca_get_data(const int ncid, const String &name, Vector &v,
+                  const bool noerror) {
   Index nelem = nc_get_dim(ncid, name + "_nelem", noerror);
   v.resize(nelem);
-  if (nelem) nca_get_data_double(ncid, name, v.get_c_array());
+  if (nelem)
+    nca_get_data(ncid, name, v.get_c_array());
 }
 
 //! Read variable of type Matrix from NetCDF file.
-/** 
+/**
  \param[in]  ncid     NetCDF file descriptor
  \param[in]  name     Variable name in NetCDF file
  \param[out] m        Data read from file
- \param[in]  noerror  Return empty variable instead of throwing an exception if variable
-                      does not exist in file
- 
+ \param[in]  noerror  Return empty variable instead of throwing an exception if
+ variable does not exist in file
+
  \author Oliver Lemke
  */
-void nca_get_data_Matrix(const int ncid,
-                         const String& name,
-                         Matrix& m,
-                         const bool noerror) {
+void nca_get_data(const int ncid, const String &name, Matrix &m,
+                  const bool noerror) {
   Index nrows = nc_get_dim(ncid, name + "_nrows", noerror);
   Index ncols = nc_get_dim(ncid, name + "_ncols", noerror);
   m.resize(nrows, ncols);
-  if (nrows && ncols) nca_get_data_double(ncid, name, m.get_c_array());
+  if (nrows && ncols)
+    nca_get_data(ncid, name, m.get_c_array());
 }
 
 //! Read variable of type Tensor4 from NetCDF file.
-/** 
+/**
  \param[in]  ncid     NetCDF file descriptor
  \param[in]  name     Variable name in NetCDF file
  \param[out] t        Data read from file
- \param[in]  noerror  Return empty variable instead of throwing an exception if variable
-                      does not exist in file
- 
+ \param[in]  noerror  Return empty variable instead of throwing an exception if
+ variable does not exist in file
+
  \author Oliver Lemke
  */
-void nca_get_data_Tensor4(const int ncid,
-                          const String& name,
-                          Tensor4& t,
-                          const bool noerror) {
+void nca_get_data(const int ncid, const String &name, Tensor4 &t,
+                  const bool noerror) {
   Index nbooks = nc_get_dim(ncid, name + "_nbooks", noerror);
   Index npages = nc_get_dim(ncid, name + "_npages", noerror);
   Index nrows = nc_get_dim(ncid, name + "_nrows", noerror);
   Index ncols = nc_get_dim(ncid, name + "_ncols", noerror);
   t.resize(nbooks, npages, nrows, ncols);
   if (nbooks && npages && nrows && ncols)
-    nca_get_data_double(ncid, name, t.get_c_array());
+    nca_get_data(ncid, name, t.get_c_array());
 }
 
-//! Write variable of type ArrayOfIndex to NetCDF file.
-/** 
+//! Write variable of type long* to NetCDF file.
+/**
  \param[in]  ncid     NetCDF file descriptor
  \param[in]  name     Variable name in NetCDF file
  \param[in]  a        Data to be written
  \returns True if variable was not empty
- 
+
  \author Oliver Lemke
  */
-bool nca_put_var_ArrayOfIndex(const int ncid,
-                              const int varid,
-                              const ArrayOfIndex& a) {
+void nca_put_var(const int ncid, const int varid, const long *ind_arr) {
+  int retval;
+  if ((retval = nc_put_var_long(ncid, varid, ind_arr)))
+    nca_error(retval, "nc_put_var");
+}
+
+//! Write variable of type long long* to NetCDF file.
+/**
+ \param[in]  ncid     NetCDF file descriptor
+ \param[in]  name     Variable name in NetCDF file
+ \param[in]  a        Data to be written
+ \returns True if variable was not empty
+
+ \author Oliver Lemke
+ */
+void nca_put_var(const int ncid, const int varid, const long long *ind_arr) {
+  int retval;
+  if ((retval = nc_put_var_longlong(ncid, varid, ind_arr)))
+    nca_error(retval, "nc_put_var");
+}
+
+//! Write variable of type ArrayOfIndex to NetCDF file.
+/**
+ \param[in]  ncid     NetCDF file descriptor
+ \param[in]  name     Variable name in NetCDF file
+ \param[in]  a        Data to be written
+ \returns True if variable was not empty
+
+ \author Oliver Lemke
+ */
+bool nca_put_var(const int ncid, const int varid, const ArrayOfIndex &a) {
   bool fail = true;
   if (a.nelem()) {
-    Index* ind_arr = new Index[a.nelem()];
-    for (Index i = 0; i < a.nelem(); i++) ind_arr[i] = a[i];
-
-    int retval;
-    if ((retval = nc_put_var_longlong(ncid, varid, ind_arr)))
-      nca_error(retval, "nc_put_var");
-
-    delete[] ind_arr;
+    nca_put_var(ncid, varid, a.data());
     fail = false;
   }
   return fail;
 }
 
 //! Write variable of type Vector to NetCDF file.
-/** 
+/**
  \param[in]  ncid     NetCDF file descriptor
  \param[in]  name     Variable name in NetCDF file
  \param[in]  v        Data to be written
  \returns True if variable was not empty
- 
+
  \author Oliver Lemke
  */
-bool nca_put_var_Vector(const int ncid, const int varid, const Vector& v) {
+bool nca_put_var(const int ncid, const int varid, const Vector &v) {
   bool fail = true;
   if (v.nelem()) {
     int retval;
     if ((retval = nc_put_var_double(ncid, varid, v.get_c_array())))
       nca_error(retval, "nc_put_var");
+    fail = false;
   }
   return fail;
 }
 
 //! Write variable of type Matrix to NetCDF file.
-/** 
+/**
  \param[in]  ncid     NetCDF file descriptor
  \param[in]  name     Variable name in NetCDF file
  \param[in]  m        Data to be written
  \returns True if variable was not empty
- 
+
  \author Oliver Lemke
  */
-bool nca_put_var_Matrix(const int ncid, const int varid, const Matrix& m) {
+bool nca_put_var(const int ncid, const int varid, const Matrix &m) {
   bool fail = true;
   if (m.nrows() && m.ncols()) {
     int retval;
     if ((retval = nc_put_var_double(ncid, varid, m.get_c_array())))
       nca_error(retval, "nc_put_var");
+    fail = false;
   }
   return fail;
 }
 
 //! Write variable of type Tensor4 to NetCDF file.
-/** 
+/**
  \param[in]  ncid     NetCDF file descriptor
  \param[in]  name     Variable name in NetCDF file
  \param[in]  t        Data to be written
  \returns True if variable was not empty
- 
+
  \author Oliver Lemke
  */
-bool nca_put_var_Tensor4(const int ncid, const int varid, const Tensor4& t) {
+bool nca_put_var(const int ncid, const int varid, const Tensor4 &t) {
   bool fail = true;
   if (t.nbooks() && t.npages() && t.nrows() && t.ncols()) {
     int retval;
     if ((retval = nc_put_var_double(ncid, varid, t.get_c_array())))
       nca_error(retval, "nc_put_var");
+    fail = false;
   }
   return fail;
 }
 
 //! Throws a runtime error for the given NetCDF error code
-/** 
+/**
  \param[in]  e  NetCDF error code
  \param[in]  s  Error message string
- 
+
  \author Oliver Lemke
  */
 
-void nca_error(const int e, const String s) {
+void nca_error(const int e, const std::string_view s) {
   ostringstream os;
   os << "NetCDF error: " << s << ", " << e;
   throw runtime_error(os.str());

--- a/src/nc_io.cc
+++ b/src/nc_io.cc
@@ -293,7 +293,7 @@ int nca_def_Tensor4(const int ncid, const String &name, const Tensor4 &t) {
 
  \author Oliver Lemke
  */
-Index nc_get_dim(const int ncid, const String &name, const bool noerror) {
+Index nca_get_dim(const int ncid, const String &name, const bool noerror) {
   int retval, dimid;
   size_t ndim;
   if ((retval = nc_inq_dimid(ncid, name.c_str(), &dimid))) {
@@ -421,7 +421,7 @@ void nca_get_data(const int ncid, const String &name, char *data) {
  */
 void nca_get_data(const int ncid, const String &name, ArrayOfIndex &aoi,
                   const bool noerror) {
-  Index nelem = nc_get_dim(ncid, name + "_nelem", noerror);
+  Index nelem = nca_get_dim(ncid, name + "_nelem", noerror);
   aoi.resize(nelem);
   if (nelem) {
     nca_get_data(ncid, name, aoi.data());
@@ -445,9 +445,9 @@ void nca_get_data(const int ncid, const String &name,
   aast.resize(species_count.nelem());
   if (species_count.nelem()) {
     Index species_strings_nelem =
-        nc_get_dim(ncid, name + "_strings_nelem", noerror);
+        nca_get_dim(ncid, name + "_strings_nelem", noerror);
     Index species_strings_length =
-        nc_get_dim(ncid, name + "_strings_length", noerror);
+        nca_get_dim(ncid, name + "_strings_length", noerror);
     char *species_strings =
         new char[species_strings_nelem * species_strings_length];
     if (species_count.nelem())
@@ -478,7 +478,7 @@ void nca_get_data(const int ncid, const String &name,
  */
 void nca_get_data(const int ncid, const String &name, Vector &v,
                   const bool noerror) {
-  Index nelem = nc_get_dim(ncid, name + "_nelem", noerror);
+  Index nelem = nca_get_dim(ncid, name + "_nelem", noerror);
   v.resize(nelem);
   if (nelem)
     nca_get_data(ncid, name, v.get_c_array());
@@ -496,8 +496,8 @@ void nca_get_data(const int ncid, const String &name, Vector &v,
  */
 void nca_get_data(const int ncid, const String &name, Matrix &m,
                   const bool noerror) {
-  Index nrows = nc_get_dim(ncid, name + "_nrows", noerror);
-  Index ncols = nc_get_dim(ncid, name + "_ncols", noerror);
+  Index nrows = nca_get_dim(ncid, name + "_nrows", noerror);
+  Index ncols = nca_get_dim(ncid, name + "_ncols", noerror);
   m.resize(nrows, ncols);
   if (nrows && ncols)
     nca_get_data(ncid, name, m.get_c_array());
@@ -515,10 +515,10 @@ void nca_get_data(const int ncid, const String &name, Matrix &m,
  */
 void nca_get_data(const int ncid, const String &name, Tensor4 &t,
                   const bool noerror) {
-  Index nbooks = nc_get_dim(ncid, name + "_nbooks", noerror);
-  Index npages = nc_get_dim(ncid, name + "_npages", noerror);
-  Index nrows = nc_get_dim(ncid, name + "_nrows", noerror);
-  Index ncols = nc_get_dim(ncid, name + "_ncols", noerror);
+  Index nbooks = nca_get_dim(ncid, name + "_nbooks", noerror);
+  Index npages = nca_get_dim(ncid, name + "_npages", noerror);
+  Index nrows = nca_get_dim(ncid, name + "_nrows", noerror);
+  Index ncols = nca_get_dim(ncid, name + "_ncols", noerror);
   t.resize(nbooks, npages, nrows, ncols);
   if (nbooks && npages && nrows && ncols)
     nca_get_data(ncid, name, t.get_c_array());

--- a/src/nc_io.h
+++ b/src/nc_io.h
@@ -88,9 +88,8 @@ int nca_def_Matrix(const int ncid, const String& name, const Matrix& m);
 
 int nca_def_Tensor4(const int ncid, const String& name, const Tensor4& t);
 
-Index nc_get_dim(const int ncid,
-                 const String& name,
-                 const bool noerror = false);
+Index nca_get_dim(const int ncid, const String &name,
+                  const bool noerror = false);
 
 void nca_get_data(const int ncid, const String& name, int* data);
 

--- a/src/nc_io.h
+++ b/src/nc_io.h
@@ -34,10 +34,11 @@
 #define nc_io_h
 
 #include <netcdf.h>
-#include "species_tags.h"
+
 #include "exceptions.h"
 #include "messages.h"
 #include "mystring.h"
+#include "species_tags.h"
 
 ////////////////////////////////////////////////////////////////////////////
 //   Default file names
@@ -91,59 +92,47 @@ Index nc_get_dim(const int ncid,
                  const String& name,
                  const bool noerror = false);
 
-void nca_get_data_int(const int ncid, const String& name, int* data);
+void nca_get_data(const int ncid, const String& name, int* data);
 
-void nca_get_data_long(const int ncid, const String& name, long* data);
+void nca_get_data(const int ncid, const String &name, long *data);
 
-void nca_get_data_longlong(const int ncid, const String& name, long long* data);
+void nca_get_data(const int ncid, const String &name, long long *data);
 
+void nca_get_data(const int ncid, const String &name, Numeric *data);
 
-void nca_get_data_double(const int ncid, const String& name, Numeric* data);
+void nca_get_data(const int ncid, const String &name, size_t start,
+                  size_t count, Numeric *data);
 
-void nca_get_dataa_double(const int ncid,
-                          const String& name,
-                          size_t start,
-                          size_t count,
-                          Numeric* data);
+void nca_get_data(const int ncid, const String &name, char *data);
 
-void nca_get_data_text(const int ncid, const String& name, char* data);
+void nca_get_data(const int ncid, const String &name,
+                               ArrayOfIndex &aoi, const bool noerror);
 
-void nca_get_data_ArrayOfIndex(const int ncid,
-                               const String& name,
-                               ArrayOfIndex& aoi,
-                               const bool noerror);
+void nca_get_data(const int ncid, const String &name,
+                  ArrayOfArrayOfSpeciesTag &aast, const bool noerror);
 
-void nca_get_data_ArrayOfArrayOfSpeciesTag(const int ncid,
-                                           const String& name,
-                                           ArrayOfArrayOfSpeciesTag& aast,
-                                           const bool noerror);
+void nca_get_data(const int ncid, const String &name, Vector &v,
+                  const bool noerror = false);
 
-void nca_get_data_Vector(const int ncid,
-                         const String& name,
-                         Vector& v,
-                         const bool noerror = false);
+void nca_get_data(const int ncid, const String &name, Matrix &m,
+                  const bool noerror = false);
 
-void nca_get_data_Matrix(const int ncid,
-                         const String& name,
-                         Matrix& m,
-                         const bool noerror = false);
+void nca_get_data(const int ncid, const String &name, Tensor4 &m,
+                  const bool noerror = false);
 
-void nca_get_data_Tensor4(const int ncid,
-                          const String& name,
-                          Tensor4& m,
-                          const bool noerror = false);
+void nca_put_var(const int ncid, const int varid, const long *ind_arr);
 
-bool nca_put_var_ArrayOfIndex(const int ncid,
-                              const int varid,
-                              const ArrayOfIndex& a);
+void nca_put_var(const int ncid, const int varid, const long long*ind_arr);
 
-bool nca_put_var_Vector(const int ncid, const int varid, const Vector& v);
+bool nca_put_var(const int ncid, const int varid, const ArrayOfIndex &a);
 
-bool nca_put_var_Matrix(const int ncid, const int varid, const Matrix& m);
+bool nca_put_var(const int ncid, const int varid, const Vector& v);
 
-bool nca_put_var_Tensor4(const int ncid, const int varid, const Tensor4& t);
+bool nca_put_var(const int ncid, const int varid, const Matrix& m);
 
-void nca_error(const int err, const String msg);
+bool nca_put_var(const int ncid, const int varid, const Tensor4& t);
+
+void nca_error(const int err, const std::string_view msg);
 
 #endif /* nc_io_h */
 

--- a/src/nc_io_array_types.cc
+++ b/src/nc_io_array_types.cc
@@ -229,12 +229,12 @@ void nca_write_to_file(const int ncid,
 //   IO function have not yet been implemented
 ////////////////////////////////////////////////////////////////////////////
 
-#define TMPL_NC_READ_WRITE_FILE_DUMMY(what)                                   \
-  void nca_write_to_file(const int, const what&, const Verbosity&) {          \
-    throw runtime_error("NetCDF support not yet implemented for this type!"); \
-  }                                                                           \
-  void nca_read_from_file(const int, what&, const Verbosity&) {               \
-    throw runtime_error("NetCDF support not yet implemented for this type!"); \
+#define TMPL_NC_READ_WRITE_FILE_DUMMY(what)                                    \
+  void nca_write_to_file(const int, const what &, const Verbosity &) {         \
+    ARTS_USER_ERROR("NetCDF support not yet implemented for this type!");      \
+  }                                                                            \
+  void nca_read_from_file(const int, what &, const Verbosity &) {              \
+    ARTS_USER_ERROR("NetCDF support not yet implemented for this type!");      \
   }
 
 //==========================================================================

--- a/src/nc_io_array_types.cc
+++ b/src/nc_io_array_types.cc
@@ -34,6 +34,38 @@
 #include "nc_io.h"
 #include "nc_io_types.h"
 
+//=== ArrayOfIndex ==========================================================
+
+//! Reads a ArrayOfIndex from a NetCDF file
+/*!
+  \param ncf     NetCDF file descriptor
+  \param v       ArrayOfIndex
+*/
+void nca_read_from_file(const int ncid, ArrayOfIndex& v, const Verbosity&) {
+  Index nelem;
+  nelem = nc_get_dim(ncid, "nelem");
+
+  v.resize(nelem);
+  nca_get_data(ncid, "ArrayOfIndex", v.data());
+}
+
+//! Writes a ArrayOfIndex to a NetCDF file
+/*!
+  \param ncid    NetCDF file descriptor
+  \param v       ArrayOfIndex
+*/
+void nca_write_to_file(const int ncid, const ArrayOfIndex& v, const Verbosity&) {
+  int retval;
+  int ncdim, varid;
+  if ((retval = nc_def_dim(ncid, "nelem", v.nelem(), &ncdim)))
+    nca_error(retval, "nc_def_dim");
+  if ((retval = nc_def_var(ncid, "ArrayOfIndex", NC_INT64, 1, &ncdim, &varid)))
+    nca_error(retval, "nc_def_var");
+  if ((retval = nc_enddef(ncid))) nca_error(retval, "nc_enddef");
+  if ((retval = nc_put_var(ncid, varid, v.data())))
+    nca_error(retval, "nc_put_var");
+}
+
 //=== ArrayOfMatrix ==========================================================
 
 //! Reads an ArrayOfMatrix from a NetCDF file

--- a/src/nc_io_array_types.cc
+++ b/src/nc_io_array_types.cc
@@ -43,7 +43,7 @@
 */
 void nca_read_from_file(const int ncid, ArrayOfIndex& v, const Verbosity&) {
   Index nelem;
-  nelem = nc_get_dim(ncid, "nelem");
+  nelem = nca_get_dim(ncid, "nelem");
 
   v.resize(nelem);
   nca_get_data(ncid, "ArrayOfIndex", v.data());
@@ -75,7 +75,7 @@ void nca_write_to_file(const int ncid, const ArrayOfIndex& v, const Verbosity&) 
 */
 void nca_read_from_file(const int ncid, ArrayOfMatrix& aom, const Verbosity&) {
   Index nelem;
-  nelem = nc_get_dim(ncid, "nelem");
+  nelem = nca_get_dim(ncid, "nelem");
 
   long* vnrows = new long[nelem];
   long* vncols = new long[nelem];
@@ -161,7 +161,7 @@ void nca_write_to_file(const int ncid,
 */
 void nca_read_from_file(const int ncid, ArrayOfVector& aov, const Verbosity&) {
   Index nelem;
-  nelem = nc_get_dim(ncid, "nelem");
+  nelem = nca_get_dim(ncid, "nelem");
 
   long* vnelem = new long[nelem];
   aov.resize(nelem);

--- a/src/nc_io_array_types.cc
+++ b/src/nc_io_array_types.cc
@@ -48,12 +48,12 @@ void nca_read_from_file(const int ncid, ArrayOfMatrix& aom, const Verbosity&) {
   long* vnrows = new long[nelem];
   long* vncols = new long[nelem];
   aom.resize(nelem);
-  nca_get_data_long(ncid, "Matrix_nrows", vnrows);
-  nca_get_data_long(ncid, "Matrix_ncols", vncols);
+  nca_get_data(ncid, "Matrix_nrows", vnrows);
+  nca_get_data(ncid, "Matrix_ncols", vncols);
   size_t pos = 0;
   for (Index i = 0; i < nelem; i++) {
     aom[i].resize(vnrows[i], vncols[i]);
-    nca_get_dataa_double(ncid,
+    nca_get_data(ncid,
                          "ArrayOfMatrix",
                          pos,
                          vnrows[i] * vncols[i],
@@ -91,10 +91,10 @@ void nca_write_to_file(const int ncid,
     nca_error(retval, "nc_def_dim");
 
   if ((retval =
-           nc_def_var(ncid, "Matrix_nrows", NC_LONG, 1, &ncdim, &varid_nrows)))
+           nc_def_var(ncid, "Matrix_nrows", NC_INT64, 1, &ncdim, &varid_nrows)))
     nca_error(retval, "nc_def_var");
   if ((retval =
-           nc_def_var(ncid, "Matrix_ncols", NC_LONG, 1, &ncdim, &varid_ncols)))
+           nc_def_var(ncid, "Matrix_ncols", NC_INT64, 1, &ncdim, &varid_ncols)))
     nca_error(retval, "nc_def_var");
   if ((retval = nc_def_var(
            ncid, "ArrayOfMatrix", NC_DOUBLE, 1, &ncdim_total, &varid)))
@@ -133,11 +133,11 @@ void nca_read_from_file(const int ncid, ArrayOfVector& aov, const Verbosity&) {
 
   long* vnelem = new long[nelem];
   aov.resize(nelem);
-  nca_get_data_long(ncid, "Vector_nelem", vnelem);
+  nca_get_data(ncid, "Vector_nelem", vnelem);
   size_t pos = 0;
   for (Index i = 0; i < nelem; i++) {
     aov[i].resize(vnelem[i]);
-    nca_get_dataa_double(
+    nca_get_data(
         ncid, "ArrayOfVector", pos, vnelem[i], aov[i].get_c_array());
     pos += vnelem[i];
   }
@@ -169,7 +169,7 @@ void nca_write_to_file(const int ncid,
     nca_error(retval, "nc_def_dim");
 
   if ((retval =
-           nc_def_var(ncid, "Vector_nelem", NC_LONG, 1, &ncdim, &varid_nelem)))
+           nc_def_var(ncid, "Vector_nelem", NC_INT64, 1, &ncdim, &varid_nelem)))
     nca_error(retval, "nc_def_var");
   if ((retval = nc_def_var(
            ncid, "ArrayOfVector", NC_DOUBLE, 1, &ncdim_total, &varid)))

--- a/src/nc_io_basic_types.cc
+++ b/src/nc_io_basic_types.cc
@@ -43,8 +43,8 @@
 */
 void nca_read_from_file(const int ncid, Matrix& m, const Verbosity&) {
   Index nrows, ncols;
-  nrows = nc_get_dim(ncid, "nrows");
-  ncols = nc_get_dim(ncid, "ncols");
+  nrows = nca_get_dim(ncid, "nrows");
+  ncols = nca_get_dim(ncid, "ncols");
 
   m.resize(nrows, ncols);
   nca_get_data(ncid, "Matrix", m.get_c_array());
@@ -78,9 +78,9 @@ void nca_write_to_file(const int ncid, const Matrix& m, const Verbosity&) {
 */
 void nca_read_from_file(const int ncid, Tensor3& t, const Verbosity&) {
   Index npages, nrows, ncols;
-  npages = nc_get_dim(ncid, "npages");
-  nrows = nc_get_dim(ncid, "nrows");
-  ncols = nc_get_dim(ncid, "ncols");
+  npages = nca_get_dim(ncid, "npages");
+  nrows = nca_get_dim(ncid, "nrows");
+  ncols = nca_get_dim(ncid, "ncols");
 
   t.resize(npages, nrows, ncols);
   nca_get_data(ncid, "Tensor3", t.get_c_array());
@@ -116,10 +116,10 @@ void nca_write_to_file(const int ncid, const Tensor3& t, const Verbosity&) {
 */
 void nca_read_from_file(const int ncid, Tensor4& t, const Verbosity&) {
   Index nbooks, npages, nrows, ncols;
-  nbooks = nc_get_dim(ncid, "nbooks");
-  npages = nc_get_dim(ncid, "npages");
-  nrows = nc_get_dim(ncid, "nrows");
-  ncols = nc_get_dim(ncid, "ncols");
+  nbooks = nca_get_dim(ncid, "nbooks");
+  npages = nca_get_dim(ncid, "npages");
+  nrows = nca_get_dim(ncid, "nrows");
+  ncols = nca_get_dim(ncid, "ncols");
 
   t.resize(nbooks, npages, nrows, ncols);
   nca_get_data(ncid, "Tensor4", t.get_c_array());
@@ -157,11 +157,11 @@ void nca_write_to_file(const int ncid, const Tensor4& t, const Verbosity&) {
 */
 void nca_read_from_file(const int ncid, Tensor5& t, const Verbosity&) {
   Index nshelves, nbooks, npages, nrows, ncols;
-  nshelves = nc_get_dim(ncid, "nshelves");
-  nbooks = nc_get_dim(ncid, "nbooks");
-  npages = nc_get_dim(ncid, "npages");
-  nrows = nc_get_dim(ncid, "nrows");
-  ncols = nc_get_dim(ncid, "ncols");
+  nshelves = nca_get_dim(ncid, "nshelves");
+  nbooks = nca_get_dim(ncid, "nbooks");
+  npages = nca_get_dim(ncid, "npages");
+  nrows = nca_get_dim(ncid, "nrows");
+  ncols = nca_get_dim(ncid, "ncols");
 
   t.resize(nshelves, nbooks, npages, nrows, ncols);
   nca_get_data(ncid, "Tensor5", t.get_c_array());
@@ -201,7 +201,7 @@ void nca_write_to_file(const int ncid, const Tensor5& t, const Verbosity&) {
 */
 void nca_read_from_file(const int ncid, Vector& v, const Verbosity&) {
   Index nelem;
-  nelem = nc_get_dim(ncid, "nelem");
+  nelem = nca_get_dim(ncid, "nelem");
 
   v.resize(nelem);
   nca_get_data(ncid, "Vector", v.get_c_array());

--- a/src/nc_io_basic_types.cc
+++ b/src/nc_io_basic_types.cc
@@ -229,12 +229,12 @@ void nca_write_to_file(const int ncid, const Vector& v, const Verbosity&) {
 //   IO function have not yet been implemented
 ////////////////////////////////////////////////////////////////////////////
 
-#define TMPL_NC_READ_WRITE_FILE_DUMMY(what)                                         \
-  void nca_write_to_file(const int, const what&, const Verbosity&) {                \
-    ARTS_USER_ERROR ("NetCDF support not yet implemented for this type!"); \
-  }                                                                                 \
-  void nca_read_from_file(const int, what&, const Verbosity&) {                     \
-    ARTS_USER_ERROR ("NetCDF support not yet implemented for this type!"); \
+#define TMPL_NC_READ_WRITE_FILE_DUMMY(what)                                    \
+  void nca_write_to_file(const int, const what &, const Verbosity &) {         \
+    ARTS_USER_ERROR("NetCDF support not yet implemented for this type!");      \
+  }                                                                            \
+  void nca_read_from_file(const int, what &, const Verbosity &) {              \
+    ARTS_USER_ERROR("NetCDF support not yet implemented for this type!");      \
   }
 
 //==========================================================================

--- a/src/nc_io_basic_types.cc
+++ b/src/nc_io_basic_types.cc
@@ -47,7 +47,7 @@ void nca_read_from_file(const int ncid, Matrix& m, const Verbosity&) {
   ncols = nc_get_dim(ncid, "ncols");
 
   m.resize(nrows, ncols);
-  nca_get_data_double(ncid, "Matrix", m.get_c_array());
+  nca_get_data(ncid, "Matrix", m.get_c_array());
 }
 
 //! Writes a Matrix to a NetCDF file
@@ -83,7 +83,7 @@ void nca_read_from_file(const int ncid, Tensor3& t, const Verbosity&) {
   ncols = nc_get_dim(ncid, "ncols");
 
   t.resize(npages, nrows, ncols);
-  nca_get_data_double(ncid, "Tensor3", t.get_c_array());
+  nca_get_data(ncid, "Tensor3", t.get_c_array());
 }
 
 //! Writes a Tensor3 to a NetCDF file
@@ -122,7 +122,7 @@ void nca_read_from_file(const int ncid, Tensor4& t, const Verbosity&) {
   ncols = nc_get_dim(ncid, "ncols");
 
   t.resize(nbooks, npages, nrows, ncols);
-  nca_get_data_double(ncid, "Tensor4", t.get_c_array());
+  nca_get_data(ncid, "Tensor4", t.get_c_array());
 }
 
 //! Writes a Tensor4 to a NetCDF file
@@ -164,7 +164,7 @@ void nca_read_from_file(const int ncid, Tensor5& t, const Verbosity&) {
   ncols = nc_get_dim(ncid, "ncols");
 
   t.resize(nshelves, nbooks, npages, nrows, ncols);
-  nca_get_data_double(ncid, "Tensor5", t.get_c_array());
+  nca_get_data(ncid, "Tensor5", t.get_c_array());
 }
 
 //! Writes a Tensor5 to a NetCDF file
@@ -204,7 +204,7 @@ void nca_read_from_file(const int ncid, Vector& v, const Verbosity&) {
   nelem = nc_get_dim(ncid, "nelem");
 
   v.resize(nelem);
-  nca_get_data_double(ncid, "Vector", v.get_c_array());
+  nca_get_data(ncid, "Vector", v.get_c_array());
 }
 
 //! Writes a Vector to a NetCDF file

--- a/src/nc_io_compound_types.cc
+++ b/src/nc_io_compound_types.cc
@@ -49,7 +49,7 @@
 void nca_read_from_file(const int ncid, GasAbsLookup& gal, const Verbosity&) {
   nca_get_data(ncid, "species", gal.species, true);
   if (!gal.species.nelem())
-    throw runtime_error("No species found in lookup table file!");
+    ARTS_USER_ERROR("No species found in lookup table file!");
 
   nca_get_data(
       ncid, "nonlinear_species", gal.nonlinear_species, true);
@@ -126,7 +126,7 @@ void nca_write_to_file(const int ncid,
                 &species_strings_ncdims[0],
                 &species_strings_varid);
   } else {
-    throw runtime_error("Current lookup table contains no species!");
+    ARTS_USER_ERROR("Current lookup table contains no species!");
   }
 
   // Define dimensions and variables

--- a/src/nc_io_compound_types.cc
+++ b/src/nc_io_compound_types.cc
@@ -47,19 +47,19 @@
  \author Oliver Lemke
 */
 void nca_read_from_file(const int ncid, GasAbsLookup& gal, const Verbosity&) {
-  nca_get_data_ArrayOfArrayOfSpeciesTag(ncid, "species", gal.species, true);
+  nca_get_data(ncid, "species", gal.species, true);
   if (!gal.species.nelem())
     throw runtime_error("No species found in lookup table file!");
 
-  nca_get_data_ArrayOfIndex(
+  nca_get_data(
       ncid, "nonlinear_species", gal.nonlinear_species, true);
-  nca_get_data_Vector(ncid, "f_grid", gal.f_grid, true);
-  nca_get_data_Vector(ncid, "p_grid", gal.p_grid, true);
-  nca_get_data_Matrix(ncid, "vmrs_ref", gal.vmrs_ref, true);
-  nca_get_data_Vector(ncid, "t_ref", gal.t_ref, true);
-  nca_get_data_Vector(ncid, "t_pert", gal.t_pert, true);
-  nca_get_data_Vector(ncid, "nls_pert", gal.nls_pert, true);
-  nca_get_data_Tensor4(ncid, "xsec", gal.xsec, true);
+  nca_get_data(ncid, "f_grid", gal.f_grid, true);
+  nca_get_data(ncid, "p_grid", gal.p_grid, true);
+  nca_get_data(ncid, "vmrs_ref", gal.vmrs_ref, true);
+  nca_get_data(ncid, "t_ref", gal.t_ref, true);
+  nca_get_data(ncid, "t_pert", gal.t_pert, true);
+  nca_get_data(ncid, "nls_pert", gal.nls_pert, true);
+  nca_get_data(ncid, "xsec", gal.xsec, true);
 }
 
 //! Writes a GasAbsLookup table to a NetCDF file
@@ -79,7 +79,7 @@ void nca_write_to_file(const int ncid,
 
   ArrayOfIndex species_count(gal.species.nelem());
   Index species_max_strlen = 0;
-  char* species_strings = NULL;
+  char* species_strings = nullptr;
 
   if (gal.species.nelem()) {
     long species_total_nelems = 0;
@@ -88,11 +88,9 @@ void nca_write_to_file(const int ncid,
       species_total_nelems += nspecies_nelem;
       species_count[nspecies] = nspecies_nelem;
 
-      for (ArrayOfSpeciesTag::const_iterator it = gal.species[nspecies].begin();
-           it != gal.species[nspecies].end();
-           it++)
-        if (it->Name().nelem() > species_max_strlen)
-          species_max_strlen = it->Name().nelem();
+      for (const auto & it : gal.species[nspecies])
+        if (it.Name().nelem() > species_max_strlen)
+          species_max_strlen = it.Name().nelem();
     }
     species_max_strlen++;
 
@@ -100,14 +98,10 @@ void nca_write_to_file(const int ncid,
     memset(species_strings, 0, species_total_nelems * species_max_strlen);
 
     Index str_i = 0;
-    for (ArrayOfArrayOfSpeciesTag::const_iterator it1 = gal.species.begin();
-         it1 != gal.species.end();
-         it1++)
-      for (ArrayOfSpeciesTag::const_iterator it2 = it1->begin();
-           it2 != it1->end();
-           it2++) {
+    for (const auto & species : gal.species)
+      for (const auto & it2 : species) {
         memccpy(&species_strings[str_i],
-                it2->Name().c_str(),
+                it2.Name().c_str(),
                 0,
                 species_max_strlen);
         str_i += species_max_strlen;
@@ -116,7 +110,7 @@ void nca_write_to_file(const int ncid,
     species_count_varid =
         nca_def_ArrayOfIndex(ncid, "species_count", species_count);
 
-    int species_strings_ncdims[2];
+    std::array<int, 2> species_strings_ncdims;
     nca_def_dim(ncid,
                 "species_strings_nelem",
                 species_total_nelems,
@@ -149,7 +143,7 @@ void nca_write_to_file(const int ncid,
   if ((retval = nc_enddef(ncid))) nca_error(retval, "nc_enddef");
 
   // Write variables
-  nca_put_var_ArrayOfIndex(ncid, species_count_varid, species_count);
+  nca_put_var(ncid, species_count_varid, species_count);
   if (gal.species.nelem()) {
     if ((retval =
              nc_put_var_text(ncid, species_strings_varid, species_strings)))
@@ -158,15 +152,15 @@ void nca_write_to_file(const int ncid,
 
   delete[] species_strings;
 
-  nca_put_var_ArrayOfIndex(
+  nca_put_var(
       ncid, nonlinear_species_varid, gal.nonlinear_species);
-  nca_put_var_Vector(ncid, f_grid_varid, gal.f_grid);
-  nca_put_var_Vector(ncid, p_grid_varid, gal.p_grid);
-  nca_put_var_Matrix(ncid, vmrs_ref_varid, gal.vmrs_ref);
-  nca_put_var_Vector(ncid, t_ref_varid, gal.t_ref);
-  nca_put_var_Vector(ncid, t_pert_varid, gal.t_pert);
-  nca_put_var_Vector(ncid, nls_pert_varid, gal.nls_pert);
-  nca_put_var_Tensor4(ncid, xsec_varid, gal.xsec);
+  nca_put_var(ncid, f_grid_varid, gal.f_grid);
+  nca_put_var(ncid, p_grid_varid, gal.p_grid);
+  nca_put_var(ncid, vmrs_ref_varid, gal.vmrs_ref);
+  nca_put_var(ncid, t_ref_varid, gal.t_ref);
+  nca_put_var(ncid, t_pert_varid, gal.t_pert);
+  nca_put_var(ncid, nls_pert_varid, gal.nls_pert);
+  nca_put_var(ncid, xsec_varid, gal.xsec);
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/src/nc_io_instantiation.h
+++ b/src/nc_io_instantiation.h
@@ -61,6 +61,7 @@ TMPL_NC_READ_WRITE_FILE(GasAbsLookup)
 
 //=== Array Types ==========================================================
 
+TMPL_NC_READ_WRITE_FILE(ArrayOfIndex)
 TMPL_NC_READ_WRITE_FILE(ArrayOfMatrix)
 TMPL_NC_READ_WRITE_FILE(ArrayOfVector)
 

--- a/src/nc_io_types.h
+++ b/src/nc_io_types.h
@@ -65,6 +65,7 @@ TMPL_NC_READ_WRITE_FILE(GasAbsLookup)
 
 //=== Array Types ==========================================================
 
+TMPL_NC_READ_WRITE_FILE(ArrayOfIndex)
 TMPL_NC_READ_WRITE_FILE(ArrayOfMatrix)
 TMPL_NC_READ_WRITE_FILE(ArrayOfVector)
 


### PR DESCRIPTION
Since changing Index to std::int64_t, it can have a different type depending on operating system (long or long long). This broke the NetCDF interface. Mapping to the NetCDF type is now done correctly.

Since NetCDF classic format does not support 64-bit integers, ARTS now writes NetCDF4 files.

All former nca_get_data_* and nca_put_var_* are now using overloading and were therefore renamed to nca_get_data/nca_put_var.

This PR universally turns on NetCDF support in all the CI builds. To better detect error scenarios, it should be turned off in at least one or two of the builds. This will be handled in a future PR.