### PR TITLE
Better development error messages

### DIFF
--- a/src/agenda_record.cc
+++ b/src/agenda_record.cc
@@ -75,7 +75,11 @@ AgRecord::AgRecord(const char* name,
 
   moutput.resize(output.nelem());
   for (Index j = 0; j < output.nelem(); ++j) {
-    moutput[j] = global_data::WsvMap.at(output[j]);
+    auto wsv_ptr = global_data::WsvMap.find(output[j]);
+    ARTS_USER_ERROR_IF(wsv_ptr == global_data::WsvMap.end(), "The ", mname,
+                       " agenda fails.\nOutput #", j + 1, " named ", output[j],
+                       " is not a WSV")
+    moutput[j] = wsv_ptr->second;
     if (moutput[j] == -1) {
       ostringstream os;
 
@@ -86,7 +90,11 @@ AgRecord::AgRecord(const char* name,
 
   minput.resize(input.nelem());
   for (Index j = 0; j < input.nelem(); ++j) {
-    minput[j] = global_data::WsvMap.at(input[j]);
+    auto wsv_ptr = global_data::WsvMap.find(input[j]);
+    ARTS_USER_ERROR_IF(wsv_ptr == global_data::WsvMap.end(), "The ", mname,
+                       " agenda fails.\nInput #", j + 1, " named ", input[j],
+                       " is not a WSV")
+    minput[j] = wsv_ptr->second;
     if (minput[j] == -1) {
       ostringstream os;
 

--- a/src/agenda_record.cc
+++ b/src/agenda_record.cc
@@ -246,7 +246,7 @@ void write_agenda_wrapper_header(ofstream& ofs,
   // Wrapper function output parameters
   const ArrayOfIndex& ago = agr.Out();
   ofs << "        // Output\n";
-  for (long long j : ago) {
+  for (auto j : ago) {
     ofs << "        ";
     ofs << wsv_groups[global_data::wsv_data[j].Group()] << "& ";
     ofs << global_data::wsv_data[j].Name() << ",\n";
@@ -255,7 +255,7 @@ void write_agenda_wrapper_header(ofstream& ofs,
   // Wrapper function input parameters
   const ArrayOfIndex& agi = agr.In();
   ofs << "        // Input\n";
-  for (long long j : agi) {
+  for (auto j : agi) {
     // Ignore Input parameters that are also output
     auto it = ago.begin();
     while (it != ago.end() && *it != j) it++;

--- a/src/agenda_record.cc
+++ b/src/agenda_record.cc
@@ -30,8 +30,8 @@
 #include "debug.h"
 #include "groups.h"
 #include "messages.h"
-#include "workspace_ng.h"
 #include "workspace_global_data.h"
+#include "workspace_ng.h"
 #include "wsv_aux.h"
 
 namespace global_data {
@@ -246,22 +246,22 @@ void write_agenda_wrapper_header(ofstream& ofs,
   // Wrapper function output parameters
   const ArrayOfIndex& ago = agr.Out();
   ofs << "        // Output\n";
-  for (ArrayOfIndex::const_iterator j = ago.begin(); j != ago.end(); j++) {
+  for (long long j : ago) {
     ofs << "        ";
-    ofs << wsv_groups[global_data::wsv_data[*j].Group()] << "& ";
-    ofs << global_data::wsv_data[*j].Name() << ",\n";
+    ofs << wsv_groups[global_data::wsv_data[j].Group()] << "& ";
+    ofs << global_data::wsv_data[j].Name() << ",\n";
   }
 
   // Wrapper function input parameters
   const ArrayOfIndex& agi = agr.In();
   ofs << "        // Input\n";
-  for (ArrayOfIndex::const_iterator j = agi.begin(); j != agi.end(); j++) {
+  for (long long j : agi) {
     // Ignore Input parameters that are also output
-    ArrayOfIndex::const_iterator it = ago.begin();
-    while (it != ago.end() && *it != *j) it++;
+    auto it = ago.begin();
+    while (it != ago.end() && *it != j) it++;
 
     if (it == ago.end()) {
-      String group_name = wsv_groups[global_data::wsv_data[*j].Group()].name;
+      String group_name = wsv_groups[global_data::wsv_data[j].Group()].name;
 
       ofs << "        const ";
       ofs << group_name;
@@ -270,7 +270,7 @@ void write_agenda_wrapper_header(ofstream& ofs,
       if (group_name != "Index" && group_name != "Numeric") {
         ofs << "&";
       }
-      ofs << " " << global_data::wsv_data[*j].Name() << ",\n";
+      ofs << " " << global_data::wsv_data[j].Name() << ",\n";
     }
   }
 

--- a/src/make_auto_md_cc.cc
+++ b/src/make_auto_md_cc.cc
@@ -18,6 +18,7 @@
 #include "agenda_record.h"
 #include "array.h"
 #include "arts.h"
+#include "debug.h"
 #include "file.h"
 #include "global_data.h"
 #include "methods.h"
@@ -432,8 +433,9 @@ int main() {
       ostringstream ain_push_os, ain_pop_os;
       ostringstream aout_push_os, aout_pop_os;
 
-      bool is_agenda_array = wsv_data[global_data::WsvMap.at(agr.Name())].Group() ==
-                             get_wsv_group_id("ArrayOfAgenda");
+      auto wsv_ptr = global_data::WsvMap.find(agr.Name());
+      ARTS_USER_ERROR_IF(wsv_ptr == global_data::WsvMap.end(), "The agenda ", agr.Name(), " fails")
+      bool is_agenda_array = wsv_data[wsv_ptr->second].Group() == get_wsv_group_id("ArrayOfAgenda");
       write_agenda_wrapper_header(ofs, agr, is_agenda_array);
 
       ofs << "\n";

--- a/src/make_auto_md_cc.cc
+++ b/src/make_auto_md_cc.cc
@@ -23,8 +23,8 @@
 #include "global_data.h"
 #include "methods.h"
 #include "workspace.h"
-#include "workspace_ng.h"
 #include "workspace_global_data.h"
+#include "workspace_ng.h"
 
 /* Adds commas and indentation to parameter lists. */
 void align(ofstream& ofs, bool& is_first_parameter, const String& indent) {

--- a/src/make_auto_md_h.cc
+++ b/src/make_auto_md_h.cc
@@ -68,12 +68,14 @@
 #include "agenda_record.h"
 #include "array.h"
 #include "arts.h"
+#include "debug.h"
 #include "file.h"
 #include "global_data.h"
 #include "methods.h"
 #include "workspace.h"
 #include "workspace_ng.h"
 #include "workspace_global_data.h"
+#include <stdexcept>
 
 /* Adds commas and indentation to parameter lists. */
 void align(ofstream& ofs, bool& is_first_parameter, const String& indent) {
@@ -673,9 +675,11 @@ int main() {
     using global_data::agenda_data;
     const Array<WsvRecord>& wsv_data = global_data::wsv_data;
     for (Index i = 0; i < agenda_data.nelem(); i++) {
-      bool is_agenda_array =
-          wsv_data[global_data::WsvMap.at(agenda_data[i].Name())].Group() ==
-          get_wsv_group_id("ArrayOfAgenda");
+      auto wsv_ptr = global_data::WsvMap.find(agenda_data[i].Name());
+      ARTS_USER_ERROR_IF(wsv_ptr == global_data::WsvMap.end(), "The ",
+                         agenda_data[i].Name(), " agenda fails");
+      bool is_agenda_array = wsv_data[wsv_ptr->second].Group() ==
+                             get_wsv_group_id("ArrayOfAgenda");
       write_agenda_wrapper_header(ofs, agenda_data[i], is_agenda_array);
 
       ofs << ";\n\n";

--- a/src/make_auto_md_h.cc
+++ b/src/make_auto_md_h.cc
@@ -73,8 +73,8 @@
 #include "global_data.h"
 #include "methods.h"
 #include "workspace.h"
-#include "workspace_ng.h"
 #include "workspace_global_data.h"
+#include "workspace_ng.h"
 #include <stdexcept>
 
 /* Adds commas and indentation to parameter lists. */
@@ -97,7 +97,7 @@ void align(ofstream& ofs, bool& is_first_parameter, const String& indent) {
 void write_method_header_documentation(ofstream& ofs, const MdRecord& mdd) {
   const Array<WsvRecord>& wsv_data = global_data::wsv_data;
 
-  String fullname = mdd.Name();
+  const String& fullname = mdd.Name();
 
   // This is needed to flag the first function parameter, which
   // needs no line break before being written:
@@ -115,8 +115,8 @@ void write_method_header_documentation(ofstream& ofs, const MdRecord& mdd) {
   // write.
   ArrayOfIndex vo = mdd.Out();            // Output
   const ArrayOfIndex& vi = mdd.InOnly();  // Input
-  ArrayOfIndex vgo = mdd.GOutType();      // Generic Output
-  ArrayOfIndex vgi = mdd.GInType();       // Generic Input
+  const ArrayOfIndex& vgo = mdd.GOutType();      // Generic Output
+  const ArrayOfIndex& vgi = mdd.GInType();       // Generic Input
   // vo and vi contain handles of workspace variables,
   // vgo and vgi handles of workspace variable groups.
 
@@ -276,7 +276,7 @@ void write_method_header(ofstream& ofs, const MdRecord& mdd) {
   //     fullname = os.str();
   //   }
 
-  String fullname = mdd.Name();
+  const String& fullname = mdd.Name();
 
   // This is needed to flag the first function parameter, which
   // needs no line break before being written:
@@ -294,8 +294,8 @@ void write_method_header(ofstream& ofs, const MdRecord& mdd) {
   // write.
   ArrayOfIndex vo = mdd.Out();            // Output
   const ArrayOfIndex& vi = mdd.InOnly();  // Input
-  ArrayOfIndex vgo = mdd.GOutType();      // Generic Output
-  ArrayOfIndex vgi = mdd.GInType();       // Generic Input
+  const ArrayOfIndex& vgo = mdd.GOutType();      // Generic Output
+  const ArrayOfIndex& vgi = mdd.GInType();       // Generic Input
   // vo and vi contain handles of workspace variables,
   // vgo and vgi handles of workspace variable groups.
 
@@ -524,10 +524,10 @@ bool md_sanity_checks(const Array<MdRecord>& md_data) {
   ostringstream os;
 
   bool is_sane = true;
-  for (Array<MdRecord>::const_iterator i = md_data.begin(); i < md_data.end();
+  for (auto i = md_data.begin(); i < md_data.end();
        ++i) {
     bool invalid_author = false;
-    for (ArrayOfString::const_iterator j = i->Authors().begin();
+    for (auto j = i->Authors().begin();
          !invalid_author && j < i->Authors().end();
          ++j) {
       if (*j == "" || *j == "unknown") invalid_author = true;


### PR DESCRIPTION
The error messages of map::at are not very good.  This works around that by composing and checking the developer errors manually.

When merged, this closes #571 