### PR TITLE
Improve PyARTS build process

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -158,7 +158,7 @@ jobs:
             sudo apt-get install -y libc++-${{ matrix.version }}-dev libc++abi-${{ matrix.version }}-dev
           fi
           sudo apt-get install -y python3-minimal python3-pip python3-setuptools zlib1g-dev libopenblas-dev libglew-dev libglfw3-dev libnetcdf-dev libmicrohttpd-dev
-          sudo pip3 install docutils lark-parser matplotlib netCDF4 numpy pytest scipy xarray
+          sudo pip3 install build docutils lark-parser matplotlib netCDF4 numpy pytest scipy xarray
 
           if [ "${{ matrix.doc }}" = "yes" ]; then
             sudo apt-get install -y texlive texlive-latex-extra doxygen
@@ -172,7 +172,7 @@ jobs:
           pkgutil --pkg-info=com.apple.pkg.CLTools_Executables
           brew upgrade python
           brew install libmicrohttpd
-          sudo pip3 install docutils lark-parser matplotlib netCDF4 numpy pytest scipy xarray
+          sudo pip3 install build docutils lark-parser matplotlib netCDF4 numpy pytest scipy xarray
           if [ "${{ matrix.compiler }}" = "gcc" ]; then
             brew install gcc@${{ matrix.version }}
             echo "CC=gcc-${{ matrix.version }}" >> $GITHUB_ENV

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -235,6 +235,12 @@ jobs:
           cd cmake-build
           make check
 
+      - name: Python Wheel (Linux / macOS)
+        if: (runner.os == 'Linux' || runner.os == 'macOS') && matrix.check == 'yes'
+        run: |
+          cd cmake-build
+          make pyarts-package
+
       - name: Check Controlfile Conversion (Linux / macOS)
         if: matrix.check == 'yes'
         run: |

--- a/cmake/modules/CheckPythonModule.cmake
+++ b/cmake/modules/CheckPythonModule.cmake
@@ -4,6 +4,7 @@
 
 macro (CHECK_PYTHON_MODULES)
   set(REQUIRED_MODULES
+    build
     docutils
     lark.parse_tree_builder
     matplotlib
@@ -15,6 +16,7 @@ macro (CHECK_PYTHON_MODULES)
     xarray)
 
   set(PYPI_NAMES
+    build
     docutils
     lark-parser
     matplotlib

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -27,7 +27,11 @@ configure_file(MANIFEST.in MANIFEST.in)
 
 add_custom_target(pyarts
   ALL
-  COMMAND ${Python3_EXECUTABLE} setup.py build
+  DEPENDS pyarts_cpp
+  COMMENT "Updating ARTS python package.")
+add_custom_target(pyarts-package
+  ALL
+  COMMAND ${Python3_EXECUTABLE} -m build
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   DEPENDS pyarts_cpp
   COMMENT "Building ARTS python package.")

--- a/python/setup.py
+++ b/python/setup.py
@@ -30,21 +30,6 @@ STABLE = int(VERSION_TUPLE[1]) % 2 == 0
 
 here = abspath(dirname(__file__))
 
-try:
-    builtin_path = join("@ARTS_BINARY_DIR@", "src", "python_interface")
-    files = listdir(builtin_path)
-    found = False
-    for file in files:
-        if splitext(file)[-1] in [".so"]:
-            builtin_lib_path = join(builtin_path, file)
-            if isfile(join("pyarts", file)):
-                remove(join("pyarts", file))
-            shutil.copy(builtin_lib_path, "pyarts")
-            found = True
-    if not found: raise
-except:
-    raise Exception("Cannot find builtin library")
-
 class BinaryDistribution(Distribution):
     """Distribution which always forces a binary package with platform name"""
     def has_ext_modules(foo):

--- a/src/python_interface/CMakeLists.txt
+++ b/src/python_interface/CMakeLists.txt
@@ -118,4 +118,7 @@ target_include_directories(pyarts_cpp PUBLIC ${ARTS_SOURCE_DIR}/src)
 target_include_directories(pyarts_cpp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(pyarts_cpp PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_compile_definitions(pyarts_cpp PUBLIC PYBIND11_DETAILED_ERROR_MESSAGES)
+set_target_properties(
+  pyarts_cpp PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+                        "${ARTS_BINARY_DIR}/python/pyarts/")
 ########################################################################################


### PR DESCRIPTION
Build python library directly inside the pyarts directory instead of copying it over in setup.py.
Switch to PEP 517 compliant python build process.
Avoid to rebuild the python package every time the arts library is recompiled (saves time during development).