### PR TITLE
Optional variadic macros

### DIFF
--- a/src/arts_options.h
+++ b/src/arts_options.h
@@ -145,61 +145,61 @@ ENUMCLASS(g0_agendaDefaultOptions,
           Mars,
           Venus)
 
-/** Options for setting dobatch_calc_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting dobatch_calc_agenda */
 ENUMCLASS(dobatch_calc_agendaDefaultOptions, char)
 
-/** Options for setting ybatch_calc_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting ybatch_calc_agenda */
 ENUMCLASS(ybatch_calc_agendaDefaultOptions, char)
 
-/** Options for setting test_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting test_agenda */
 ENUMCLASS(test_agendaDefaultOptions, char)
 
-/** Options for setting surface_rtprop_sub_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting surface_rtprop_sub_agenda */
 ENUMCLASS(surface_rtprop_sub_agendaDefaultOptions, char)
 
-/** Options for setting spt_calc_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting spt_calc_agenda */
 ENUMCLASS(spt_calc_agendaDefaultOptions, char)
 
-/** Options for setting sensor_response_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting sensor_response_agenda */
 ENUMCLASS(sensor_response_agendaDefaultOptions, char)
 
 /** Options for setting propmat_clearsky_agenda */
 ENUMCLASS(propmat_clearsky_agendaDefaultOptions, char, Empty)
 
-/** Options for setting pha_mat_spt_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting pha_mat_spt_agenda */
 ENUMCLASS(pha_mat_spt_agendaDefaultOptions, char)
 
-/** Options for setting met_profile_calc_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting met_profile_calc_agenda */
 ENUMCLASS(met_profile_calc_agendaDefaultOptions, char)
 
-/** Options for setting main_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting main_agenda */
 ENUMCLASS(main_agendaDefaultOptions, char)
 
-/** Options for setting jacobian_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting jacobian_agenda */
 ENUMCLASS(jacobian_agendaDefaultOptions, char)
 
-/** Options for setting iy_radar_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting iy_radar_agenda */
 ENUMCLASS(iy_radar_agendaDefaultOptions, char)
 
-/** Options for setting iy_independent_beam_approx_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting iy_independent_beam_approx_agenda */
 ENUMCLASS(iy_independent_beam_approx_agendaDefaultOptions, char)
 
-/** Options for setting inversion_iterate_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting inversion_iterate_agenda */
 ENUMCLASS(inversion_iterate_agendaDefaultOptions, char)
 
-/** Options for setting forloop_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting forloop_agenda */
 ENUMCLASS(forloop_agendaDefaultOptions, char)
 
-/** Options for setting doit_scat_field_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting doit_scat_field_agenda */
 ENUMCLASS(doit_scat_field_agendaDefaultOptions, char)
 
-/** Options for setting doit_rte_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting doit_rte_agenda */
 ENUMCLASS(doit_rte_agendaDefaultOptions, char)
 
-/** Options for setting doit_mono_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting doit_mono_agenda */
 ENUMCLASS(doit_mono_agendaDefaultOptions, char)
 
-/** Options for setting doit_conv_test_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
+/** Options for setting doit_conv_test_agenda */
 ENUMCLASS(doit_conv_test_agendaDefaultOptions, char)
 
 /** Options for setting planets */

