### PR TITLE
Fix memory leak caused by cyclic reference

### DIFF
--- a/python/pyarts/workspace/workspace.py
+++ b/python/pyarts/workspace/workspace.py
@@ -377,16 +377,21 @@ class Workspace(InternalWorkspace):
             raise AttributeError("You cannot delete __class__")
 
         getattr(self, attr).delete_level()
-    
+
     def __copy__(self):
-        return Workspace(super().__copy__())
-    
+        x = super().__copy__()
+        out = Workspace()
+        out.swap(x)
+        return out
+
     def __deepcopy__(self, *args):
-        return Workspace(super().__deepcopy__(*args))
-    
+        x = super().__deepcopy__(*args)
+        out = Workspace()
+        out.swap(x)
+        return out
+
     def __getstate__(self):
         return {"Workspace": super().__getstate__()}
-    
+
     def __setstate__(self, d):
         super().__setstate__(d["Workspace"])
-        

--- a/python/test/workspace/test_groups.py
+++ b/python/test/workspace/test_groups.py
@@ -1002,8 +1002,10 @@ class TestGroups:
         for i in range(len(x)):
             if x[i] == "CallbackFunction":
                 continue
-            if x[i] == "Agenda":
-                exec(f"ws.v{i} = cxx.{x[i]}(ws)")
+            elif x[i] == "Agenda":
+                continue  # Cannot unpickle a standalone Agenda
+            elif x[i] == "ArrayOfAgenda":
+                continue  # Cannot unpickle a standalone ArrayOfAgenda
             else:
                 exec(f"ws.v{i} = cxx.{x[i]}()")
 

