### PR TITLE
Update getting-started page

### DIFF
--- a/examples/getting-started/README.rst
+++ b/examples/getting-started/README.rst
@@ -16,3 +16,7 @@ To date it consists of
    and its variables can be set and accessed.
 2. Clearsky radiance --- shows some examples of how to set up
    pyarts to run clearsky simulations.
+
+Once you're familiar with the basics, have a look at
+:doc:`the other examples <examples>` which demonstrate more ARTS
+features.

--- a/python/doc/source/getting.started.rst
+++ b/python/doc/source/getting.started.rst
@@ -1,7 +1,1 @@
-Getting started
-===============
-
-We recommend starting with the :doc:`"Getting-started" <examples.getting-started>` section
-under :doc:`"Examples" <examples>` to get started with pyarts. These guides are run as part
-of our continous integration process, so they should always be up to date.
-
+.. include:: examples.getting-started.rst 


### PR DESCRIPTION
Display the `getting-started` page directly on the top-level with
no additional link indirection and add a link to the other examples.