--- a/src/arts_options.h
+++ b/src/arts_options.h
@@ -146,61 +146,61 @@ ENUMCLASS(g0_agendaDefaultOptions,
           Venus)
 
 /** Options for setting dobatch_calc_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(dobatch_calc_agendaDefaultOptions, char)
+ENUMCLASS(dobatch_calc_agendaDefaultOptions, char)
 
 /** Options for setting ybatch_calc_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(ybatch_calc_agendaDefaultOptions, char)
+ENUMCLASS(ybatch_calc_agendaDefaultOptions, char)
 
 /** Options for setting test_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(test_agendaDefaultOptions, char)
+ENUMCLASS(test_agendaDefaultOptions, char)
 
 /** Options for setting surface_rtprop_sub_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(surface_rtprop_sub_agendaDefaultOptions, char)
+ENUMCLASS(surface_rtprop_sub_agendaDefaultOptions, char)
 
 /** Options for setting spt_calc_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(spt_calc_agendaDefaultOptions, char)
+ENUMCLASS(spt_calc_agendaDefaultOptions, char)
 
 /** Options for setting sensor_response_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(sensor_response_agendaDefaultOptions, char)
+ENUMCLASS(sensor_response_agendaDefaultOptions, char)
 
 /** Options for setting propmat_clearsky_agenda */
 ENUMCLASS(propmat_clearsky_agendaDefaultOptions, char, Empty)
 
 /** Options for setting pha_mat_spt_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(pha_mat_spt_agendaDefaultOptions, char)
+ENUMCLASS(pha_mat_spt_agendaDefaultOptions, char)
 
 /** Options for setting met_profile_calc_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(met_profile_calc_agendaDefaultOptions, char)
+ENUMCLASS(met_profile_calc_agendaDefaultOptions, char)
 
 /** Options for setting main_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(main_agendaDefaultOptions, char)
+ENUMCLASS(main_agendaDefaultOptions, char)
 
 /** Options for setting jacobian_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(jacobian_agendaDefaultOptions, char)
+ENUMCLASS(jacobian_agendaDefaultOptions, char)
 
 /** Options for setting iy_radar_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(iy_radar_agendaDefaultOptions, char)
+ENUMCLASS(iy_radar_agendaDefaultOptions, char)
 
 /** Options for setting iy_independent_beam_approx_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(iy_independent_beam_approx_agendaDefaultOptions, char)
+ENUMCLASS(iy_independent_beam_approx_agendaDefaultOptions, char)
 
 /** Options for setting inversion_iterate_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(inversion_iterate_agendaDefaultOptions, char)
+ENUMCLASS(inversion_iterate_agendaDefaultOptions, char)
 
 /** Options for setting forloop_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(forloop_agendaDefaultOptions, char)
+ENUMCLASS(forloop_agendaDefaultOptions, char)
 
 /** Options for setting doit_scat_field_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(doit_scat_field_agendaDefaultOptions, char)
+ENUMCLASS(doit_scat_field_agendaDefaultOptions, char)
 
 /** Options for setting doit_rte_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(doit_rte_agendaDefaultOptions, char)
+ENUMCLASS(doit_rte_agendaDefaultOptions, char)
 
 /** Options for setting doit_mono_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(doit_mono_agendaDefaultOptions, char)
+ENUMCLASS(doit_mono_agendaDefaultOptions, char)
 
 /** Options for setting doit_conv_test_agenda --- CHANGE TO ENUMCLASS WHEN ADDING ANY OPTIONS AND REMOVE THIS PART OF THE COMMENT */
