### PR TITLE
Fix environment for macOS build

### DIFF
--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -1,7 +1,7 @@
 dependencies:
         - build
         - ccache
-        - clang
+        - clang=16.*
         - clangxx
         - cmake
         - docutils
@@ -9,7 +9,7 @@ dependencies:
         - glew
         - glfw
         - lark-parser
-        - libclang
+        - libclang=16.*
         - libcxx
         - libmicrohttpd
         - llvm-openmp


### PR DESCRIPTION
Force clang16 for now. clang17 build fails, presumably due to libc++17 package not yet available in conda-forge.