--- a/src/agenda_class.cc
+++ b/src/agenda_class.cc
@@ -781,13 +781,13 @@ Agenda& Agenda::operator=(const Agenda& x) {
 bool Agenda::has_same_origin(const Workspace& ws2) const {return workspace()->original_workspace == ws2.original_workspace;}
 
 std::shared_ptr<Workspace> Agenda::workspace() const {
-    auto workspace = ws.lock();
-    ARTS_USER_ERROR_IF(workspace == nullptr,
-                       "This agenda does not contain a valid Workspace.\n"
-                       "The workspace might have gotten deleted, or\n"
-                       "you're accessing a default-constructed agenda.");
-    return workspace;
-  }
+  auto workspace = ws.lock();
+  ARTS_USER_ERROR_IF(workspace == nullptr,
+                     "This agenda does not contain a valid Workspace.\n"
+                     "The workspace might have gotten deleted, or\n"
+                     "you're accessing a default-constructed agenda.");
+  return workspace;
+}
 
 //! Output operator for Agenda.
 /*! 
@@ -975,4 +975,24 @@ std::pair<ArrayOfIndex, ArrayOfIndex> Agenda::get_global_inout() const {
     ain = agr.In();
   }
   return {ain, aout};
+}
+
+void Agenda::set_workspace(Workspace& x) {
+  ws = x.shared_from_this();
+  for (auto& mr: mml) {
+    mr.set_workspace(x);
+  }
+}
+
+void MRecord::set_workspace(Workspace& x) {
+  mtasks.set_workspace(x);
+  if (msetvalue.holdsAgenda()) {
+    Agenda a = msetvalue;
+    a.set_workspace(x);
+    msetvalue = a;
+  } else if (msetvalue.holdsArrayOfAgenda()) {
+    ArrayOfAgenda a = msetvalue;
+    for (auto& b: a) b.set_workspace(x);
+    msetvalue = a;
+  }
 }

--- a/src/agenda_class.cc
+++ b/src/agenda_class.cc
@@ -61,10 +61,9 @@ MRecord::MRecord(const Index id,
       minternal(internal) {
 }
 
-Agenda::Agenda() : ws(nullptr), mname(), mml(), moutput_push(), moutput_dup() {}
 
 Agenda::Agenda(Workspace& workspace)
-    : ws(workspace.shared_ptr()),
+    : ws(workspace.weak_from_this()),
       mname(),
       mml(),
       moutput_push(),
@@ -98,7 +97,7 @@ void Agenda::append(const String& methodname, const TokVal& keywordvalue) {
   // Find explicit method id in MdMap.
   ArrayOfIndex input = md_data[id].InOnly();
 
-  mml.push_back(MRecord(id, output, input, keywordvalue, Agenda(*ws)));
+  mml.push_back(MRecord(id, output, input, keywordvalue, Agenda(*workspace())));
   mchecked = false;
 }
 
@@ -109,7 +108,7 @@ void Agenda::append(const String& methodname, const TokVal& keywordvalue) {
 */
 void Agenda::check(Workspace& ws_in, const Verbosity& verbosity) {
   // Check that this agenda has a default workspace
-  if (not ws.get()) {
+  if (not workspace().get()) {
     mchecked = false;
     return;
   }
@@ -355,7 +354,7 @@ void Agenda::set_outputs_to_push_and_dup(const Verbosity& verbosity) {
         method.Id() == WsmAgendaExecuteExclIndex) {
       for (Index j = 0; j < md_data[method.Id()].GInType().nelem(); j++) {
         if (md_data[method.Id()].GInType()[j] == WsvAgendaGroupIndex) {
-          const String& agenda_name = (*ws->wsv_data_ptr)[gins[j]].Name();
+          const String& agenda_name = (*workspace()->wsv_data_ptr)[gins[j]].Name();
           const auto agenda_it =
               AgendaMap.find(agenda_name);
           // The executed agenda must not be a user created agenda
@@ -499,28 +498,28 @@ void Agenda::set_outputs_to_push_and_dup(const Verbosity& verbosity) {
   out3 << "  [Agenda::pushpop]                 : " << name() << "\n";
   out3 << "  [Agenda::pushpop] - # Funcs in Ag : " << mml.nelem() << "\n";
   out3 << "  [Agenda::pushpop] - AgOut         : ";
-  PrintWsvNames(out3, *ws, aout);
+  PrintWsvNames(out3, *workspace(), aout);
   out3 << "\n";
   out3 << "  [Agenda::pushpop] - AgIn          : ";
-  PrintWsvNames(out3, *ws, ain);
+  PrintWsvNames(out3, *workspace(), ain);
   out3 << "\n";
   out3 << "  [Agenda::pushpop] - All WSM output: ";
-  PrintWsvNames(out3, *ws, outputs);
+  PrintWsvNames(out3, *workspace(), outputs);
   out3 << "\n";
   out3 << "  [Agenda::pushpop] - All WSM input : ";
-  PrintWsvNames(out3, *ws, inputs);
+  PrintWsvNames(out3, *workspace(), inputs);
   out3 << "\n";
   out3 << "  [Agenda::pushpop] - Output WSVs push     : ";
-  PrintWsvNames(out3, *ws, moutput_push);
+  PrintWsvNames(out3, *workspace(), moutput_push);
   out3 << "\n";
   out3 << "  [Agenda::pushpop] - Output WSVs dup      : ";
-  PrintWsvNames(out3, *ws, moutput_dup);
+  PrintWsvNames(out3, *workspace(), moutput_dup);
   out3 << "\n";
   out3 << "  [Agenda::pushpop] - Ag inp dup    : ";
-  PrintWsvNames(out3, *ws, agenda_only_in_wsm_out);
+  PrintWsvNames(out3, *workspace(), agenda_only_in_wsm_out);
   out3 << "\n";
   out3 << "  [Agenda::pushpop] - Ag out dup    : ";
-  PrintWsvNames(out3, *ws, agenda_only_out_wsm_in);
+  PrintWsvNames(out3, *workspace(), agenda_only_out_wsm_in);
   out3 << "\n";
 }
 
@@ -653,7 +652,7 @@ bool Agenda::is_output(Index var) const {
              j++) {
           if (md_data[this_method.Id()].GInType()[j] == WsvAgendaGroupIndex) {
             const String& agenda_name =
-                (*ws->wsv_data_ptr)[this_method.In()[j]].Name();
+                (*workspace()->wsv_data_ptr)[this_method.In()[j]].Name();
             const auto agenda_it =
                 AgendaMap.find(agenda_name);
             // The executed agenda must not be a user created agenda
@@ -779,6 +778,17 @@ Agenda& Agenda::operator=(const Agenda& x) {
   return *this;
 }
 
+bool Agenda::has_same_origin(const Workspace& ws2) const {return workspace()->original_workspace == ws2.original_workspace;}
+
+std::shared_ptr<Workspace> Agenda::workspace() const {
+    auto workspace = ws.lock();
+    ARTS_USER_ERROR_IF(workspace == nullptr,
+                       "This agenda does not contain a valid Workspace.\n"
+                       "The workspace might have gotten deleted, or\n"
+                       "you're accessing a default-constructed agenda.");
+    return workspace;
+  }
+
 //! Output operator for Agenda.
 /*! 
   This is useful for debugging.
@@ -843,7 +853,7 @@ void MRecord::print(ostream& os, const String& indent) const {
       else
         os << ",";
 
-      os << mtasks.workspace().wsv_data_ptr -> operator[](Out()[i]).Name();
+      os << mtasks.workspace()->wsv_data_ptr->operator[](Out()[i]).Name();
     }
 
     for (Index i = 0; i < In().nelem(); ++i) {
@@ -852,7 +862,7 @@ void MRecord::print(ostream& os, const String& indent) const {
       else
         os << ",";
 
-      os << mtasks.workspace().wsv_data_ptr -> operator[](In()[i]).Name();
+      os << mtasks.workspace()->wsv_data_ptr->operator[](In()[i]).Name();
     }
 
     os << ")";
@@ -930,8 +940,8 @@ MRecord MRecord::deepcopy_if(Workspace& workspace) const {
   MRecord out(workspace);
   
   out.mid = mid;
-  out.moutput = make_same_wsvs(workspace, mtasks.workspace(), moutput);
-  out.minput = make_same_wsvs(workspace, mtasks.workspace(), minput);
+  out.moutput = make_same_wsvs(workspace, *mtasks.workspace(), moutput);
+  out.minput = make_same_wsvs(workspace, *mtasks.workspace(), minput);
   out.msetvalue = msetvalue;
   out.mtasks = mtasks.deepcopy_if(workspace);
   out.minternal = minternal;
@@ -945,8 +955,8 @@ Agenda Agenda::deepcopy_if(Workspace& workspace) const {
   Agenda out(workspace);
   out.mname = mname;
   for (auto& method : mml) out.mml.push_back(method.deepcopy_if(workspace));
-  out.moutput_push = make_same_wsvs(workspace, *ws, moutput_push);
-  out.moutput_dup = make_same_wsvs(workspace, *ws, moutput_dup);
+  out.moutput_push = make_same_wsvs(workspace, *this->workspace(), moutput_push);
+  out.moutput_dup = make_same_wsvs(workspace, *this->workspace(), moutput_dup);
   out.main_agenda = main_agenda;
   out.mchecked = mchecked;
 

--- a/src/agenda_class.h
+++ b/src/agenda_class.h
@@ -107,6 +107,8 @@ class Agenda final {
 
   [[nodiscard]] std::shared_ptr<Workspace> workspace() const;
 
+  void set_workspace(Workspace& x);
+
   //! Creates a deep copy of the agenda if necessary (i.e., different workspace)!
   Agenda deepcopy_if(Workspace&) const;
 
@@ -209,6 +211,8 @@ class MRecord {
   void print(ostream& os, const String& indent) const;
 
   friend ostream& operator<<(ostream& os, const MRecord& a);
+
+  void set_workspace(Workspace& x);
 
  private:
   /** Method id. */

--- a/src/agenda_class.h
+++ b/src/agenda_class.h
@@ -68,7 +68,7 @@ class MRecord;
 */
 class Agenda final {
  public:
-  Agenda();
+  Agenda() = default;
   explicit Agenda(Workspace& workspace);
 
   /*! 
@@ -103,10 +103,9 @@ class Agenda final {
 
   friend ostream& operator<<(ostream& os, const Agenda& a);
 
-  [[nodiscard]] bool has_same_origin(const Workspace& ws2) const {return ws->original_workspace == ws2.original_workspace;}
-  
-  [[nodiscard]] Workspace& workspace() {return *ws;}
-  [[nodiscard]] const Workspace& workspace() const {return *ws;}
+  [[nodiscard]] bool has_same_origin(const Workspace& ws2) const;
+
+  [[nodiscard]] std::shared_ptr<Workspace> workspace() const;
 
   //! Creates a deep copy of the agenda if necessary (i.e., different workspace)!
   Agenda deepcopy_if(Workspace&) const;
@@ -115,7 +114,7 @@ class Agenda final {
   [[nodiscard]] std::pair<ArrayOfIndex, ArrayOfIndex> get_global_inout() const;
 
  private:
-  std::shared_ptr<Workspace> ws;      /*!< The workspace upon which this Agenda lives. */
+  std::weak_ptr<Workspace> ws;      /*!< The workspace upon which this Agenda lives. */
   String mname;       /*!< Agenda name. */
   Array<MRecord> mml; /*!< The actual list of methods to execute. */
 

--- a/src/m_rte.cc
+++ b/src/m_rte.cc
@@ -2439,7 +2439,7 @@ void iyMC(Workspace& ws,
   if (nf) {
     WorkspaceOmpParallelCopyGuard wss{ws};
 
-#pragma omp parallel for if (!arts_omp_in_parallel() && nf > 1) firstprivate(ws)
+#pragma omp parallel for if (!arts_omp_in_parallel() && nf > 1) firstprivate(wss)
     for (Index f_index = 0; f_index < nf; f_index++) {
       if (failed) continue;
 

--- a/src/parser.cc
+++ b/src/parser.cc
@@ -40,7 +40,7 @@ ArtsParser::ArtsParser(Agenda& tasklist,
                        String controlfile,
                        const Verbosity& rverbosity)
     : mtasklist(tasklist),
-      ws(tasklist.workspace().shared_ptr()),
+      ws(tasklist.workspace()),
       mcfile(std::move(controlfile)),
       mcfile_version(1),
       verbosity(rverbosity) {

--- a/src/propmat_field.cc
+++ b/src/propmat_field.cc
@@ -71,14 +71,16 @@ void field_of_propagation(Workspace& ws,
   additional_source_field =
       FieldOfStokesVector(nalt, nlat, nlon, StokesVector(nf, stokes_dim));
 
-#pragma omp parallel for if (not arts_omp_in_parallel()) schedule(guided) \
-    firstprivate(ws)
+  WorkspaceOmpParallelCopyGuard wss{ws};
+
+#pragma omp parallel for if (not arts_omp_in_parallel()) collapse(3) \
+    firstprivate(wss)
   for (Index i = 0; i < nalt; i++) {
     for (Index j = 0; j < nlat; j++) {
       for (Index k = 0; k < nlon; k++) {
         thread_local Index itmp;
         get_stepwise_clearsky_propmat(
-            ws,
+            wss,
             propmat_field(i, j, k),
             additional_source_field(i, j, k),
             itmp,

--- a/src/python_interface/py_agenda.cpp
+++ b/src/python_interface/py_agenda.cpp
@@ -1,9 +1,11 @@
+#include <algorithm>
 #include <global_data.h>
 #include <parameters.h>
 #include <parser.h>
 #include <pybind11/attr.h>
 #include <pybind11/detail/common.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
 #include <pybind11/stl/filesystem.h>
 #include <memory>
 #include <type_traits>
@@ -272,147 +274,7 @@ void py_agenda(py::module_& m) {
       .def_property_readonly("input", &MRecord::In)
       .def_property_readonly("value", &MRecord::SetValue)
       .def_property_readonly("tasks", &MRecord::Tasks)
-      .PythonInterfaceBasicRepresentation(MRecord)
-      .def(py::pickle(
-          [](const MRecord& self) {
-            return py::make_tuple(
-                self.Id(),
-                self.Tasks(),
-                self.SetValue(),
-                self.Tasks().workspace()->wsvs(self.Out()),
-                self.Tasks().workspace()->wsvs(self.In()),
-                global_data::md_data[self.Id()].Name(),
-                global_data::md_data[self.Id()].Description(),
-                global_data::md_data[self.Id()].Authors(),
-                global_data::md_data[self.Id()].Out(),
-                global_data::md_data[self.Id()].GOut(),
-                global_data::md_data[self.Id()].GOutType(),
-                global_data::md_data[self.Id()].GOutSpecType(),
-                global_data::md_data[self.Id()].GOutDescription(),
-                global_data::md_data[self.Id()].In(),
-                global_data::md_data[self.Id()].GIn(),
-                global_data::md_data[self.Id()].GInType(),
-                global_data::md_data[self.Id()].GInSpecType(),
-                global_data::md_data[self.Id()].GInDefault(),
-                global_data::md_data[self.Id()].GInDescription(),
-                global_data::md_data[self.Id()].InOnly(),
-                global_data::md_data[self.Id()].InOut(),
-                global_data::md_data[self.Id()].OutOnly(),
-                global_data::md_data[self.Id()].SetMethod(),
-                global_data::md_data[self.Id()].AgendaMethod(),
-                global_data::md_data[self.Id()].Supergeneric(),
-                global_data::md_data[self.Id()].UsesTemplates(),
-                global_data::md_data[self.Id()].PassWorkspace(),
-                global_data::md_data[self.Id()].PassWsvNames(),
-                global_data::md_data[self.Id()].ActualGroups());
-          },
-          [](const py::tuple& t) {
-            ARTS_USER_ERROR_IF(t.size() != 29, "Invalid state!")
-            auto id = t[0].cast<Index>();
-            auto ag = t[1].cast<Agenda>();
-            auto tv = t[2].cast<TokVal>();
-            auto out_wsv = t[3].cast<Workspace::wsv_data_type>();
-            auto in_wsv = t[4].cast<Workspace::wsv_data_type>();
-
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].Name() not_eq t[5].cast<String>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].Description() not_eq
-                    t[6].cast<String>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].Authors() not_eq
-                    t[7].cast<ArrayOfString>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].Out() not_eq t[8].cast<ArrayOfIndex>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].GOut() not_eq
-                    t[9].cast<ArrayOfString>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].GOutType() not_eq
-                    t[10].cast<ArrayOfIndex>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].GOutSpecType() not_eq
-                    t[11].cast<ArrayOfArrayOfIndex>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].GOutDescription() not_eq
-                    t[12].cast<Array<String>>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].In() not_eq t[13].cast<ArrayOfIndex>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].GIn() not_eq
-                    t[14].cast<ArrayOfString>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].GInType() not_eq
-                    t[15].cast<ArrayOfIndex>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].GInSpecType() not_eq
-                    t[16].cast<ArrayOfArrayOfIndex>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].GInDefault() not_eq
-                    t[17].cast<Array<String>>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].GInDescription() not_eq
-                    t[18].cast<Array<String>>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].InOnly() not_eq
-                    t[19].cast<ArrayOfIndex>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].InOut() not_eq
-                    t[20].cast<ArrayOfIndex>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].OutOnly() not_eq
-                    t[21].cast<ArrayOfIndex>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].SetMethod() not_eq t[22].cast<bool>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].AgendaMethod() not_eq
-                    t[23].cast<bool>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].Supergeneric() not_eq
-                    t[24].cast<bool>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].UsesTemplates() not_eq
-                    t[25].cast<bool>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].PassWorkspace() not_eq
-                    t[26].cast<bool>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].PassWsvNames() not_eq
-                    t[27].cast<bool>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-            ARTS_USER_ERROR_IF(
-                global_data::md_data[id].ActualGroups() not_eq
-                    t[28].cast<String>(),
-                "Method state not same as on construction; are you using a different Arts version?")
-
-            return new MRecord{id,
-                               ag.workspace()->wsvs(out_wsv),
-                               ag.workspace()->wsvs(in_wsv),
-                               tv,
-                               ag};
-          }));
+      .PythonInterfaceBasicRepresentation(MRecord);
 
   py::class_<Array<MRecord>>(m, "ArrayOfMRecord")
       .PythonInterfaceArrayDefault(MRecord)
