### PR TITLE
Use GCC 13 for macOS CI build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -17,7 +17,7 @@ jobs:
           ubuntu-gcc-12-debug,
           ubuntu-clang-15-nofortran,
           ubuntu-clang-16-nofortran,
-          macos-gcc-12,
+          macos-gcc-13,
           macos-clang-16,
         ]
 
@@ -91,14 +91,14 @@ jobs:
             libcxx: "yes"
             buildtype: "Release"
 
-          - name: macos-gcc-12
+          - name: macos-gcc-13
             os: macos-11
             compiler: gcc
-            version: "12"
+            version: "13"
             doc: "no"
             arts: "yes"
             fortran: "yes"
-            fortran-version: "12"
+            fortran-version: "13"
             check: "yes"
             libcxx: "no"
             buildtype: "Release"


### PR DESCRIPTION
Cover all GCC versions from 11 to 13 in the CI builds.