### PR TITLE
Force enable docserver in CI and fix git version

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -202,7 +202,7 @@ jobs:
         run: |
           mkdir cmake-build
           cd cmake-build
-          cmake -DCMAKE_BUILD_TYPE=${{ matrix.buildtype }} -DENABLE_PCH=1 -DENABLE_GUI=1 -DNUM_PYARTS_WSM=2 -DNUM_PYARTS_WSV=1 -DNUM_PYARTS_WSC=1 -DNUM_PYARTS_WSG=1 -DENABLE_FORTRAN=$USEFORTRAN -DENABLE_NETCDF=1 ${{ matrix.cmakeflags }} ..
+          cmake -DCMAKE_BUILD_TYPE=${{ matrix.buildtype }} -DENABLE_PCH=1 -DENABLE_GUI=1 -DNUM_PYARTS_WSM=2 -DNUM_PYARTS_WSV=1 -DNUM_PYARTS_WSC=1 -DNUM_PYARTS_WSG=1 -DENABLE_FORTRAN=$USEFORTRAN -DENABLE_NETCDF=1 -DENABLE_DOCSERVER=1 ${{ matrix.cmakeflags }} ..
 
       - name: Build (Linux)
         if: runner.os == 'Linux' && matrix.arts == 'yes'

--- a/cmake/modules/ArtsVersion.cmake
+++ b/cmake/modules/ArtsVersion.cmake
@@ -17,7 +17,7 @@ set (GIT_DIR "${ARTS_SOURCE_DIR}/.git")
 
 if (IS_DIRECTORY "${GIT_DIR}")
   execute_process (COMMAND
-                   git describe --always --abbrev=8 --dirty
+                   git describe --always --abbrev=8 --first-parent --dirty
                    WORKING_DIRECTORY "${ARTS_SOURCE_DIR}"
                    OUTPUT_VARIABLE GIT_COMMIT_HASH
                    ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
Ensure that the CI compiles with docserver support and fails with an
error if MHD is not available.

Remove branch names from auto-generated ARTS version number.