### PR TITLE
Allow empty parens in WSM calls

### DIFF
--- a/controlfiles/CMakeLists.txt
+++ b/controlfiles/CMakeLists.txt
@@ -216,5 +216,6 @@ if (ARTS_XML_DATA_DIR)
   arts_test_run_ctlfile(fast artscomponents/cia/TestCIADerivs.arts)
 endif (ARTS_XML_DATA_DIR)
 
-
-
+####################
+### Syntax tests ###
+arts_test_run_ctlfile(fast artscomponents/syntax/TestWSMCalls.arts)

--- a/controlfiles/artscomponents/syntax/TestWSMCalls.arts
+++ b/controlfiles/artscomponents/syntax/TestWSMCalls.arts
@@ -1,0 +1,16 @@
+Arts2 {
+  # All these call syntaxes should work
+  water_p_eq_agendaSet
+
+  water_p_eq_agendaSet()
+
+  water_p_eq_agendaSet(   )
+
+  water_p_eq_agendaSet(
+  )
+
+  water_p_eq_agendaSet(
+    # Comment here is allowed
+  )
+}
+

--- a/python/pyarts/parser.py
+++ b/python/pyarts/parser.py
@@ -245,11 +245,13 @@ class WSMCall:
                     a = self.convert_argument(n, a)
                 s += to_python(a, workspace) + ", "
 
-            a = self.args[-1]
-            n = self.arg_names[len(self.args)-1]
-            if not isinstance(a, WSV):
-                a = self.convert_argument(n, a)
-            s += to_python(a, workspace) + ")\n"
+            if len(self.args):
+                a = self.args[-1]
+                n = self.arg_names[len(self.args)-1]
+                if not isinstance(a, WSV):
+                    a = self.convert_argument(n, a)
+                s += to_python(a, workspace)
+            s += ")\n"
 
         if self.args is None:
             keys = list(self.kwargs.keys())
@@ -258,11 +260,13 @@ class WSMCall:
                 if not isinstance(a, WSV):
                     a = self.convert_argument(k, a)
                 s += str(k) + "=" + to_python(a, workspace) + ", "
-            k = keys[-1]
-            a = self.kwargs[keys[-1]]
-            if not isinstance(a, WSV):
-                a = self.convert_argument(k, a)
-            s += str(k) + "=" + to_python(a, workspace) + ")\n"
+            if len(keys):
+                k = keys[-1]
+                a = self.kwargs[keys[-1]]
+                if not isinstance(a, WSV):
+                    a = self.convert_argument(k, a)
+                s += str(k) + "=" + to_python(a, workspace)
+            s += ")\n"
         return s
 
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -107,6 +107,11 @@ class ArtsParser {
                          ArrayOfIndex& auto_vars,
                          Array<TokVal>& auto_vars_values);
 
+  void use_default_method_args(const MdRecord *mdd, String &methodname,
+                               ArrayOfIndex &output, ArrayOfIndex &input,
+                               ArrayOfIndex &auto_vars,
+                               Array<TokVal> &auto_vars_values);
+
   String set_gin_to_default(const MdRecord* mdd,
                             ArrayOfIndex& auto_vars,
                             Array<TokVal>& auto_vars_values,


### PR DESCRIPTION
This PR extends the syntax in controlfiles to allow to specify empty parens for WSM calls without arguments.

Before only this syntax was allowed:

```
water_p_eq_agendaSet
```

Now this is allowed as well:

```
water_p_eq_agendaSet()

water_p_eq_agendaSet(   )

water_p_eq_agendaSet(
)

water_p_eq_agendaSet(
  # Comment here is allowed
)
```