### PR TITLE
Fix clangd completion inside OpenMP blocks

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,2 @@
+CompileFlags:
+  Remove: [-fopenmp*]


### PR DESCRIPTION
Turn off `-fopenmp` option for clangd to work around completion being broken inside OpenMP blocks.