-ENUMCLASS_EMPTY(doit_conv_test_agendaDefaultOptions, char)
+ENUMCLASS(doit_conv_test_agendaDefaultOptions, char)
 
 /** Options for setting planets */
 ENUMCLASS(planetDefaultOptions,

--- a/src/debug.h
+++ b/src/debug.h
@@ -29,7 +29,6 @@
 
 #include <sstream>
 #include <string>
-#include <tuple>
 
 /*! Take all arguments and turn to string by their operator<<() */
 template <typename ... Args>
@@ -80,19 +79,20 @@ std::string var_string(Args&& ... args) {
 #define ARTS_NOEXCEPT noexcept(false)
 
 /*! Condition should be true to pass internal check */
-#define ARTS_ASSERT(condition, ...) {     \
-  if (not (condition)) {                  \
-    throw std::runtime_error(             \
-    var_string("Failed Internal Assert: " \
-        #condition "\n" "This is a bug! " \
-        "Bug is found at:\n\t" __FILE__   \
-        ":", __LINE__, "\nPlease contact" \
-        " ARTS developers so we can fix " \
-        "our error(s) via:\n\t"           \
-        "github.com/atmtools/arts\n") +   \
-    var_string(__VA_ARGS__)               \
-    );                                    \
-  } }
+#define ARTS_ASSERT(condition, ...)                                            \
+  {                                                                            \
+    if (not(condition)) {                                                      \
+      throw std::runtime_error(                                                \
+          var_string("Failed Internal Assert: " #condition "\n"                \
+                     "This is a bug! "                                         \
+                     "Bug is found at:\n\t" __FILE__ ":",                      \
+                     __LINE__,                                                 \
+                     "\nPlease contact"                                        \
+                     " ARTS developers so we can fix "                         \
+                     "our error(s) via:\n\t"                                   \
+                     "github.com/atmtools/arts\n" __VA_OPT__(, __VA_ARGS__))); \
+    }                                                                          \
+  }
 
 #else
 
@@ -131,34 +131,34 @@ std::string var_string(Args&& ... args) {
 #define ARTS_USER_NOEXCEPT noexcept(false)
 
 /*! Condition should be false to pass external check */
-#define ARTS_USER_ERROR_IF(condition, ...) {  \
-  static_assert(std::tuple_size<decltype(     \
-    std::make_tuple(__VA_ARGS__))>::value,    \
-    "Must have an error message in user-"     \
-    "facing code in " __FILE__);              \
-  if (condition) {                            \
-    throw std::runtime_error(                 \
-      var_string("User Error: " #condition    \
-        "\nError is found at:\n\t" __FILE__   \
-        ":", __LINE__, "\nPlease follow "     \
-        "these instructions to correct your " \
-        "error:\n") + var_string(__VA_ARGS__) \
-    );                                        \
-  } }
+#define ARTS_USER_ERROR_IF(condition, ...)                                     \
+  {                                                                            \
+    static_assert(false __VA_OPT__(or true),                                   \
+                  "Must have an error message in user-"                        \
+                  "facing code in " __FILE__);                                 \
+    if (condition) {                                                           \
+      throw std::runtime_error(var_string(                                     \
+          "User Error: " #condition "\nError is found at:\n\t" __FILE__ ":",   \
+          __LINE__,                                                            \
+          "\nPlease follow "                                                   \
+          "these instructions to correct your "                                \
+          "error:\n" __VA_OPT__(, __VA_ARGS__)));                              \
+    }                                                                          \
+  }
 
 /*! An error has occured, will throw the error */
-#define ARTS_USER_ERROR(...) {                \
-  static_assert(std::tuple_size<decltype(     \
-    std::make_tuple(__VA_ARGS__))>::value,    \
-    "Must have an error message in user-"     \
-    "facing code in " __FILE__);              \
-    throw std::runtime_error(                 \
-      var_string("User Error:\n"              \
-        "Error is found at:\n\t" __FILE__     \
-        ":", __LINE__, "\nPlease follow "     \
-        "these instructions to correct your " \
-        "error:\n") + var_string(__VA_ARGS__) \
-    );                                        \
+#define ARTS_USER_ERROR(...)                                                   \
+  {                                                                            \
+    static_assert(false __VA_OPT__(or true),                                   \
+                  "Must have an error message in user-"                        \
+                  "facing code in " __FILE__);                                 \
+    throw std::runtime_error(                                                  \
+        var_string("User Error:\n"                                             \
+                   "Error is found at:\n\t" __FILE__ ":",                      \
+                   __LINE__,                                                   \
+                   "\nPlease follow "                                          \
+                   "these instructions to correct your "                       \
+                   "error:\n" __VA_OPT__(, __VA_ARGS__)));                     \
   }
 
 #endif  // NO_ARTS_USER_ERRORS

--- a/src/depr.h
+++ b/src/depr.h
@@ -6,30 +6,35 @@
 #include "debug.h"
 
 #ifndef NO_DEPR
-#define DEPRECATED_FUNCTION(FUNCTION_NAME, DATE_STRING_OR_SILLY_REASON, ...)                          \
-static_assert(std::tuple_size<decltype(                                                               \
-  std::make_tuple(__VA_ARGS__))>::value,                                                              \
-  "Must give a deprecation reason in user facing code in " __FILE__);                                 \
-{                                                                                                     \
-static bool i_have_not_informed_you=true;                                                             \
-if (i_have_not_informed_you) {                                                                        \
-  std::cerr << "################################################################################\n"   \
-               "#### DEPRECATED FUNCTION WARNING ###############################################\n"   \
-               "################################################################################\n"   \
-            << '\n'                                                                                   \
-            << '\n'                                                                                   \
-            << FUNCTION_NAME << " is deprecated since " << DATE_STRING_OR_SILLY_REASON                \
-            << '\n'                                                                                   \
-            << '\n'                                                                                   \
-            << var_string(__VA_ARGS__)                                                                \
-            << '\n'                                                                                   \
-            << '\n'                                                                                   \
-            << "################################################################################\n"   \
-               "#### DEPRECATED FUNCTION WARNING ###############################################\n"   \
-               "################################################################################\n";  \
-  i_have_not_informed_you = false;                                                                    \
-}                                                                                                     \
-}
+#define DEPRECATED_FUNCTION(FUNCTION_NAME, DATE_STRING_OR_SILLY_REASON, ...)   \
+  static_assert(                                                               \
+      false __VA_OPT__(or true),                                               \
+      "Must give a deprecation reason in user facing code in " __FILE__);      \
+  {                                                                            \
+    static bool i_have_not_informed_you = true;                                \
+    if (i_have_not_informed_you) {                                             \
+      std::cerr << "#########################################################" \
+                   "#######################\n"                                 \
+                   "#### DEPRECATED FUNCTION WARNING "                         \
+                   "###############################################\n"         \
+                   "#########################################################" \
+                   "#######################\n"                                 \
+                << '\n'                                                        \
+                << '\n'                                                        \
+                << FUNCTION_NAME << " is deprecated since "                    \
+                << DATE_STRING_OR_SILLY_REASON << '\n'                         \
+                << '\n'                                                        \
+                << var_string(__VA_ARGS__) << '\n'                             \
+                << '\n'                                                        \
+                << "#########################################################" \
+                   "#######################\n"                                 \
+                   "#### DEPRECATED FUNCTION WARNING "                         \
+                   "###############################################\n"         \
+                   "#########################################################" \
+                   "#######################\n";                                \
+      i_have_not_informed_you = false;                                         \
+    }                                                                          \
+  }
 #endif
 
-#endif  // depr_h
+#endif // depr_h

--- a/src/enums.h
+++ b/src/enums.h
@@ -12,63 +12,68 @@
 #include "nonstd.h"
 
 /** Checks if the enum number is good.
- * 
+ *
  * It is good as long as it is above-equal to 0 and less than FINAL
- * 
+ *
  * @param[in] x An enum class defined by ENUMCLASS or similar
  * @return Whether the enum is good
  */
-template <typename EnumType>
-constexpr bool good_enum(EnumType x) noexcept {
+template <typename EnumType> constexpr bool good_enum(EnumType x) noexcept {
   return std::size_t(x) < std::size_t(EnumType::FINAL);
 }
 
 /** Internal string view array generator.
- * 
+ *
  * Automagically seperates a list by the commas in it,
  * removing spaces before creating the named variable
- * 
+ *
  * @param[in] strchars A list of characters
  * @return An array of views into the original strchars
  */
-template <typename EnumType> constexpr
-std::array<std::string_view, size_t(EnumType::FINAL)> enum_strarray(
-  const std::string_view strchars) noexcept {
+template <typename EnumType>
+constexpr std::array<std::string_view, size_t(EnumType::FINAL)>
+enum_strarray(const std::string_view strchars) noexcept {
   std::array<std::string_view, size_t(EnumType::FINAL)> out;
-  
+
   // Find the start
   std::string_view::size_type N0 = 0;
-  
+
   // Set all the values
-  for (auto& str: out) {
+  for (auto &str : out) {
     // Find a comma but never look beyond the end of the string
     const std::string_view::size_type N1 =
-      std::min(strchars.find(',', N0), strchars.size());
-    
+        std::min(strchars.find(',', N0), strchars.size());
+
     // Set the string between start and the length of the string
     str = strchars.substr(N0, N1 - N0);
-    
+
     // Remove spaces at the beginning and at the end of the string
-    while (nonstd::isspace(str.front())) str.remove_prefix(1);
-    while (nonstd::isspace(str.back())) str.remove_suffix(1);
-    
+    while (nonstd::isspace(str.front()))
+      str.remove_prefix(1);
+    while (nonstd::isspace(str.back()))
+      str.remove_suffix(1);
+
     // Set the new start for the next iteration
     N0 = N1 + 1;
   }
-  
+
   return out;
 }
 
-constexpr std::array<std::string_view, 0> enum_strarray() noexcept { return {}; }
+template <typename EnumType>
+constexpr std::array<std::string_view, 0> enum_strarray() noexcept {
+  return {};
+}
 
 /** A list of all enum types by index-conversion
- * 
+ *
  * Note that this assumes the enums are sorted from 0-FINAL
- * 
+ *
  * @return A list of all enum types
  */
-template <typename EnumType> constexpr
-std::array<EnumType, size_t(EnumType::FINAL)> enum_typarray() noexcept {
+template <typename EnumType>
+constexpr std::array<EnumType, size_t(EnumType::FINAL)>
+enum_typarray() noexcept {
   std::array<EnumType, size_t(EnumType::FINAL)> out{};
   for (size_t i = 0; i < size_t(EnumType::FINAL); i++)
     out[i] = EnumType(i);
@@ -77,13 +82,13 @@ std::array<EnumType, size_t(EnumType::FINAL)> enum_typarray() noexcept {
 
 /** Checks if the enum class type is good and otherwise throws
  * an error message composed by variadic input
- * 
+ *
  * @param[in] type The enum class type variable
  * @param[in] ...args A list of errors to print if type is bad
  */
-template <typename EnumType, typename ... Messages> constexpr
-void check_enum_error(EnumType type, Messages ... args) {
-  ARTS_USER_ERROR_IF (not good_enum(type), args...)
+template <typename EnumType, typename... Messages>
+constexpr void check_enum_error(EnumType type, Messages... args) {
+  ARTS_USER_ERROR_IF(not good_enum(type), args...)
 }
 
 /*! Enum style
@@ -106,20 +111,20 @@ void check_enum_error(EnumType type, Messages ... args) {
  * Additionally, will generate a constexpr "toENUMTYPE" function
  * that takes a std::string_view and returns a corresponding ENUMTYPE
  * object or ENUMTYPE::FINAL if the object is bad
- * 
+ *
  * Additionally, will generate intuitive std::istream& and
  * std::ostream& operators
  *
  * Use the "good_enum(ENUMTYPE)" template function to check
  * if the enum class object is any good
- * 
+ *
  * Use check_enum_error(ENUMTYPE, message...) to throw an error
  * composed by the variadic message if the enum value is bad
  *
  * \verbatim
  // Example:
  ENUMCLASS(Test, char, Value)
- 
+
  // Generates (effectively):
  enum class Test : char {Value, FINAL};
  namespace enumstrs {
@@ -131,57 +136,15 @@ void check_enum_error(EnumType type, Messages ... args) {
  constexpr std::string_view toString(Test x) noexcept;
  constexpr Test toTest(const std::string_view& x) noexcept;
  inline std::ostream &operator<<(std::ostream &os, const Test x);
- inline std::istream &operator>>(std::istream &is, Test &x);  // throws if not good_enum(x) at end
- \endverbatim
+ inline std::istream &operator>>(std::istream &is, Test &x);  // throws if not
+ good_enum(x) at end \endverbatim
  */
-#define ENUMCLASS(ENUMTYPE, TYPE, ...)                                    \
-  enum class ENUMTYPE : TYPE { __VA_ARGS__, FINAL };                      \
-                                                                          \
-  namespace enumstrs {                                                    \
-  constexpr auto ENUMTYPE##Names = enum_strarray<ENUMTYPE>(#__VA_ARGS__); \
-  }                                                                       \
-                                                                          \
-  namespace enumtyps {                                                    \
-  [[maybe_unused]]                                                        \
-  constexpr auto ENUMTYPE##Types = enum_typarray<ENUMTYPE>();             \
-  }                                                                       \
-                                                                          \
-  constexpr std::string_view toString(ENUMTYPE x) noexcept {              \
-    if (good_enum(x))                                                     \
-      return enumstrs::ENUMTYPE##Names[(TYPE)x];                          \
-    return "BAD " #ENUMTYPE;                                              \
-  }                                                                       \
-                                                                          \
-  constexpr ENUMTYPE to##ENUMTYPE(const std::string_view x) noexcept {    \
-    for (TYPE i = 0; i < (TYPE)ENUMTYPE::FINAL; i++)                      \
-      if (enumstrs::ENUMTYPE##Names[i] == x) return ENUMTYPE(i);          \
-    return ENUMTYPE::FINAL;                                               \
-  }                                                                       \
-                                                                          \
-  constexpr ENUMTYPE to##ENUMTYPE##OrThrow(const std::string_view x) {    \
-    const ENUMTYPE out = to##ENUMTYPE(x);                                 \
-    check_enum_error(out, "Cannot understand argument: \"", x, "\"\n"     \
-                     "Valid " #ENUMTYPE " options are: ["                 \
-                     #__VA_ARGS__ "]");                                   \
-    return out;                                                           \
-  }                                                                       \
-                                                                          \
-  inline std::ostream &operator<<(std::ostream &os, const ENUMTYPE x) {   \
-    return os << toString(x);                                             \
-  }                                                                       \
-                                                                          \
-  inline std::istream &operator>>(std::istream &is, ENUMTYPE &x) {        \
-    std::string val;                                                      \
-    is >> val;                                                            \
-    x = to##ENUMTYPE##OrThrow(val);                                       \
-    return is;                                                            \
-  }
-
-#define ENUMCLASS_EMPTY(ENUMTYPE, TYPE)                                        \
-  enum class ENUMTYPE : TYPE { FINAL };                                        \
+#define ENUMCLASS(ENUMTYPE, TYPE, ...)                                         \
+  enum class ENUMTYPE : TYPE { __VA_OPT__(__VA_ARGS__, ) FINAL };              \
                                                                                \
   namespace enumstrs {                                                         \
-  constexpr auto ENUMTYPE##Names = enum_strarray();                            \
+  constexpr auto ENUMTYPE##Names =                                             \
+      enum_strarray<ENUMTYPE>(__VA_OPT__(#__VA_ARGS__));                       \
   }                                                                            \
                                                                                \
   namespace enumtyps {                                                         \
@@ -189,23 +152,24 @@ void check_enum_error(EnumType type, Messages ... args) {
   }                                                                            \
                                                                                \
   constexpr std::string_view toString(ENUMTYPE x) noexcept {                   \
-    if (good_enum(x)) return enumstrs::ENUMTYPE##Names[(TYPE)x];               \
+    if (good_enum(x))                                                          \
+      return enumstrs::ENUMTYPE##Names[(TYPE)x];                               \
     return "BAD " #ENUMTYPE;                                                   \
   }                                                                            \
                                                                                \
   constexpr ENUMTYPE to##ENUMTYPE(const std::string_view x) noexcept {         \
     for (TYPE i = 0; i < (TYPE)ENUMTYPE::FINAL; i++)                           \
-      if (enumstrs::ENUMTYPE##Names[i] == x) return ENUMTYPE(i);               \
+      if (enumstrs::ENUMTYPE##Names[i] == x)                                   \
+        return ENUMTYPE(i);                                                    \
     return ENUMTYPE::FINAL;                                                    \
   }                                                                            \
                                                                                \
   constexpr ENUMTYPE to##ENUMTYPE##OrThrow(const std::string_view x) {         \
-    ENUMTYPE out = to##ENUMTYPE(x);                                            \
-    check_enum_error(out,                                                      \
-                     "Cannot understand argument: \"",                         \
-                     x,                                                        \
+    const ENUMTYPE out = to##ENUMTYPE(x);                                      \
+    check_enum_error(out, "Cannot understand argument: \"", x,                 \
                      "\"\n"                                                    \
-                     "Valid " #ENUMTYPE " options are: []");                   \
+                     "Valid " #ENUMTYPE                                        \
+                     " options are: [" __VA_OPT__(#__VA_ARGS__) "]");          \
     return out;                                                                \
   }                                                                            \
                                                                                \
@@ -220,5 +184,4 @@ void check_enum_error(EnumType type, Messages ... args) {
     return is;                                                                 \
   }
 
-#endif  // enums_h
-
+#endif // enums_h


### PR DESCRIPTION
This uses the C++20 `__VA_OPT__` command to get rid of `ENUMCLASS_EMPTY`, and also to clean up some of the internal error code