### PR TITLE
Callback op

### DIFF
--- a/python/pyarts/workspace/__init__.py
+++ b/python/pyarts/workspace/__init__.py
@@ -7,3 +7,4 @@ Contains many ways to manipulate the workspace object
 """
 
 from pyarts.workspace.workspace import Workspace, arts_agenda # noqa
+from pyarts.workspace.callback import callback_operator # noqa

--- a/python/pyarts/workspace/callback.py
+++ b/python/pyarts/workspace/callback.py
@@ -1,0 +1,144 @@
+from ast import parse, FunctionDef, Return, Name, Tuple, List, ClassDef
+from inspect import getsource
+import pyarts.arts as cxx
+from pyarts.workspace import Workspace
+from pyarts.workspace.utility import unindent as unindent
+
+
+_errvar = "Unknown Value"
+
+
+_group_types = [
+    eval(f"cxx.{x.name}") for x in list(cxx.globals.get_wsv_groups())
+]
+
+
+def safe_set(ws, attr, val):
+    if ws._hasattr_check_(attr):
+        ws._getattr_unchecked_(attr).initialize_if_not()
+        ws._setattr_unchecked_(attr,
+                               type(ws._getattr_unchecked_(attr).value)(val))
+    elif type(val) in _group_types:
+        ws._getattr_unchecked_(attr).initialize_if_not()
+        ws._setattr_unchecked_(attr, val)
+    else:
+        raise RuntimeError(f"'{attr}' is not on Workspace, and "
+                           f"{type(val)} is not a Workspace Group")
+
+
+def _CallbackOperator(func, ins, outs, extras=[], fnstr="Undefined"):
+    extras.extend(ins)
+
+    def fn(ws):
+        try:
+            out = func(*[ws._getattr_unchecked_(x).value for x in ins])
+
+            if len(outs) == 1:
+                safe_set(ws, outs[0], out)
+            elif len(outs) > 1:
+                for i in range(len(outs)):
+                    attr = outs[i]
+                    val = out[i]
+                    safe_set(ws, attr, val)
+        except Exception as e:
+            raise RuntimeError(
+                f"Raised internal error:\n{e}\n\n"
+                "The original function (if known) reads:\n"
+                f"{fnstr}"
+                f"\n\nThe callback is:\nInput: {extras}\nOutput: {outs}"
+            )
+
+    return cxx.CallbackOperator(fn, extras, outs)
+
+
+def _callback_operator_function(funcdef):
+    assert isinstance(funcdef, FunctionDef), "Must be a function"
+    return [x.arg for x in funcdef.args.args]
+
+
+def _callback_operator_return(expr):
+    value = expr.value
+
+    if isinstance(value, Name):
+        return [value.id]
+    elif isinstance(value, Tuple) or isinstance(value, List):
+        return [x.id if isinstance(x, Name) else _errvar
+                for x in value.elts]
+    return []
+
+
+def _find_return(body):
+    for expr in body:
+        if isinstance(expr, Return):
+            return _callback_operator_return(expr)
+        elif isinstance(expr, FunctionDef) or isinstance(expr, ClassDef):
+            continue
+
+        if hasattr(expr, "body"):
+            t = _find_return(expr.body)
+            if t is not None:
+                return t
+        if hasattr(expr, "orelse"):
+            t = _find_return(expr.orelse)
+            if t is not None:
+                return t
+
+    return None
+
+
+def _rename_var(name_list, **kwargs):
+    """ Renames things in name_list by the kwargs
+    """
+    if name_list is None:
+        return []
+
+    for i in range(len(name_list)):
+        n = name_list[i]
+        n = kwargs.get(n, n)
+        name_list[i] = n
+    return name_list
+
+
+def _callback_operator(func, inputs, outputs, extras, **kwargs):
+    """ Internal source code parser
+    """
+    srccod = getsource(func)
+    srccod = unindent(srccod)
+    srcast = parse(srccod)
+
+    assert len(srcast.body) == 1
+
+    code_body = srcast.body[0]
+
+    args = (
+        inputs
+        if len(inputs)
+        else _rename_var(_callback_operator_function(code_body), **kwargs)
+    )
+
+    retvals = (
+        outputs
+        if len(outputs)
+        else _rename_var(_find_return(code_body.body), **kwargs)
+    )
+
+    if _errvar in retvals:
+        raise RuntimeError(f"Missing return name in:\n{srccod}\n\n"
+                           f"The return-values are {retvals}")
+
+    return _CallbackOperator(func, args, retvals, extras, srccod)
+
+
+def callback_operator(
+    func=None, *, inputs=[], outputs=[], extras=[], **kwargs
+):
+    """
+    Creates a callback operator
+    """
+    def parser(fn):
+        return _callback_operator(fn, inputs, outputs, extras, **kwargs)
+
+    if func is None:
+        return parser
+    else:
+        return _callback_operator(func, inputs, outputs, extras, **kwargs)

--- a/src/callback.cc
+++ b/src/callback.cc
@@ -1,5 +1,7 @@
 #include "callback.h"
 
+#include "workspace_ng.h"
+
 CallbackFunction::CallbackFunction()
     : std::function<void(Workspace&)>([](Workspace&) {}) {}
 
@@ -8,4 +10,30 @@ CallbackFunction::CallbackFunction(std::function<void(Workspace&)> x)
 
 std::ostream& operator<<(std::ostream& os, const CallbackFunction&) {
   return os << "Callback";
+}
+
+std::ostream& operator<<(std::ostream& os, const CallbackOperator& op) {
+  os << "CallbackOperator\nInputs: [";
+  for (auto& n: op.inputs) {
+    os << n << ", ";
+  }
+  os << "]\nOutputs: [";
+  for (auto& n: op.outputs) {
+    os << n << ", ";
+  }
+  return os << ']';
+}
+
+void CallbackOperator::operator()(Workspace& ws_in) const {
+  auto ws = Workspace::create();
+
+  for (auto& n : inputs) {
+    ws->set_wsv(ws_in.copy_wsv(n));
+  }
+
+  callback(*ws);
+
+  for (auto& n : outputs) {
+    ws_in.set_wsv(ws->copy_wsv(n));
+  }
 }

--- a/src/callback.cc
+++ b/src/callback.cc
@@ -31,7 +31,7 @@ void CallbackOperator::operator()(Workspace& ws_in) const {
     ws->set_wsv(ws_in.copy_wsv(n));
   }
 
-  callback(*ws);
+  callback(ws);
 
   for (auto& n : outputs) {
     ws_in.set_wsv(ws->copy_wsv(n));

--- a/src/callback.h
+++ b/src/callback.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <memory>
 #include <ostream>
 
 class Workspace;
@@ -12,15 +13,9 @@ struct CallbackFunction : public std::function<void(Workspace&)> {
 };
 
 struct CallbackOperator {
-  CallbackFunction callback;
+  std::function<void(std::shared_ptr<Workspace>)> callback;
   std::vector<std::string> inputs;
   std::vector<std::string> outputs;
-
-  CallbackOperator() = default;
-
-  CallbackOperator(CallbackFunction cb,
-                   std::vector<std::string> i,
-                   std::vector<std::string> o) : callback(std::move(cb)), inputs(std::move(i)), outputs(std::move(o)) {}
 
   void operator()(Workspace& ws) const;
 

--- a/src/callback.h
+++ b/src/callback.h
@@ -1,10 +1,9 @@
-#ifndef callback_h
-#define callback_h
-
-class Workspace;
+#pragma once
 
 #include <functional>
 #include <ostream>
+
+class Workspace;
 
 struct CallbackFunction : public std::function<void(Workspace&)> {
   CallbackFunction();
@@ -12,4 +11,18 @@ struct CallbackFunction : public std::function<void(Workspace&)> {
   friend std::ostream& operator<<(std::ostream& os, const CallbackFunction&);
 };
 
-#endif
+struct CallbackOperator {
+  CallbackFunction callback;
+  std::vector<std::string> inputs;
+  std::vector<std::string> outputs;
+
+  CallbackOperator() = default;
+
+  CallbackOperator(CallbackFunction cb,
+                   std::vector<std::string> i,
+                   std::vector<std::string> o) : callback(std::move(cb)), inputs(std::move(i)), outputs(std::move(o)) {}
+
+  void operator()(Workspace& ws) const;
+
+  friend std::ostream& operator<<(std::ostream& os, const CallbackOperator&);
+};

--- a/src/groups.cc
+++ b/src/groups.cc
@@ -205,6 +205,16 @@ units of m^5 molec^(-2)
   wsv_groups.emplace_back("CallbackFunction",
                           "Used to inject custom code into *Agenda*\n");
 
+  wsv_groups.emplace_back("CallbackOperator",
+                          R"--(Used to inject custom code into *Agenda*
+
+Unlike *CallbackFunction*, this type also holds information about the inputs and outputs
+of the custom code.  This is used to create a new limited scope workspace for the custom
+code to run in.
+
+FIXME: ADD DETAILS
+)--");
+
   wsv_groups.emplace_back("CovarianceMatrix", "A covariance matrix\n");
 
   wsv_groups.emplace_back("EnergyLevelMap",

--- a/src/m_callback.cc
+++ b/src/m_callback.cc
@@ -1,3 +1,5 @@
+#include <exception>
+#include <stdexcept>
 #include "callback.h"
 #include "messages.h"
 
@@ -5,4 +7,12 @@ void CallbackFunctionExecute(Workspace& ws,
                              const CallbackFunction& function,
                              const Verbosity&) {
   function(ws);
+}
+
+void CallbackOperatorExecute(Workspace& ws,
+                             const CallbackOperator& op,
+                             const Verbosity&) try {
+  op(ws);
+} catch (std::exception& e) {
+  throw std::runtime_error(var_string(e.what(), "\n\n", op));
 }

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -622,6 +622,25 @@ void define_md_data_raw() {
       PASSWSVNAMES(false)));
 
   md_data_raw.push_back(create_mdrecord(
+      NAME("CallbackOperatorExecute"),
+      DESCRIPTION("Execute any code keeping the workspace safe\n"),
+      AUTHORS("Richard Larsson"),
+      OUT(),
+      GOUT(),
+      GOUT_TYPE(),
+      GOUT_DESC(),
+      IN(),
+      GIN("op"),
+      GIN_TYPE("CallbackOperator"),
+      GIN_DEFAULT(NODEF),
+      GIN_DESC("This will execute the callback operator"),
+      SETMETHOD(false),
+      AGENDAMETHOD(false),
+      USES_TEMPLATES(false),
+      PASSWORKSPACE(true),
+      PASSWSVNAMES(false)));
+
+  md_data_raw.push_back(create_mdrecord(
       NAME("CheckUnique"),
       DESCRIPTION(
           "Checks that *abs_lines* contains only unique absorption lines\n"),

--- a/src/python_interface/CMakeLists.txt
+++ b/src/python_interface/CMakeLists.txt
@@ -100,6 +100,7 @@ pybind11_add_module(pyarts_cpp THIN_LTO
     py_options.cpp
     py_hitran.cpp
     py_fwd.cpp
+    py_callback.cpp
 
     pydocs.cpp
     gen_auto_py_helpers.cpp

--- a/src/python_interface/py_callback.cpp
+++ b/src/python_interface/py_callback.cpp
@@ -22,8 +22,7 @@ void py_callback(py::module_& m) {
       .def(
           "__call__",
           [](const CallbackOperator& cb, Workspace& w) { cb(w); },
-          py::arg("ws"),
-          py::is_operator())
+          py::arg("ws"))
       .PythonInterfaceWorkspaceDocumentation(CallbackOperator);
 }
 }  // namespace Python

--- a/src/python_interface/py_callback.cpp
+++ b/src/python_interface/py_callback.cpp
@@ -1,0 +1,22 @@
+#include <callback.h>
+#include <pybind11/pybind11.h>
+
+#include "py_macros.h"
+
+namespace Python {
+void py_callback(py::module_& m) {
+  py::class_<CallbackOperator>(m, "CallbackOperator")
+      .def(py::init<>())
+      .def(py::init<std::function<void(Workspace&)>,
+                    std::vector<std::string>,
+                    std::vector<std::string>>(),
+           py::arg("fn"),
+           py::arg("inputs"),
+           py::arg("outputs"))
+      .PythonInterfaceCopyValue(CallbackOperator)
+      .PythonInterfaceBasicRepresentation(CallbackOperator)
+      .PythonInterfaceFileIO(CallbackOperator)
+      .def("__call__", &CallbackOperator::operator(), py::arg("ws"))
+      ;
+}
+}  // namespace Python

--- a/src/python_interface/py_callback.cpp
+++ b/src/python_interface/py_callback.cpp
@@ -1,5 +1,8 @@
 #include <callback.h>
+#include <pybind11/attr.h>
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include "py_macros.h"
 
@@ -7,7 +10,7 @@ namespace Python {
 void py_callback(py::module_& m) {
   py::class_<CallbackOperator>(m, "CallbackOperator")
       .def(py::init<>())
-      .def(py::init<std::function<void(Workspace&)>,
+      .def(py::init<std::function<void(std::shared_ptr<Workspace>)>,
                     std::vector<std::string>,
                     std::vector<std::string>>(),
            py::arg("fn"),
@@ -16,7 +19,11 @@ void py_callback(py::module_& m) {
       .PythonInterfaceCopyValue(CallbackOperator)
       .PythonInterfaceBasicRepresentation(CallbackOperator)
       .PythonInterfaceFileIO(CallbackOperator)
-      .def("__call__", &CallbackOperator::operator(), py::arg("ws"))
-      ;
+      .def(
+          "__call__",
+          [](const CallbackOperator& cb, Workspace& w) { cb(w); },
+          py::arg("ws"),
+          py::is_operator())
+      .PythonInterfaceWorkspaceDocumentation(CallbackOperator);
 }
 }  // namespace Python

--- a/src/python_interface/py_module.cpp
+++ b/src/python_interface/py_module.cpp
@@ -44,6 +44,7 @@ void py_math(py::module_& m);
 void py_options(py::module_& m);
 void py_hitran(py::module_& m);
 void py_fwd(py::module_& m);
+void py_callback(py::module_& m);
 
 /** Construct a new pybind11 module object to hold all the Arts types and functions
  * 
@@ -134,6 +135,7 @@ PYBIND11_MODULE(arts, m) {
   py_star(m);
   py_agenda(m);
   py_fwd(m);
+  py_callback(m);
 
   // Must be last, it contains automatic conversion operations
   py_workspace(m, ws, wsv);

--- a/src/workspace_ng.h
+++ b/src/workspace_ng.h
@@ -178,6 +178,10 @@ class Workspace final : public std::enable_shared_from_this<Workspace> {
     return nullptr;
   }
 
+  std::tuple<WorkspaceVariableStruct, WsvRecord> copy_wsv(std::string_view) const;
+
+  void set_wsv(const std::tuple<WorkspaceVariableStruct, WsvRecord>&);
+
   /** Swap with another workspace */
   void swap(Workspace &other) noexcept;
 

--- a/src/xml_io_arts_types.h
+++ b/src/xml_io_arts_types.h
@@ -146,6 +146,7 @@ TMPL_XML_READ_WRITE_STREAM(ArrayOfVector)
 
 TMPL_XML_READ_WRITE_STREAM(CallbackFunction)
 TMPL_XML_READ_WRITE_STREAM(SpectralRadianceProfileOperator)
+TMPL_XML_READ_WRITE_STREAM(CallbackOperator)
 
 //==========================================================================
 

--- a/src/xml_io_compound_types.cc
+++ b/src/xml_io_compound_types.cc
@@ -2347,3 +2347,20 @@ void xml_write_to_stream(ostream&,
                          const Verbosity&) {
   ARTS_USER_ERROR("Method not implemented!");
 }
+
+//=== CallbackOperator =========================================
+
+void xml_read_from_stream(istream&,
+                          CallbackOperator&,
+                          bifstream* /* pbifs */,
+                          const Verbosity&) {
+  ARTS_USER_ERROR("Method not implemented!");
+}
+
+void xml_write_to_stream(ostream&,
+                         const CallbackOperator&,
+                         bofstream* /* pbofs */,
+                         const String& /* name */,
+                         const Verbosity&) {
+  ARTS_USER_ERROR("Method not implemented!");
+}


### PR DESCRIPTION
This adds a callback operator type to Arts.  This is a safer way of wrapping python callbacks.  There are still probably a few details to work through.

Here is a basic example:

```python3
from pyarts.workspace import Workspace, callback_operator
import pyarts.arts as cxx

@callback_operator
def test(a, b):
    print("oi")
    b += 3
    a += 3
    atmosphere_dim = b
    return atmosphere_dim, a

ws = Workspace()
ws.a = cxx.Index(1)
ws.b = cxx.Index(2)

assert not ws.atmosphere_dim.init
assert ws.a.value == 1
assert ws.b.value == 2

test(ws)

assert ws.a.value == 4
assert ws.b.value == 2
assert ws.atmosphere_dim.value == 5
```

As this test shows, you can add custom named variables.  You can also add pure workspace variables that are apparently unrelated.  It will deal with the outputs and inputs for you.  If you need to rename inputs or outputs, you can do so by using the arguments provided by `callback_operator`.  This all still needs some more tests but I want to know if the general idea is acceptable.