### PR TITLE
Case-insensitive sorting on sphinx group pages

### DIFF
--- a/src/python_interface/gen_auto_py_helpers.cpp
+++ b/src/python_interface/gen_auto_py_helpers.cpp
@@ -54,6 +54,19 @@ uint32_t hlist_num_cols(const std::vector<String>& v) {
   return v.size() < 5 ? 1 : 2;
 };
 
+bool str_compare_nocase(const std::string& lhs, const std::string& rhs) {
+  auto str_toupper = [](std::string s) {
+    std::transform(s.begin(),
+                   s.end(),
+                   s.begin(),
+                   [](unsigned char c) { return std::toupper(c); }  // correct
+    );
+    return s;
+  };
+
+  return str_toupper(lhs) < str_toupper(rhs);
+};
+
 String unwrap_stars(String x) {
   const auto find = [&](auto p) {
     p = std::min(p, x.end());

--- a/src/python_interface/pydocs.cpp
+++ b/src/python_interface/pydocs.cpp
@@ -23,6 +23,9 @@ String group_generics_inout(const String& group) {
       outdocs.second.push_back(method.Name());
   }
 
+  std::sort(outdocs.first.begin(), outdocs.first.end(), str_compare_nocase);
+  std::sort(outdocs.second.begin(), outdocs.second.end(), str_compare_nocase);
+
   String out;
 
   if (outdocs.first.size()) {
@@ -61,6 +64,8 @@ String group_workspace_types(const String& group) {
   for (auto& var: global_data::wsv_data) {
     if (gr == var.Group()) vars.push_back(var.Name());
   }
+
+  std::sort(vars.begin(), vars.end(), str_compare_nocase);
 
   String out;
   if (vars.size()) {

--- a/src/python_interface/pydocs.h
+++ b/src/python_interface/pydocs.h
@@ -4,6 +4,8 @@
 
 uint32_t hlist_num_cols(const std::vector<String>& v);
 
+bool str_compare_nocase(const std::string& lhs, const std::string& rhs);
+
 String unwrap_stars(String);
 
 String get_agenda_io(const String&);


### PR DESCRIPTION
Improves sorting for group pages, e.g. [Workspace methods that require GriddedField3](https://atmtools.github.io/arts-docs-master/pyarts/stubs/pyarts.arts.GriddedField3.html).