### PR TITLE
Fix istream unget bug

### DIFF
--- a/src/double_imanip.cc
+++ b/src/double_imanip.cc
@@ -1,0 +1,44 @@
+#include "double_imanip.h"
+
+#include <fast_float/fast_float.h>
+
+#include <ios>
+#include <system_error>
+
+#include "debug.h"
+
+const double_imanip& double_imanip::operator>>(double& x) const {
+  std::istream& is = *in;
+  std::string buf;
+
+  // Read to the buffer
+  is >> buf;
+  ARTS_USER_ERROR_IF(is.fail(), "Cannot read from stream")
+
+  // Actual conversion
+  const auto res =
+      fast_float::from_chars(buf.c_str(), buf.c_str() + buf.size(), x);
+
+  // Error (only std::errc::invalid_argument possible)
+  ARTS_USER_ERROR_IF(res.ec == std::errc::invalid_argument,
+                     "The argument: \n\n'",
+                     buf,
+                     R"--('
+
+is not convertible to a valid double.  At the very least it
+cannot be converted to one using the standard string-to-double
+routine
+)--")
+
+  if (!is.eof() && is.tellg() != -1) {
+    is.seekg(std::distance(buf.c_str(), res.ptr) - buf.size(),
+             std::ios_base::cur);
+  } else {
+    // Use alternative method for non-seekable files
+    // This is known to break in very rare cases on macOS with Clang
+    std::size_t n = std::distance(buf.c_str(), res.ptr);
+    while (n++ < buf.size()) is.unget();
+  }
+
+  return *this;
+}

--- a/src/double_imanip.h
+++ b/src/double_imanip.h
@@ -13,46 +13,11 @@
 #ifndef double_imanip_h
 #define double_imanip_h
 
-#include <fstream>
-#include <limits>
-#include <stdexcept>
-
-#include "debug.h"
-
-#include <fast_float/fast_float.h>
-
 /** Input manipulator class for doubles to enable nan and inf parsing. */
+#include <istream>
 class double_imanip {
  public:
-  const double_imanip& operator>>(double& x) const {
-    std::istream& is = *in;
-    std::string buf;
-
-    // Read to the buffer
-    is >> buf;
-    ARTS_USER_ERROR_IF(is.fail(), "Cannot read from stream")
-
-    // Actual conversion
-    const auto res =
-        fast_float::from_chars(buf.c_str(), buf.c_str() + buf.size(), x);
-
-    // Error (only std::errc::invalid_argument possible)
-    ARTS_USER_ERROR_IF(res.ec == std::errc::invalid_argument,
-                       "The argument: \n\n'",
-                       buf,
-                       R"--('
-
-is not convertible to a valid double.  At the very least it
-cannot be converted to one using the standard string-to-double
-routine
-)--")
-
-    // Put the stream to be where it is supposed to be
-    std::size_t n = std::distance(buf.c_str(), res.ptr);
-    while (n++ < buf.size()) is.unget();
-
-    return *this;
-  }
+  const double_imanip& operator>>(double& x) const;
 
   std::istream& operator>>(const double_imanip&) const { return *in; }
 

--- a/src/matpack/CMakeLists.txt
+++ b/src/matpack/CMakeLists.txt
@@ -1,4 +1,12 @@
-add_library(matpack STATIC lin_alg.cc logic.cc propagationmatrix.cc matpack_math.cc matpack_sparse.cc rational.cc)
+add_library( matpack STATIC
+  lin_alg.cc
+  logic.cc
+  propagationmatrix.cc
+  matpack_math.cc
+  matpack_sparse.cc
+  rational.cc
+  ../double_imanip.cc
+)
 target_link_libraries(matpack PRIVATE ${LAPACK_LIBRARIES})
 target_include_directories(matpack PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_include_directories(matpack PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")


### PR DESCRIPTION
Use seekg instead of unget to move around while parsing XML files. Unget could lead to unexpected failures in rare cases as reported by @m-brath. So far, only happened on macOS with Clang for one particular file.

The fix requires the input stream to be seekable. Therefore, gzipped xml files will still be read with the old method.

Also move implementation of double_imanip to cc file.