@@ -476,7 +338,6 @@ void py_agenda(py::module_& m) {
                                  *w.get<Verbosity>("verbosity"));
            }),
            py::keep_alive<0, 1>())
-      .PythonInterfaceCopyValue(Agenda)
       .PythonInterfaceFileIO(Agenda)
       .def_property_readonly("main", &Agenda::is_main_agenda)
       .def_property("name", &Agenda::name, &Agenda::set_name)
@@ -777,35 +638,6 @@ Both agendas must be defined on the same workspace)--"),
            })
       .def_property("methods", &Agenda::Methods, &Agenda::set_methods)
       .def("has_same_origin", &Agenda::has_same_origin)
-      .def(py::pickle(
-          [](const Agenda& self) {
-            return py::make_tuple(
-                self.name(), self.Methods(), self.is_main_agenda());
-          },
-          [](const py::tuple& t) {
-            ARTS_USER_ERROR_IF(t.size() != 3, "Invalid state!")
-
-            std::shared_ptr<Workspace> workspace=Workspace::create();
-            auto* val = new Agenda{*workspace};
-
-            val->set_name(t[0].cast<String>());
-            auto methods = t[1].cast<Array<MRecord>>();
-            std::transform(methods.begin(),
-                           methods.end(),
-                           methods.begin(),
-                           [&workspace](auto& met) {
-                             return met.deepcopy_if(*workspace);
-                           });
-            val->set_methods(methods);
-            val->set_outputs_to_push_and_dup(Verbosity{});
-
-            if (t[2].cast<bool>())
-              val->set_main_agenda();
-            else
-              val->check(*workspace, Verbosity{});
-
-            return val;
-          }))
       .PythonInterfaceWorkspaceDocumentation(Agenda);
 
   py::class_<ArrayOfAgenda>(m, "ArrayOfAgenda")

--- a/src/workspace_ng.h
+++ b/src/workspace_ng.h
@@ -203,9 +203,6 @@ class Workspace final : public std::enable_shared_from_this<Workspace> {
     outstream << (*wsv_data_ptr)[i].Name() << "(" << i << ") ";
   }
 
-  //! Get a shared pointer to the object
-  std::shared_ptr<Workspace> shared_ptr() {return shared_from_this();}
-
   //! Gets a full copy that owns all the data (only gets the top of the stack)
   std::shared_ptr<Workspace> deepcopy();
 


### PR DESCRIPTION
Workspace was not deleted if it contained an Agenda variable. Since Agenda had a `shared_ptr` to the Workspace it was living in, it was creating a cyclic reference between the Agenda and the Workspace. Thus, the Workspace destructor was never called.
This affected PyARTS when using multiple Workspaces.

Thanks to Paulina and Robert for reporting this bug.