### PR TITLE
add surfaceFlatRvRhEvEh

### DIFF
--- a/controlfiles/CMakeLists.txt
+++ b/controlfiles/CMakeLists.txt
@@ -67,6 +67,7 @@ arts_test_run_ctlfile(fast artscomponents/transmission/TestTransmissionWithScat.
 arts_test_run_ctlfile(fast artscomponents/surfacetypes/TestSurfaceTypes.arts)
 
 arts_test_run_ctlfile(fast artscomponents/surface/TestTessem.arts)
+arts_test_run_ctlfile(fast artscomponents/surface/TestSurfaceFlatRvRhEvEh.arts)
 
 arts_test_run_ctlfile(fast artscomponents/faraday/TestFaradayRotation.arts)
 

--- a/controlfiles/artscomponents/surface/TestSurfaceFlatRvRhEvEh.arts
+++ b/controlfiles/artscomponents/surface/TestSurfaceFlatRvRhEvEh.arts
@@ -1,0 +1,27 @@
+Arts2 {
+
+VectorSet(f_grid, [10.65e9, 18.7e9, 36.5e9])
+IndexSet(stokes_dim, 4)
+
+IndexSet(atmosphere_dim, 1)
+
+VectorSet(rtp_pos, [5])
+VectorSet(rtp_los, [127])
+VectorSet(specular_los, [53])
+NumericSet(surface_skin_t, 280)
+MatrixSet(surface_rv_rh, [0.4, 0.6; 0.3, 0.5; 0.2, 0.4])
+MatrixCreate(surface_ev_eh)
+MatrixSet(surface_ev_eh, [0.6, 0.4; 0.7, 0.5; 0.8, 0.6])
+
+MatrixCreate(REFsurface_los)
+Tensor4Create(REFsurface_rmatrix)
+MatrixCreate(REFsurface_emission)
+surfaceFlatRvRh(surface_los=REFsurface_los, surface_rmatrix=REFsurface_rmatrix, surface_emission=REFsurface_emission)
+
+surfaceFlatRvRhEvEh(surface_ev_eh=surface_ev_eh)
+
+Compare(REFsurface_los, surface_los, 1e-6)
+Compare(REFsurface_rmatrix, surface_rmatrix, 1e-6)
+Compare(REFsurface_emission, surface_emission, 1e-6)
+
+}

--- a/src/m_surface.cc
+++ b/src/m_surface.cc
@@ -2564,18 +2564,18 @@ void surfaceFlatRvRh(Matrix& surface_los,
 
 /* Workspace method: Doxygen documentation will be auto-generated */
 void surfaceFlatRvRhEvEh(Matrix& surface_los,
-                     Tensor4& surface_rmatrix,
-                     Matrix& surface_emission,
-                     const Vector& f_grid,
-                     const Index& stokes_dim,
-                     const Index& atmosphere_dim,
-                     const Vector& rtp_pos,
-                     const Vector& rtp_los,
-                     const Vector& specular_los,
-                     const Numeric& surface_skin_t,
-                     const Matrix& surface_rv_rh,
-                     const Matrix& surface_ev_eh,
-                     const Verbosity&) {
+                         Tensor4& surface_rmatrix,
+                         Matrix& surface_emission,
+                         const Vector& f_grid,
+                         const Index& stokes_dim,
+                         const Index& atmosphere_dim,
+                         const Vector& rtp_pos,
+                         const Vector& rtp_los,
+                         const Vector& specular_los,
+                         const Numeric& surface_skin_t,
+                         const Matrix& surface_rv_rh,
+                         const Matrix& surface_ev_eh,
+                         const Verbosity&) {
   chk_if_in_range("atmosphere_dim", atmosphere_dim, 1, 3);
   chk_if_in_range("stokes_dim", stokes_dim, 1, 4);
   chk_rte_pos(atmosphere_dim, rtp_pos);

--- a/src/m_surface.cc
+++ b/src/m_surface.cc
@@ -2563,6 +2563,112 @@ void surfaceFlatRvRh(Matrix& surface_los,
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
+void surfaceFlatRvRhEvEh(Matrix& surface_los,
+                     Tensor4& surface_rmatrix,
+                     Matrix& surface_emission,
+                     const Vector& f_grid,
+                     const Index& stokes_dim,
+                     const Index& atmosphere_dim,
+                     const Vector& rtp_pos,
+                     const Vector& rtp_los,
+                     const Vector& specular_los,
+                     const Numeric& surface_skin_t,
+                     const Matrix& surface_rv_rh,
+                     const Matrix& surface_ev_eh,
+                     const Verbosity&) {
+  chk_if_in_range("atmosphere_dim", atmosphere_dim, 1, 3);
+  chk_if_in_range("stokes_dim", stokes_dim, 1, 4);
+  chk_rte_pos(atmosphere_dim, rtp_pos);
+  chk_rte_los(atmosphere_dim, rtp_los);
+  chk_rte_los(atmosphere_dim, specular_los);
+  chk_not_negative("surface_skin_t", surface_skin_t);
+
+  const Index nf = f_grid.nelem();
+
+  // check for surface_rv_rh
+  if (surface_rv_rh.ncols() != 2) {
+    ostringstream os;
+    os << "The number of columns in *surface_rv_rh* must be two,\n"
+       << "but the actual number of columns is " << surface_rv_rh.ncols()
+       << "\n";
+    throw runtime_error(os.str());
+  }
+
+  if (surface_rv_rh.nrows() != nf && surface_rv_rh.nrows() != 1) {
+    ostringstream os;
+    os << "The number of rows in *surface_rv_rh* should\n"
+       << "match length of *f_grid* or be 1."
+       << "\n length of *f_grid* : " << nf
+       << "\n rows in *surface_rv_rh* : " << surface_rv_rh.nrows() << "\n";
+    throw runtime_error(os.str());
+  }
+
+  if (min(surface_rv_rh) < 0 || max(surface_rv_rh) > 1) {
+    throw runtime_error("All values in *surface_rv_rh* must be inside [0,1].");
+  }
+
+  // check for surface_ev_eh
+  if (surface_ev_eh.ncols() != 2) {
+    ostringstream os;
+    os << "The number of columns in *surface_ev_eh* must be two,\n"
+       << "but the actual number of columns is " << surface_ev_eh.ncols()
+       << "\n";
+    throw runtime_error(os.str());
+  }
+
+  if (surface_ev_eh.nrows() != nf && surface_ev_eh.nrows() != 1) {
+    ostringstream os;
+    os << "The number of rows in *surface_ev_eh* should\n"
+       << "match length of *f_grid* or be 1."
+       << "\n length of *f_grid* : " << nf
+       << "\n rows in *surface_ev_eh* : " << surface_ev_eh.nrows() << "\n";
+    throw runtime_error(os.str());
+  }
+
+  if (min(surface_ev_eh) < 0 || max(surface_ev_eh) > 1) {
+    throw runtime_error("All values in *surface_ev_eh* must be inside [0,1].");
+  }
+
+  surface_los.resize(1, specular_los.nelem());
+  surface_los(0, joker) = specular_los;
+
+  surface_emission.resize(nf, stokes_dim);
+  surface_rmatrix.resize(1, nf, stokes_dim, stokes_dim);
+
+  surface_emission = 0;
+  surface_rmatrix = 0;
+
+  Vector b(nf);
+  planck(b, f_grid, surface_skin_t);
+
+  Numeric rmean = 0.0, rdiff = 0.0, emean = 0.0, ediff = 0.0;
+
+  for (Index iv = 0; iv < nf; iv++) {
+    if (iv == 0 || surface_rv_rh.nrows() > 1) {
+      rmean = 0.5 * (surface_rv_rh(iv, 0) + surface_rv_rh(iv, 1));
+      rdiff = 0.5 * (surface_rv_rh(iv, 0) - surface_rv_rh(iv, 1));
+      emean = 0.5 * (surface_ev_eh(iv, 0) + surface_ev_eh(iv, 1));
+      ediff = 0.5 * (surface_ev_eh(iv, 0) - surface_ev_eh(iv, 1));
+    }
+
+    surface_emission(iv, 0) = emean * b[iv];
+    surface_rmatrix(0, iv, 0, 0) = rmean;
+
+    if (stokes_dim > 1) {
+      surface_emission(iv, 1) = ediff * b[iv];
+
+      surface_rmatrix(0, iv, 0, 1) = rdiff;
+      surface_rmatrix(0, iv, 1, 0) = rdiff;
+      surface_rmatrix(0, iv, 1, 1) = rmean;
+
+      for (Index i = 2; i < stokes_dim; i++) {
+        surface_rmatrix(0, iv, i, i) = rmean;
+      }
+    }
+  }
+}
+
+/* Workspace method: Doxygen documentation will be auto-generated */
 void surfaceFlatScalarReflectivity(Matrix& surface_los,
                                    Tensor4& surface_rmatrix,
                                    Matrix& surface_emission,

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -20022,6 +20022,35 @@ where N>=0 and the species name is something line "H2O".
       GIN_DESC()));
 
   md_data_raw.push_back(create_mdrecord(
+      NAME("surfaceFlatRvRhEvEh"),
+      DESCRIPTION(
+          "Creates variables to mimic specular reflection by a (flat) surface\n"
+          "where *surface_rv_rh* and surface_ev_eh is specified.\n"
+          "\n"
+          "This method is similar to *surfaceFlatRvRh*, but surface_ev_eh is also\n"
+          "specified. In *surfaceFlatRvRh*, ev(eh) = 1 - rv(rh). However, the\n"
+          "reflectivity calculated by Fastem and SURFEM-Ocean is corrected by\n"
+          "the anisotropic downward radiation. Therefore, This method is suitable\n"
+          "for providing both emissivity and reflectivity externally.\n"),
+      AUTHORS("Shaofei Wang"),
+      OUT("surface_los", "surface_rmatrix", "surface_emission"),
+      GOUT(),
+      GOUT_TYPE(),
+      GOUT_DESC(),
+      IN("f_grid",
+         "stokes_dim",
+         "atmosphere_dim",
+         "rtp_pos",
+         "rtp_los",
+         "specular_los",
+         "surface_skin_t",
+         "surface_rv_rh"),
+      GIN("surface_ev_eh"),
+      GIN_TYPE("Matrix"),
+      GIN_DEFAULT(NODEF),
+      GIN_DESC("Surface emissivity, for a given position and angle.")));
+
+  md_data_raw.push_back(create_mdrecord(
       NAME("surfaceFlatScalarReflectivity"),
       DESCRIPTION(
           "Creates variables to mimic specular reflection by a (flat) surface\n"


### PR DESCRIPTION
Hi, all

In this PR, i add a WSM `surfaceFlatRvRhEvEh`.

This method can calculate `surface_rmatrix `and `surface_emission` when emissivity and reflectance are provided externally.

The reason to add this method is that `e+r≠1` in some sea surface emissivity model (such as Fastem and SURFEM-Ocean). 

This method is similar to `surfaceFlatRvRh`, but `surface_ev_eh` is also need specified.