### PR TITLE
Make use of unordered map in workspace ang python gin

### DIFF
--- a/src/mystring.h
+++ b/src/mystring.h
@@ -259,4 +259,15 @@ void extract(T& x, String& line, std::size_t n) {
   line.erase(0, N);
 }
 
+//Specialize std::hash for String (this is allowed by the standard)
+namespace std {
+  template <> struct hash<String>
+  {
+    size_t operator()(const String & x) const
+    {
+      return hash<string>{}(x);
+    }
+  };
+}
+
 #endif  // mystring_h

--- a/src/python_interface/gen_auto_py.cpp
+++ b/src/python_interface/gen_auto_py.cpp
@@ -1665,7 +1665,7 @@ Index get_and_set_wsv_gin_pos(Workspace& ws, Index pos, const char* const name, 
 }
 
 Index create_workspace_gin_default_internal(Workspace& ws, const String& key) {
-  const static std::map<String, Index> gins {
+  const static std::unordered_map<String, Index> gins {
 )--";
 
   std::map<String, TypeVal> has;

--- a/src/workspace_ng.cc
+++ b/src/workspace_ng.cc
@@ -147,8 +147,9 @@ std::shared_ptr<void> Workspace::operator[](Index i) {
 Workspace::Workspace()
     : ws(global_data::wsv_data.nelem()),
       wsv_data_ptr(std::make_shared<Array<WsvRecord>>(global_data::wsv_data)),
-      WsvMap_ptr(std::make_shared<map<String, Index>>(global_data::WsvMap)),
+      WsvMap_ptr(std::make_shared<unordered_map<String, Index>>()),
       original_workspace(this) {
+  for(auto x : global_data::WsvMap) WsvMap_ptr -> emplace(x);
   ARTS_ASSERT(wsv_data_ptr -> size() == WsvMap_ptr->size())
 
   for (Index i = 0; i < (*wsv_data_ptr).nelem(); i++) {

--- a/src/workspace_ng.h
+++ b/src/workspace_ng.h
@@ -25,7 +25,7 @@
 #ifndef WORKSPACE_NG_INCLUDED
 #define WORKSPACE_NG_INCLUDED
 
-#include <map>
+#include <unordered_map>
 #include <memory>
 #include <stack>
 #include <vector>
@@ -75,7 +75,7 @@ class Workspace final : public std::enable_shared_from_this<Workspace> {
   using wsv_data_type = Array<WsvRecord>;
   std::shared_ptr<wsv_data_type> wsv_data_ptr;
 
-  using WsvMap_type = map<String, Index>;
+  using WsvMap_type = unordered_map<String, Index>;
   std::shared_ptr<WsvMap_type> WsvMap_ptr;
 
   Workspace* original_workspace;


### PR DESCRIPTION
This is a very small update but it should by all definitions be faster to use unordered maps than ordered maps.  The main reason I am commenting is that my private laptop fails two tests: the pyarts zeeman test and the arts test rte calc mc test.  The former is a comparison failure where the  error reported is very similar to the actual error.  The latter fails because it produces negative temperatures.

Anyways, ignore this comment for the mergability of this code IF it passes online CI.