### PR TITLE
Rearrange internal disort methods

### DIFF
--- a/src/disort.cc
+++ b/src/disort.cc
@@ -1011,6 +1011,8 @@ void run_cdisort(Workspace& ws,
   //Intensity of incident sun beam
   Numeric fbeam = 0.;
 
+  Index N_lev= p_grid.nelem();
+
   if (suns_do) {
     nphi = aa_grid.nelem();
     umu0 = Conversion::cosd(sun_rte_los[0]);
@@ -1117,9 +1119,9 @@ void run_cdisort(Workspace& ws,
     pmom_gas.resize(ds.nlyr, Nlegendre);
 
   }
-  Matrix directbeam(nf, ds.nlyr + 1,0);
-  Matrix deltatau(nf, ds.nlyr + 1,0);
-  Matrix snglsctalbedo(nf, ds.nlyr + 1,0);
+  Matrix directbeam(nf,N_lev,0);
+  Matrix deltatau(nf,N_lev,0);
+  Matrix snglsctalbedo(nf, N_lev,0);
 
 
   // loop over all frequencies
@@ -1307,21 +1309,23 @@ void run_cdisort(Workspace& ws,
 
     for (Index k = cboxlims[1] - cboxlims[0]; k > 0; k--) {
       deltatau(f_index, k - 1 + ncboxremoved) =
-          dtauc(0, ds.nlyr - k  + ncboxremoved);
+          dtauc(0, ds.nlyr - k  + cboxlims[0]);
     }
 
     for (Index k = cboxlims[1] - cboxlims[0]; k > 0; k--) {
       snglsctalbedo(f_index, k - 1 + ncboxremoved) =
-          ssalb(0, ds.nlyr - k + ncboxremoved);
+          ssalb(0, ds.nlyr - k + cboxlims[0]);
     }
 
-    directbeam(1, cboxlims[1] - cboxlims[0] + ncboxremoved) =
-        suns[0].spectrum(f_index, 0)/PI;
+    if (suns_do){
+      directbeam(1, cboxlims[1] - cboxlims[0] + ncboxremoved) =
+          suns[0].spectrum(f_index, 0)/PI;
 
-    for (Index k = cboxlims[1] - cboxlims[0]; k > 0; k--) {
-      directbeam(f_index, k - 1 + ncboxremoved) =
-          directbeam(f_index, k + ncboxremoved) *
-          exp(-dtauc(0, ds.nlyr - k + ncboxremoved)/umu0);
+      for (Index k = cboxlims[1] - cboxlims[0]; k > 0; k--) {
+        directbeam(f_index, k - 1 + ncboxremoved) =
+            directbeam(f_index, k + ncboxremoved) *
+            exp(-dtauc(0, ds.nlyr - k + cboxlims[0])/umu0);
+      }
     }
   }
 

--- a/src/disort.cc
+++ b/src/disort.cc
@@ -1318,7 +1318,7 @@ void run_cdisort(Workspace& ws,
     }
 
     if (suns_do){
-      directbeam(1, cboxlims[1] - cboxlims[0] + ncboxremoved) =
+      directbeam(f_index, cboxlims[1] - cboxlims[0] + ncboxremoved) =
           suns[0].spectrum(f_index, 0)/PI;
 
       for (Index k = cboxlims[1] - cboxlims[0]; k > 0; k--) {
@@ -1553,7 +1553,7 @@ void run_cdisort_flux(Workspace& ws,
   if (gas_scattering_do){
     sca_bulk_par_layer.resize(1, ds.nlyr);
     sca_coeff_gas_layer.resize(1, ds.nlyr);
-    sca_coeff_gas_level(1, ds.nlyr + 1);
+    sca_coeff_gas_level.resize(1, ds.nlyr + 1);
     pmom_gas.resize(ds.nlyr, Nlegendre);
 
   }

--- a/src/disort.cc
+++ b/src/disort.cc
@@ -1113,7 +1113,7 @@ void run_cdisort(Workspace& ws,
   if (gas_scattering_do){
     sca_bulk_par_layer.resize(1, ds.nlyr);
     sca_coeff_gas_layer.resize(1, ds.nlyr);
-    sca_coeff_gas_level(1, ds.nlyr + 1);
+    sca_coeff_gas_level.resize(1, ds.nlyr + 1);
     pmom_gas.resize(ds.nlyr, Nlegendre);
 
   }
@@ -1204,7 +1204,8 @@ void run_cdisort(Workspace& ws,
 
     // Optical depth of layers
     // Single scattering albedo of layers
-    get_dtauc_ssalb(dtauc, ssalb, ext_bulk_gas, ext_bulk_par, abs_bulk_par, z);
+    ext_bulk_gas_i(0,joker)=ext_bulk_gas(f_index, joker);
+    get_dtauc_ssalb(dtauc, ssalb, ext_bulk_gas_i, ext_bulk_par, abs_bulk_par, z);
 
     //upper boundary conditions:
     // DISORT offers isotropic incoming radiance or emissivity-scaled planck

--- a/src/disort.cc
+++ b/src/disort.cc
@@ -1485,6 +1485,10 @@ void run_cdisort_flux(Workspace& ws,
 
   if (only_tro && (Npfct < 0 || Npfct > 3)) {
     nang = Npfct;
+    if (Npfct < 0){
+      get_angs(pfct_angs, scat_data, Npfct);
+      nang = pfct_angs.nelem();
+    }
     nlinspace(pfct_angs, 0, 180, nang);
 
     pha_bulk_par.resize(nf_ssd, ds.nlyr + 1, nang);
@@ -1582,14 +1586,16 @@ void run_cdisort_flux(Workspace& ws,
   ds.bc.btemp = surface_skin_t;
   ds.bc.temis = 1.;
 
+  //
+  Index N_lev= p_grid.nelem();
   Matrix spectral_direct_irradiance_field;
-  Matrix dFdtau(nf, ds.nlyr+1,0);
-  Matrix deltatau(nf, ds.nlyr,0);
-  Matrix snglsctalbedo(nf, ds.nlyr,0);
+  Matrix dFdtau(nf, N_lev,0);
+  Matrix deltatau(nf, N_lev,0);
+  Matrix snglsctalbedo(nf, N_lev,0);
 
   if (suns_do){
     //Resize direct field
-    spectral_direct_irradiance_field.resize(nf, ds.nlyr+1);
+    spectral_direct_irradiance_field.resize(nf, N_lev);
     spectral_direct_irradiance_field = 0;
   }
 

--- a/src/disort.cc
+++ b/src/disort.cc
@@ -1575,7 +1575,7 @@ void run_cdisort_flux(Workspace& ws,
     f_grid_i=f_grid[f_index];
 
     // Get particle bulk properties but onl if pnd_field is non-zero
-    if (pnd_non_zero) {
+    if (pnd_non_zero && (suns_do || emission)) {
       if (only_tro && (Npfct < 0 || Npfct > 3)) {
         ext_bulk_par = 0.0;
         abs_bulk_par = 0.0;

--- a/src/disort.cc
+++ b/src/disort.cc
@@ -1755,7 +1755,6 @@ void run_cdisort_flux(Workspace& ws,
       }
       dFdtau(f_index, k) = dFdtau(f_index, k + 1);
     }
-    std::cout << "end of index " << f_index << "\n";
 
   }
 

--- a/src/disort.cc
+++ b/src/disort.cc
@@ -442,13 +442,12 @@ void get_paroptprop(MatrixView ext_bulk_par,
                     ConstVectorView t_profile,
                     ConstVectorView DEBUG_ONLY(p_grid),
                     const ArrayOfIndex& cloudbox_limits,
-                    ConstVectorView f_grid) {
+                    const Index f_index) {
   const Index Np_cloud = pnd_profiles.ncols();
   DEBUG_ONLY(const Index Np = p_grid.nelem());
-  const Index nf = f_grid.nelem();
 
-  ARTS_ASSERT(ext_bulk_par.nrows() == nf);
-  ARTS_ASSERT(abs_bulk_par.nrows() == nf);
+  ARTS_ASSERT(ext_bulk_par.nrows() == 1);
+  ARTS_ASSERT(abs_bulk_par.nrows() == 1);
   ARTS_ASSERT(ext_bulk_par.ncols() == Np);
   ARTS_ASSERT(abs_bulk_par.ncols() == Np);
 
@@ -482,7 +481,8 @@ void get_paroptprop(MatrixView ext_bulk_par,
                       1,
                       T_array,
                       dir_array,
-                      -1);
+                      f_index);
+
   opt_prop_ScatSpecBulk(ext_mat_ssbulk,
                         abs_vec_ssbulk,
                         ptype_ssbulk,
@@ -498,16 +498,13 @@ void get_paroptprop(MatrixView ext_bulk_par,
                 abs_vec_ssbulk,
                 ptype_ssbulk);
 
-  Index f_this = 0;
-  bool pf = (abs_vec_bulk.nbooks() != 1);
-  for (Index ip = 0; ip < Np_cloud; ip++)
-    for (Index f_index = 0; f_index < nf; f_index++) {
-      if (pf) f_this = f_index;
-      ext_bulk_par(f_index, ip + cloudbox_limits[0]) =
-          ext_mat_bulk(f_this, ip, 0, 0, 0);
-      abs_bulk_par(f_index, ip + cloudbox_limits[0]) =
-          abs_vec_bulk(f_this, ip, 0, 0);
-    }
+
+  for (Index ip = 0; ip < Np_cloud; ip++){
+      ext_bulk_par(0, ip + cloudbox_limits[0]) =
+          ext_mat_bulk(0, ip, 0, 0, 0);
+      abs_bulk_par(0, ip + cloudbox_limits[0]) =
+          abs_vec_bulk(0, ip, 0, 0);
+  }
 }
 
 void get_dtauc_ssalb(MatrixView dtauc,
@@ -589,7 +586,8 @@ void get_parZ(Tensor3& pha_bulk_par,
               ConstMatrixView pnd_profiles,
               ConstVectorView t_profile,
               ConstVectorView pfct_angs,
-              const ArrayOfIndex& cloudbox_limits) {
+              const ArrayOfIndex& cloudbox_limits,
+              const Index f_index) {
   const Index Np_cloud = pnd_profiles.ncols();
   const Index nang = pfct_angs.nelem();
 
@@ -623,7 +621,7 @@ void get_parZ(Tensor3& pha_bulk_par,
                      T_array,
                      pdir_array,
                      idir_array,
-                     -1);
+                     f_index);
   pha_mat_ScatSpecBulk(pha_mat_ssbulk,
                        ptype_ssbulk,
                        pha_mat_Nse,
@@ -1078,124 +1076,135 @@ void run_cdisort(Workspace& ws,
   // Transform to mu, starting with negative values
   for (Index i = 0; i < ds.numu; i++) ds.umu[i] = -cos(za_grid[i] * PI / 180);
 
-  //gas absorption
-  Matrix ext_bulk_gas(nf, ds.nlyr + 1);
-  get_gasoptprop(ws, ext_bulk_gas, propmat_clearsky_agenda, t, vmr, p, f_grid);
 
-  // Get particle bulk properties
-  Index nang;
-  Vector pfct_angs;
-  Matrix ext_bulk_par(nf, ds.nlyr + 1), abs_bulk_par(nf, ds.nlyr + 1);
-  Index nf_ssd = scat_data[0][0].f_grid.nelem();
-  Tensor3 pha_bulk_par;
+  //allocate
+  Matrix deltatau(nf, ds.nlyr, 0);
+  Matrix snglsctalbedo(nf, ds.nlyr,0);
+  Matrix directbeam(nf, ds.nlyr + 1, 0);
 
-  if (only_tro && (Npfct < 0 || Npfct > 3)) {
-    nang = Npfct;
-    nlinspace(pfct_angs, 0, 180, nang);
+  // loop over all frequencies
+  for (Index f_index = 0; f_index < f_grid.nelem(); f_index++) {
 
-    pha_bulk_par.resize(nf_ssd, ds.nlyr + 1, nang);
+    Vector f_grid_i(1, f_grid[f_index]);
 
-    ext_bulk_par = 0.0;
-    abs_bulk_par = 0.0;
-    pha_bulk_par = 0.0;
+    //gas absorption
+    Matrix ext_bulk_gas(1, ds.nlyr + 1);
+    get_gasoptprop(ws, ext_bulk_gas, propmat_clearsky_agenda, t, vmr, p, f_grid_i);
 
-    Index iflat = 0;
+    // Get particle bulk properties
+    Index nang;
+    Vector pfct_angs;
+    Matrix ext_bulk_par(1, ds.nlyr + 1), abs_bulk_par(1, ds.nlyr + 1);
+//    Index nf_ssd = scat_data[0][0].f_grid.nelem();
+    Tensor3 pha_bulk_par;
 
-    for (Index iss = 0; iss < scat_data.nelem(); iss++) {
-      const Index nse = scat_data[iss].nelem();
-      ext_abs_pfun_from_tro(ext_bulk_par,
-                            abs_bulk_par,
-                            pha_bulk_par,
-                            scat_data[iss],
-                            iss,
-                            pnd(Range(iflat, nse), joker),
-                            cboxlims,
-                            t,
-                            pfct_angs);
-      iflat += nse;
-    }
-  } else {
+  //  if (only_tro && (Npfct < 0 || Npfct > 3)) {
+  //    nang = Npfct;
+  //    nlinspace(pfct_angs, 0, 180, nang);
+  //
+  //    pha_bulk_par.resize(nf_ssd, ds.nlyr + 1, nang);
+  //
+  //    ext_bulk_par = 0.0;
+  //    abs_bulk_par = 0.0;
+  //    pha_bulk_par = 0.0;
+  //
+  //    Index iflat = 0;
+  //
+  //    for (Index iss = 0; iss < scat_data.nelem(); iss++) {
+  //      const Index nse = scat_data[iss].nelem();
+  //      ext_abs_pfun_from_tro(ext_bulk_par,
+  //                            abs_bulk_par,
+  //                            pha_bulk_par,
+  //                            scat_data[iss],
+  //                            iss,
+  //                            pnd(Range(iflat, nse), joker),
+  //                            cboxlims,
+  //                            t,
+  //                            pfct_angs);
+  //      iflat += nse;
+  //    }
+  //  } else {
     get_angs(pfct_angs, scat_data, Npfct);
     nang = pfct_angs.nelem();
 
-    pha_bulk_par.resize(nf_ssd, ds.nlyr + 1, nang);
+    pha_bulk_par.resize(1, ds.nlyr + 1, nang);
 
     get_paroptprop(
-        ext_bulk_par, abs_bulk_par, scat_data, pnd, t, p, cboxlims, f_grid);
-    get_parZ(pha_bulk_par, scat_data, pnd, t, pfct_angs, cboxlims);
-  }
+        ext_bulk_par, abs_bulk_par, scat_data, pnd, t, p, cboxlims, f_index);
+    get_parZ(pha_bulk_par, scat_data, pnd, t, pfct_angs, cboxlims, f_index);
+  //  }
 
-  Tensor3 pfct_bulk_par(nf_ssd, ds.nlyr, nang);
-  get_pfct(pfct_bulk_par, pha_bulk_par, ext_bulk_par, abs_bulk_par, cboxlims);
+    Tensor3 pfct_bulk_par(1, ds.nlyr, nang);
+    get_pfct(pfct_bulk_par, pha_bulk_par, ext_bulk_par, abs_bulk_par, cboxlims);
 
-  // Legendre polynomials of phase function
-  Tensor3 pmom(nf_ssd, ds.nlyr, Nlegendre, 0.);
-  get_pmom(pmom, pfct_bulk_par, pfct_angs, Nlegendre);
+    // Legendre polynomials of phase function
+    Tensor3 pmom(1, ds.nlyr, Nlegendre, 0.);
+    get_pmom(pmom, pfct_bulk_par, pfct_angs, Nlegendre);
 
-  if (gas_scattering_do) {
-    // gas scattering
+    if (gas_scattering_do) {
+      // gas scattering
 
-    // layer averaged particle scattering coefficient
-    Matrix sca_bulk_par_layer(nf_ssd, ds.nlyr);
-    get_scat_bulk_layer(sca_bulk_par_layer, ext_bulk_par, abs_bulk_par);
+      // layer averaged particle scattering coefficient
+      Matrix sca_bulk_par_layer(1, ds.nlyr);
+      get_scat_bulk_layer(sca_bulk_par_layer, ext_bulk_par, abs_bulk_par);
 
-    // call gas_scattering_properties
-    Matrix sca_coeff_gas_layer(nf_ssd, ds.nlyr, 0.);
-    Matrix sca_coeff_gas_level(nf_ssd, ds.nlyr + 1, 0.);
-    Matrix pmom_gas(ds.nlyr, Nlegendre, 0.);
+      // call gas_scattering_properties
+      Matrix sca_coeff_gas_layer(1, ds.nlyr, 0.);
+      Matrix sca_coeff_gas_level(1, ds.nlyr + 1, 0.);
+      Matrix pmom_gas(ds.nlyr, Nlegendre, 0.);
 
-    get_gas_scattering_properties(ws,
-                                  sca_coeff_gas_layer,
-                                  sca_coeff_gas_level,
-                                  pmom_gas,
-                                  f_grid,
-                                  p,
-                                  t,
-                                  vmr,
-                                  gas_scattering_agenda);
+      get_gas_scattering_properties(ws,
+                                    sca_coeff_gas_layer,
+                                    sca_coeff_gas_level,
+                                    pmom_gas,
+                                    f_grid_i,
+                                    p,
+                                    t,
+                                    vmr,
+                                    gas_scattering_agenda);
 
-    // call add_norm_phase_functions
-    add_normed_phase_functions(
-        pmom, sca_bulk_par_layer, pmom_gas, sca_coeff_gas_layer);
+      // call add_norm_phase_functions
+      add_normed_phase_functions(
+          pmom, sca_bulk_par_layer, pmom_gas, sca_coeff_gas_layer);
 
-    // add gas_scat_ext to ext_bulk_par
-    ext_bulk_par += sca_coeff_gas_level;
-  }
+      // add gas_scat_ext to ext_bulk_par
+      ext_bulk_par += sca_coeff_gas_level;
+    }
 
-  // Optical depth of layers
-  Matrix dtauc(nf, ds.nlyr);
-  // Single scattering albedo of layers
-  Matrix ssalb(nf, ds.nlyr);
-  get_dtauc_ssalb(dtauc, ssalb, ext_bulk_gas, ext_bulk_par, abs_bulk_par, z);
+    // Optical depth of layers
+    Matrix dtauc(1, ds.nlyr);
+    // Single scattering albedo of layers
+    Matrix ssalb(1, ds.nlyr);
+    get_dtauc_ssalb(dtauc, ssalb, ext_bulk_gas, ext_bulk_par, abs_bulk_par, z);
 
-  //upper boundary conditions:
-  // DISORT offers isotropic incoming radiance or emissivity-scaled planck
-  // emission. Both are applied additively.
-  // We want to have cosmic background radiation, for which ttemp=COSMIC_BG_TEMP
-  // and temis=1 should give identical results to fisot(COSMIC_BG_TEMP). As they
-  // are additive we should use either the one or the other.
-  // Note: previous setup (using fisot) setting temis=0 should be avoided.
-  // Generally, temis!=1 should be avoided since that technically implies a
-  // reflective upper boundary (though it seems that this is not exploited in
-  // DISORT1.2, which we so far use).
+    //upper boundary conditions:
+    // DISORT offers isotropic incoming radiance or emissivity-scaled planck
+    // emission. Both are applied additively.
+    // We want to have cosmic background radiation, for which ttemp=COSMIC_BG_TEMP
+    // and temis=1 should give identical results to fisot(COSMIC_BG_TEMP). As they
+    // are additive we should use either the one or the other.
+    // Note: previous setup (using fisot) setting temis=0 should be avoided.
+    // Generally, temis!=1 should be avoided since that technically implies a
+    // reflective upper boundary (though it seems that this is not exploited in
+    // DISORT1.2, which we so far use).
 
-  // Cosmic background
-  // we use temis*ttemp as upper boundary specification, hence CBR set to 0.
-  ds.bc.fisot = 0;
+    // Cosmic background
+    // we use temis*ttemp as upper boundary specification, hence CBR set to 0.
+    ds.bc.fisot = 0;
 
-  // Top of the atmosphere temperature and emissivity
-  ds.bc.ttemp = COSMIC_BG_TEMP;
-  ds.bc.btemp = surface_skin_t;
-  ds.bc.temis = 1.;
+    // Top of the atmosphere temperature and emissivity
+    ds.bc.ttemp = COSMIC_BG_TEMP;
+    ds.bc.btemp = surface_skin_t;
+    ds.bc.temis = 1.;
 
-  for (Index f_index = 0; f_index < f_grid.nelem(); f_index++) {
+
     snprintf(ds.header, 128, "ARTS Calc f_index = %" PRId64, f_index);
 
     std::memcpy(ds.dtauc,
-                dtauc(f_index, joker).unsafe_data_handle(),
+                dtauc(0, joker).unsafe_data_handle(),
                 sizeof(Numeric) * ds.nlyr);
     std::memcpy(ds.ssalb,
-                ssalb(f_index, joker).unsafe_data_handle(),
+                ssalb(0, joker).unsafe_data_handle(),
                 sizeof(Numeric) * ds.nlyr);
 
     // Wavenumber in [1/cm]
@@ -1214,7 +1223,7 @@ void run_cdisort(Workspace& ws,
     ds.bc.fbeam = fbeam;
 
     std::memcpy(ds.pmom,
-                pmom(f_index, joker, joker).unsafe_data_handle(),
+                pmom(0, joker, joker).unsafe_data_handle(),
                 sizeof(Numeric) * pmom.nrows() * pmom.ncols());
 
     enum class Status { FIRST_TRY, RETRY, SUCCESS };
@@ -1265,6 +1274,25 @@ void run_cdisort(Workspace& ws,
         }
       }
     }
+
+    for (Index k = cboxlims[1] - cboxlims[0]; k > 0; k--) {
+      deltatau(1, k - 1 + ncboxremoved) =
+          dtauc(0, ds.nlyr - k  + ncboxremoved);
+    }
+
+    for (Index k = cboxlims[1] - cboxlims[0]; k > 0; k--) {
+      snglsctalbedo(1, k - 1 + ncboxremoved) =
+          ssalb(0, ds.nlyr - k + ncboxremoved);
+    }
+
+    directbeam(1, cboxlims[1] - cboxlims[0] + ncboxremoved) =
+        suns[0].spectrum(f_index, 0)/PI;
+
+    for (Index k = cboxlims[1] - cboxlims[0]; k > 0; k--) {
+      directbeam(f_index, k - 1 + ncboxremoved) =
+          directbeam(f_index, k + ncboxremoved) *
+          exp(-dtauc(0, ds.nlyr - k + ncboxremoved)/umu0);
+    }
   }
 
   // Allocate aux data
@@ -1276,41 +1304,14 @@ void run_cdisort(Workspace& ws,
 
     if (disort_aux_vars[i] == "Layer optical thickness"){
       cnt += 1;
-      Matrix deltatau(nf, ds.nlyr, 0);
-      for (Index f_index = 0; f_index < f_grid.nelem(); f_index++) {
-        for (Index k = cboxlims[1] - cboxlims[0]; k > 0; k--) {
-          deltatau(f_index, k - 1 + ncboxremoved) =
-              dtauc(f_index, ds.nlyr - k  + ncboxremoved);
-        }
-      }
       disort_aux[cnt] = deltatau;
     }
     else if (disort_aux_vars[i] == "Single scattering albedo"){
       cnt+=1;
-      Matrix snglsctalbedo(nf, ds.nlyr,0);
-      for (Index f_index = 0; f_index < f_grid.nelem(); f_index++) {
-        for (Index k = cboxlims[1] - cboxlims[0]; k > 0; k--) {
-          snglsctalbedo(f_index, k - 1 + ncboxremoved) =
-              ssalb(f_index, ds.nlyr - k + ncboxremoved);
-        }
-      }
       disort_aux[cnt]=snglsctalbedo;
     }
     else if (disort_aux_vars[i] == "Direct beam") {
       cnt += 1;
-      Matrix directbeam(nf, ds.nlyr + 1, 0);
-      if (suns_do) {
-        for (Index f_index = 0; f_index < f_grid.nelem(); f_index++) {
-          directbeam(f_index, cboxlims[1] - cboxlims[0] + ncboxremoved) =
-              suns[0].spectrum(f_index, 0)/PI;
-
-          for (Index k = cboxlims[1] - cboxlims[0]; k > 0; k--) {
-            directbeam(f_index, k - 1 + ncboxremoved) =
-                directbeam(f_index, k + ncboxremoved) *
-                exp(-dtauc(f_index, ds.nlyr - k + ncboxremoved)/umu0);
-          }
-        }
-      }
       disort_aux[cnt]=directbeam;
     } else {
       ARTS_USER_ERROR (
@@ -1380,6 +1381,14 @@ void run_cdisort_flux(Workspace& ws,
                 vmr_profiles,
                 pnd_profiles,
                 cloudbox_limits);
+
+  bool pnd_zero=false;
+  for (Index i = 0; i < pnd.nrows(); i++) {
+    for (Index j = 0; j < pnd.ncols(); j++){
+      pnd_zero+=pnd(i,j);
+    }
+  }
+
 
 #if not ARTS_LGPL
 
@@ -1472,141 +1481,152 @@ void run_cdisort_flux(Workspace& ws,
     for (Index i = 0; i <= ds.nlyr; i++) ds.temper[i] = t[ds.nlyr - i];
   }
 
-  //gas absorption
-  Matrix ext_bulk_gas(nf, ds.nlyr + 1);
-  get_gasoptprop(ws, ext_bulk_gas, propmat_clearsky_agenda, t, vmr, p, f_grid);
-
-  // Get particle bulk properties
-  Index nang;
-  Vector pfct_angs;
-  Matrix ext_bulk_par(nf, ds.nlyr + 1), abs_bulk_par(nf, ds.nlyr + 1);
-  Index nf_ssd = scat_data[0][0].f_grid.nelem();
-  Tensor3 pha_bulk_par;
-
-  if (only_tro && (Npfct < 0 || Npfct > 3)) {
-    nang = Npfct;
-    if (Npfct < 0){
-      get_angs(pfct_angs, scat_data, Npfct);
-      nang = pfct_angs.nelem();
-    }
-    nlinspace(pfct_angs, 0, 180, nang);
-
-    pha_bulk_par.resize(nf_ssd, ds.nlyr + 1, nang);
-
-    ext_bulk_par = 0.0;
-    abs_bulk_par = 0.0;
-    pha_bulk_par = 0.0;
-
-    Index iflat = 0;
-
-    for (Index iss = 0; iss < scat_data.nelem(); iss++) {
-      const Index nse = scat_data[iss].nelem();
-      ext_abs_pfun_from_tro(ext_bulk_par,
-                            abs_bulk_par,
-                            pha_bulk_par,
-                            scat_data[iss],
-                            iss,
-                            pnd(Range(iflat, nse), joker),
-                            cboxlims,
-                            t,
-                            pfct_angs);
-      iflat += nse;
-    }
-  } else {
-    get_angs(pfct_angs, scat_data, Npfct);
-    nang = pfct_angs.nelem();
-
-    pha_bulk_par.resize(nf_ssd, ds.nlyr + 1, nang);
-
-    get_paroptprop(
-        ext_bulk_par, abs_bulk_par, scat_data, pnd, t, p, cboxlims, f_grid);
-    get_parZ(pha_bulk_par, scat_data, pnd, t, pfct_angs, cboxlims);
-  }
-
-  Tensor3 pfct_bulk_par(nf_ssd, ds.nlyr, nang);
-  get_pfct(pfct_bulk_par, pha_bulk_par, ext_bulk_par, abs_bulk_par, cboxlims);
-
-  // Legendre polynomials of phase function
-  Tensor3 pmom(nf_ssd, ds.nlyr, Nlegendre, 0.);
-  get_pmom(pmom, pfct_bulk_par, pfct_angs, Nlegendre);
-
-  if (gas_scattering_do) {
-    // gas scattering
-
-    // layer averaged particle scattering coefficient
-    Matrix sca_bulk_par_layer(nf_ssd, ds.nlyr);
-    get_scat_bulk_layer(sca_bulk_par_layer, ext_bulk_par, abs_bulk_par);
-
-    // call gas_scattering_properties
-    Matrix sca_coeff_gas_layer(nf_ssd, ds.nlyr, 0.);
-    Matrix sca_coeff_gas_level(nf_ssd, ds.nlyr + 1, 0.);
-    Matrix pmom_gas(ds.nlyr, Nlegendre, 0.);
-
-    get_gas_scattering_properties(ws,
-                                  sca_coeff_gas_layer,
-                                  sca_coeff_gas_level,
-                                  pmom_gas,
-                                  f_grid,
-                                  p,
-                                  t,
-                                  vmr,
-                                  gas_scattering_agenda);
-
-    // call add_norm_phase_functions
-    add_normed_phase_functions(
-        pmom, sca_bulk_par_layer, pmom_gas, sca_coeff_gas_layer);
-
-    // add gas_scat_ext to ext_bulk_par
-    ext_bulk_par += sca_coeff_gas_level;
-  }
-
-  // Optical depth of layers
-  Matrix dtauc(nf, ds.nlyr);
-  // Single scattering albedo of layers
-  Matrix ssalb(nf, ds.nlyr);
-  get_dtauc_ssalb(dtauc, ssalb, ext_bulk_gas, ext_bulk_par, abs_bulk_par, z);
-
-  //upper boundary conditions:
-  // DISORT offers isotropic incoming radiance or emissivity-scaled planck
-  // emission. Both are applied additively.
-  // We want to have cosmic background radiation, for which ttemp=COSMIC_BG_TEMP
-  // and temis=1 should give identical results to fisot(COSMIC_BG_TEMP). As they
-  // are additive we should use either the one or the other.
-  // Note: previous setup (using fisot) setting temis=0 should be avoided.
-  // Generally, temis!=1 should be avoided since that technically implies a
-  // reflective upper boundary (though it seems that this is not exploited in
-  // DISORT1.2, which we so far use).
-
-  // Cosmic background
-  // we use temis*ttemp as upper boundary specification, hence CBR set to 0.
-  ds.bc.fisot = 0;
-
-  // Top of the atmosphere temperature and emissivity
-  ds.bc.ttemp = COSMIC_BG_TEMP;
-  ds.bc.btemp = surface_skin_t;
-  ds.bc.temis = 1.;
-
   //
   Index N_lev= p_grid.nelem();
   Matrix spectral_direct_irradiance_field;
-  Matrix dFdtau(nf, N_lev,0);
-  Matrix deltatau(nf, N_lev,0);
-  Matrix snglsctalbedo(nf, N_lev,0);
-
   if (suns_do){
     //Resize direct field
     spectral_direct_irradiance_field.resize(nf, N_lev);
     spectral_direct_irradiance_field = 0;
   }
+  Matrix dFdtau(nf, N_lev,0);
+  Matrix deltatau(nf, N_lev,0);
+  Matrix snglsctalbedo(nf, N_lev,0);
+
+  // start loop over all frequencies
 
   for (Index f_index = 0; f_index < f_grid.nelem(); f_index++) {
+
+    Vector f_grid_i(1, f_grid[f_index]);
+
+    std::cout << "f_index = " << f_index << "\n";
+    std::cout << "f_grid_i = " << f_grid_i << "\n";
+
+
+    //gas absorption
+    Matrix ext_bulk_gas(1, ds.nlyr + 1);
+    get_gasoptprop(ws, ext_bulk_gas, propmat_clearsky_agenda, t, vmr, p, f_grid_i);
+
+    // Get particle bulk properties
+    Index nang;
+    Vector pfct_angs;
+    Matrix ext_bulk_par(1, ds.nlyr + 1), abs_bulk_par(1, ds.nlyr + 1);
+//    Index nf_ssd = scat_data[0][0].f_grid.nelem();
+    Tensor3 pha_bulk_par;
+
+  //  if (only_tro && (Npfct < 0 || Npfct > 3)) {
+  //    nang = Npfct;
+  //    if (Npfct < 0){
+  //      get_angs(pfct_angs, scat_data, Npfct);
+  //      nang = pfct_angs.nelem();
+  //    }
+  //    nlinspace(pfct_angs, 0, 180, nang);
+  //
+  //    pha_bulk_par.resize(nf_ssd, ds.nlyr + 1, nang);
+  //
+  //    ext_bulk_par = 0.0;
+  //    abs_bulk_par = 0.0;
+  //    pha_bulk_par = 0.0;
+  //
+  //    Index iflat = 0;
+  //
+  //    for (Index iss = 0; iss < scat_data.nelem(); iss++) {
+  //      const Index nse = scat_data[iss].nelem();
+  //      ext_abs_pfun_from_tro(ext_bulk_par,
+  //                            abs_bulk_par,
+  //                            pha_bulk_par,
+  //                            scat_data[iss],
+  //                            iss,
+  //                            pnd(Range(iflat, nse), joker),
+  //                            cboxlims,
+  //                            t,
+  //                            pfct_angs);
+  //      iflat += nse;
+  //    }
+  //  } else {
+    get_angs(pfct_angs, scat_data, Npfct);
+    nang = pfct_angs.nelem();
+
+    pha_bulk_par.resize(1, ds.nlyr + 1, nang);
+
+    get_paroptprop(
+        ext_bulk_par, abs_bulk_par, scat_data, pnd, t, p, cboxlims, f_index);
+    get_parZ(pha_bulk_par, scat_data, pnd, t, pfct_angs, cboxlims, f_index);
+  //  }
+
+    Tensor3 pfct_bulk_par(1, ds.nlyr, nang);
+    get_pfct(pfct_bulk_par, pha_bulk_par, ext_bulk_par, abs_bulk_par, cboxlims);
+
+    // Legendre polynomials of phase function
+    Tensor3 pmom(1, ds.nlyr, Nlegendre, 0.);
+    get_pmom(pmom, pfct_bulk_par, pfct_angs, Nlegendre);
+
+    if (gas_scattering_do) {
+      // gas scattering
+
+      // layer averaged particle scattering coefficient
+      Matrix sca_bulk_par_layer(1, ds.nlyr);
+      get_scat_bulk_layer(sca_bulk_par_layer, ext_bulk_par, abs_bulk_par);
+
+      // call gas_scattering_properties
+      Matrix sca_coeff_gas_layer(1, ds.nlyr, 0.);
+      Matrix sca_coeff_gas_level(1, ds.nlyr + 1, 0.);
+      Matrix pmom_gas(ds.nlyr, Nlegendre, 0.);
+
+      get_gas_scattering_properties(ws,
+                                    sca_coeff_gas_layer,
+                                    sca_coeff_gas_level,
+                                    pmom_gas,
+                                    f_grid_i,
+                                    p,
+                                    t,
+                                    vmr,
+                                    gas_scattering_agenda);
+
+      // call add_norm_phase_functions
+      add_normed_phase_functions(
+          pmom, sca_bulk_par_layer, pmom_gas, sca_coeff_gas_layer);
+
+      // add gas_scat_ext to ext_bulk_par
+      ext_bulk_par += sca_coeff_gas_level;
+    }
+
+    // Optical depth of layers
+    Matrix dtauc(1, ds.nlyr);
+    // Single scattering albedo of layers
+    Matrix ssalb(1, ds.nlyr);
+    get_dtauc_ssalb(dtauc, ssalb, ext_bulk_gas, ext_bulk_par, abs_bulk_par, z);
+
+    //upper boundary conditions:
+    // DISORT offers isotropic incoming radiance or emissivity-scaled planck
+    // emission. Both are applied additively.
+    // We want to have cosmic background radiation, for which ttemp=COSMIC_BG_TEMP
+    // and temis=1 should give identical results to fisot(COSMIC_BG_TEMP). As they
+    // are additive we should use either the one or the other.
+    // Note: previous setup (using fisot) setting temis=0 should be avoided.
+    // Generally, temis!=1 should be avoided since that technically implies a
+    // reflective upper boundary (though it seems that this is not exploited in
+    // DISORT1.2, which we so far use).
+
+    // Cosmic background
+    // we use temis*ttemp as upper boundary specification, hence CBR set to 0.
+    ds.bc.fisot = 0;
+
+    // Top of the atmosphere temperature and emissivity
+    ds.bc.ttemp = COSMIC_BG_TEMP;
+    ds.bc.btemp = surface_skin_t;
+    ds.bc.temis = 1.;
+
+
+
+
     snprintf(ds.header, 128, "ARTS Calc f_index = %" PRId64, f_index);
 
     std::memcpy(ds.dtauc,
-                dtauc(f_index, joker).unsafe_data_handle(),
+                dtauc(0, joker).unsafe_data_handle(),
                 sizeof(Numeric) * ds.nlyr);
     std::memcpy(ds.ssalb,
-                ssalb(f_index, joker).unsafe_data_handle(),
+                ssalb(0, joker).unsafe_data_handle(),
                 sizeof(Numeric) * ds.nlyr);
 
     // Wavenumber in [1/cm]
@@ -1625,7 +1645,7 @@ void run_cdisort_flux(Workspace& ws,
     ds.bc.fbeam = fbeam;
 
     std::memcpy(ds.pmom,
-                pmom(f_index, joker, joker).unsafe_data_handle(),
+                pmom(0, joker, joker).unsafe_data_handle(),
                 sizeof(Numeric) * pmom.nrows() * pmom.ncols());
 
     c_disort(&ds, &out);
@@ -1678,6 +1698,8 @@ void run_cdisort_flux(Workspace& ws,
       }
       dFdtau(f_index, k) = dFdtau(f_index, k + 1);
     }
+    std::cout << "end of index " << f_index << "\n";
+
   }
 
   // Allocate aux data

--- a/src/disort.h
+++ b/src/disort.h
@@ -369,9 +369,9 @@ void get_paroptprop(MatrixView ext_bulk_par,
                     const ArrayOfArrayOfSingleScatteringData& scat_data,
                     ConstMatrixView pnd_profiles,
                     ConstVectorView t_profile,
-                    ConstVectorView p_grid,
+                    ConstVectorView DEBUG_ONLY(p_grid),
                     const ArrayOfIndex& cloudbox_limits,
-                    ConstVectorView f_grid);
+                    const Index f_index);
 
 /** get_dtauc_ssalb
  *
@@ -444,7 +444,8 @@ void get_parZ(Tensor3& pha_bulk_par,
               ConstMatrixView pnd_profiles,
               ConstVectorView t_profile,
               ConstVectorView pfct_angs,
-              const ArrayOfIndex& cloudbox_limits);
+              const ArrayOfIndex& cloudbox_limits,
+              const Index f_index);
 
 /** get_pfct.
  *

--- a/src/optproperties.cc
+++ b/src/optproperties.cc
@@ -2428,12 +2428,20 @@ void ext_abs_pfun_from_tro(MatrixView ext_data,
   // Check that all data is TRO
   {
     bool all_totrand = true;
+    bool temp_const = false;
     for (Index ie = 0; ie < nse; ie++) {
       if (scat_data[ie].ptype != PTYPE_TOTAL_RND)
         all_totrand = false;
+
+      if (scat_data[ie].T_grid.nelem()){
+        temp_const = true;
+      }
     }
     ARTS_USER_ERROR_IF (!all_totrand,
                         "This method demands that all scat_data are TRO");
+
+    ARTS_USER_ERROR_IF( temp_const, "This method demands that the scat data \n"
+                       "must not be constant in temperature.");
   }
 
   // Help variables to hold non-zero data inside the cloudbox

--- a/src/optproperties.cc
+++ b/src/optproperties.cc
@@ -2405,15 +2405,20 @@ void ext_abs_pfun_from_tro(MatrixView ext_data,
                            ConstMatrixView pnd_data,
                            ArrayOfIndex& cloudbox_limits,
                            ConstVectorView T_grid,
-                           ConstVectorView sa_grid)
-{
+                           ConstVectorView sa_grid,
+                           const Index f_index) {
   // Sizes
   const Index nse = scat_data.nelem();
-  const Index nf = scat_data[0].f_grid.nelem();
   [[maybe_unused]] const Index nt = T_grid.nelem();
   const Index nsa = sa_grid.nelem();
   const Index ncl = cloudbox_limits[1] - cloudbox_limits[0] + 1;
-  
+  Index nf;
+  if (f_index == -1) {
+    nf = scat_data[0].f_grid.nelem();
+  } else {
+    nf = 1;
+  }
+
   ARTS_ASSERT(ext_data.nrows() == nf);
   ARTS_ASSERT(ext_data.ncols() == nt);
   ARTS_ASSERT(abs_data.nrows() == nf);
@@ -2433,7 +2438,7 @@ void ext_abs_pfun_from_tro(MatrixView ext_data,
       if (scat_data[ie].ptype != PTYPE_TOTAL_RND)
         all_totrand = false;
 
-      if (scat_data[ie].T_grid.nelem()){
+      if (scat_data[ie].T_grid.nelem() == 1) {
         temp_const = true;
       }
     }
@@ -2486,24 +2491,59 @@ void ext_abs_pfun_from_tro(MatrixView ext_data,
       Tensor3 itw2(nvals, nsa, 4);
       interpweights(itw2, gp_t, gp_sa);
 
-      // Loop frequencies
-      for (Index iv = 0; iv < nf; iv++) {
+      if (f_index < 0) {
+        // Loop frequencies
+        for (Index iv = 0; iv < nf; iv++) {
+          // Interpolate
+          Vector ext1(nvals), abs1(nvals);
+          Matrix pfu1(nvals, nsa);
+          interp(
+              ext1, itw1, scat_data[ie].ext_mat_data(iv, joker, 0, 0, 0), gp_t);
+          interp(
+              abs1, itw1, scat_data[ie].abs_vec_data(iv, joker, 0, 0, 0), gp_t);
+          interp(pfu1,
+                 itw2,
+                 scat_data[ie].pha_mat_data(iv, joker, joker, 0, 0, 0, 0),
+                 gp_t,
+                 gp_sa);
+
+          // Add to container variables
+          for (Index i = 0; i < nvals; i++) {
+            const Index ic = cboxlayer[i];
+            const Index it = cl_start + ic;
+            ext_data(iv, it) += pnd_data(ie, ic) * ext1[i];
+            abs_data(iv, it) += pnd_data(ie, ic) * abs1[i];
+            for (Index ia = 0; ia < nsa; ia++) {
+              pfun_data(iv, it, ia) += pnd_data(ie, ic) * pfu1(i, ia);
+            }
+          }
+        }
+      } else {
         // Interpolate
         Vector ext1(nvals), abs1(nvals);
-        Matrix pfu1(nvals,nsa);
-        interp(ext1, itw1, scat_data[ie].ext_mat_data(iv,joker,0,0,0), gp_t);
-        interp(abs1, itw1, scat_data[ie].abs_vec_data(iv,joker,0,0,0), gp_t);
-        interp(pfu1, itw2, scat_data[ie].pha_mat_data(iv,joker,joker,0,0,0,0),
-               gp_t, gp_sa);
+        Matrix pfu1(nvals, nsa);
+        interp(ext1,
+               itw1,
+               scat_data[ie].ext_mat_data(f_index, joker, 0, 0, 0),
+               gp_t);
+        interp(abs1,
+               itw1,
+               scat_data[ie].abs_vec_data(f_index, joker, 0, 0, 0),
+               gp_t);
+        interp(pfu1,
+               itw2,
+               scat_data[ie].pha_mat_data(f_index, joker, joker, 0, 0, 0, 0),
+               gp_t,
+               gp_sa);
 
         // Add to container variables
         for (Index i = 0; i < nvals; i++) {
           const Index ic = cboxlayer[i];
           const Index it = cl_start + ic;
-          ext_data(iv,it) += pnd_data(ie,ic) * ext1[i];
-          abs_data(iv,it) += pnd_data(ie,ic) * abs1[i];
+          ext_data(0, it) += pnd_data(ie, ic) * ext1[i];
+          abs_data(0, it) += pnd_data(ie, ic) * abs1[i];
           for (Index ia = 0; ia < nsa; ia++) {
-            pfun_data(iv,it,ia) += pnd_data(ie,ic) * pfu1(i,ia);
+            pfun_data(0, it, ia) += pnd_data(ie, ic) * pfu1(i, ia);
           }
         }
       }

--- a/src/optproperties.h
+++ b/src/optproperties.h
@@ -303,6 +303,7 @@ void ext_abs_pfun_from_tro(MatrixView ext_data,
                            ConstMatrixView pnd_data,
                            ArrayOfIndex& cloudbox_limits,
                            ConstVectorView T_grid,
-                           ConstVectorView sa_grid);
+                           ConstVectorView sa_grid,
+                           const Index f_index = -1);
 
 #endif  //optproperties_h


### PR DESCRIPTION
*Move the calculation of the phase function and legendre moments inside the frequency loop. In the previous version they were calculated at once outside the frequency loop, but this could results in massive need of ram (hundreds of GB), when calculating sprectral all sky fluxes with thousand and more frequencies especially within the visible regime.

*Add a check if pnd_field is completly zero to skip the calculation of scattering properties within the internal disort methods.