### PR TITLE
Add convenience functions for reading ARTS types in PyARTS

### DIFF
--- a/src/python_interface/py_macros.h
+++ b/src/python_interface/py_macros.h
@@ -67,7 +67,7 @@ constexpr Index negative_clamp(const Index i, const Index n) noexcept {
             return x;                                                      \
           },                                                               \
           py::arg("file").none(false),                                     \
-          py::doc("Create :class:`" #Type "` from file\n"                    \
+          py::doc("Create :class:`" #Type "` from file\n"                  \
                   "\n"                                                     \
                   "Parameters:\n"                                          \
                   "    file (str): A file that can be read\n"              \

--- a/src/python_interface/py_macros.h
+++ b/src/python_interface/py_macros.h
@@ -58,6 +58,21 @@ constexpr Index negative_clamp(const Index i, const Index n) noexcept {
                   "    file (str): A file that can be read\n"              \
                   "\n"                                                     \
                   "On Error:\n"                                            \
+                  "    Throws RuntimeError for any failure to read"))      \
+      .def_static(                                                         \
+          "fromxml",                                                       \
+          [](const char* const file) {                                     \
+            Type x;                                                        \
+            xml_read_from_file(file, x, Verbosity());                      \
+            return x;                                                      \
+          },                                                               \
+          py::arg("file").none(false),                                     \
+          py::doc("Create :class:`" #Type "` from file\n"                    \
+                  "\n"                                                     \
+                  "Parameters:\n"                                          \
+                  "    file (str): A file that can be read\n"              \
+                  "\n"                                                     \
+                  "On Error:\n"                                            \
                   "    Throws RuntimeError for any failure to read"))
 
 #define PythonInterfaceIndexItemAccess(Type)                                \

--- a/src/python_interface/py_workspace.cpp
+++ b/src/python_interface/py_workspace.cpp
@@ -338,7 +338,11 @@ void py_workspace(py::module_& m,
                              }, "The group of the variable")
       .def("delete_level", [](WorkspaceVariable& v) {
         if (v.stack_depth()) v.pop_workspace_level();
-      }, "Delete a level from the workspace variable stack");
+      }, "Delete a level from the workspace variable stack")
+      .def("readxml",[](const py::object& wsv, const char* const filename){
+        wsv.attr("initialize_if_not")();
+        wsv.attr("value").attr("readxml")(filename);
+      }, "Read the variable from an xml file");
 
   ws.def("number_of_initialized_variables", [](Workspace& w){
     Index count = 0;


### PR DESCRIPTION
Initializing an ARTS type variable from an XML file currently requires two lines of code, creating the ARTS type variable and then calling `readxml`:

```python
v = pyarts.arts.Vector()
v.readxml("my_fgrid.xml")
```

This PR adds a convenience function to create an ARTS type variable directly from a file:
```python
w = pyarts.arts.Vector.fromxml("my_fgrid.xml")
```

The PR also adds a `readxml` method to the `WorkspaceVariable` type in Python to intialize a WSV from an XML file:

```python
ws.f_grid.readxml("myfgrid.xml")
```