### PR TITLE
Add CMake presets and conda environment configurations

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,109 @@
+{
+  "version": 2,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "base-default",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "1",
+        "CMAKE_INSTALL_PREFIX": "$env{HOME}/arts_install",
+        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
+        "ENABLE_ARTS_LGPL": "0",
+        "ENABLE_FORTRAN": "1",
+        "ENABLE_GUI": "0",
+        "ENABLE_NETCDF": "0",
+        "ENABLE_PCH": "0",
+        "FASTWIGNER": "0",
+        "NO_FASTEM": "0",
+        "NO_OPENMP": "0",
+        "NO_RT4": "0",
+        "NO_TMATRIX": "0",
+        "SPHINX_JOBS": "4",
+        "TEST_JOBS": "4"
+      }
+    },
+    {
+      "name": "default-gcc-mamba",
+      "inherits": "base-default",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "$env{CONDA_PREFIX}/bin/g++",
+        "CMAKE_C_COMPILER": "$env{CONDA_PREFIX}/bin/gcc",
+        "CMAKE_Fortran_COMPILER": "$env{CONDA_PREFIX}/bin/gfortran"
+      },
+      "environment": {
+        "CFLAGS": "-isystem $env{CONDA_PREFIX}/include",
+        "CPPFLAGS": "$env{CFLAGS}",
+        "CXXFLAGS": "$env{CFLAGS}",
+        "FFLAGS": "$env{CFLAGS}",
+        "LDFLAGS": "-L$env{CONDA_PREFIX}/lib -Wl,-rpath,$env{CONDA_PREFIX}/lib"
+      }
+    },
+    {
+      "name": "perf-gcc-mamba",
+      "inherits": "default-gcc-mamba",
+      "environment": {
+        "CFLAGS": "-isystem $env{CONDA_PREFIX}/include -fno-omit-frame-pointer",
+        "CXXFLAGS": "$env{CFLAGS}"
+      }
+    },
+    {
+      "name": "default-clang-mamba",
+      "inherits": "default-gcc-mamba",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "$env{CONDA_PREFIX}/bin/clang++",
+        "CMAKE_C_COMPILER": "$env{CONDA_PREFIX}/bin/clang",
+        "CMAKE_Fortran_COMPILER": "$env{CONDA_PREFIX}/bin/gfortran",
+        "ENABLE_PCH": "1"
+      }
+    },
+    {
+      "name": "mac-gcc13-hb-mamba",
+      "inherits": "default-gcc-mamba",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "gcc-13",
+        "CMAKE_CXX_COMPILER": "g++-13",
+        "CMAKE_Fortran_COMPILER": "gfortran-13",
+        "ENABLE_PCH": "0"
+      }
+    },
+    {
+      "name": "macm1-clang-hb-mamba",
+      "inherits": "default-gcc-mamba",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "/opt/homebrew/opt/llvm/bin/clang++",
+        "CMAKE_C_COMPILER": "/opt/homebrew/opt/llvm/bin/clang",
+        "CMAKE_Fortran_COMPILER": "gfortran-13",
+        "ENABLE_PCH": "1"
+      }
+    },
+    {
+      "name": "macintel-clang-hb-mamba",
+      "inherits": "default-gcc-mamba",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "/usr/local/opt/llvm/bin/clang++",
+        "CMAKE_C_COMPILER": "/usr/local/opt/llvm/bin/clang",
+        "CMAKE_Fortran_COMPILER": "gfortran-13"
+      }
+    },
+    {
+      "name": "levante-gcc-mamba",
+      "inherits": "base-default",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "/sw/spack-levante/gcc-11.2.0-bcn7mb/bin/gcc",
+        "CMAKE_CXX_COMPILER": "/sw/spack-levante/gcc-11.2.0-bcn7mb/bin/g++",
+        "CMAKE_Fortran_COMPILER": "/sw/spack-levante/gcc-11.2.0-bcn7mb/bin/gfortran",
+        "CMAKE_PREFIX_PATH": "",
+        "BLAS_blas_LIBRARY": "/sw/spack-levante/openblas-0.3.18-mzclcq/lib/libopenblas.so"
+      }
+    }
+  ]
+}

--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -1,0 +1,43 @@
+name: pyarts-dev
+dependencies:
+        - python=3.10
+        - binutils
+        - build
+        - ccache
+        - clang
+        - clangxx
+        - cmake
+        - docutils
+        - gcc
+        - gfortran
+        - glew
+        - glfw
+        - gmp
+        - gxx
+        - lark-parser
+        - libclang
+        - libcxx
+        - libmicrohttpd
+        - llvm-openmp
+        - matplotlib
+        - netcdf4
+        - numpy
+        - pkg-config
+        - pytest
+        - scipy
+        - sphinx>=6
+        - sphinx_rtd_theme
+        - xarray
+        - zlib
+        - mesa-libgl-devel-cos7-x86_64
+        - libselinux-cos7-x86_64
+        - libglvnd-glx-cos7-x86_64
+        - libxext-cos7-x86_64
+        - libxdamage-cos7-x86_64
+        - libxcb-cos7-x86_64
+        - libxfixes-cos7-x86_64
+        - libxxf86vm-cos7-x86_64
+        - libxau-cos7-x86_64
+        - expat-cos7-x86_64
+channels:
+        - conda-forge

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -1,0 +1,29 @@
+name: pyarts-dev
+dependencies:
+        - python=3.10
+        - build
+        - ccache
+        - clang
+        - clangxx
+        - cmake
+        - docutils
+        - gfortran
+        - glew
+        - glfw
+        - lark-parser
+        - libclang
+        - libcxx
+        - libmicrohttpd
+        - llvm-openmp
+        - matplotlib
+        - netcdf4
+        - numpy
+        - pkg-config
+        - pytest
+        - scipy
+        - sphinx>=6
+        - sphinx_rtd_theme
+        - xarray
+        - zlib
+channels:
+        - conda-forge


### PR DESCRIPTION
This PR adds CMake presets for easier build configuration.
It also provides conda environment yaml files to easily create an ARTS development environment.
The `README.md` has been updated accordingly.

Presets are provided for mambaforge based builds with gcc (Linux) and clang (macOS+Linux), for macOS builds with homebrew compilers and for compilation on the DKRZ Levante system.