### PR TITLE
Fix a problem with references when using shared-ptrs

### DIFF
--- a/src/python_interface/gen_auto_py.cpp
+++ b/src/python_interface/gen_auto_py.cpp
@@ -186,7 +186,7 @@ std::vector<std::vector<std::string>> supergeneric_types(
 
 std::string method_g_types(const std::string& type) {
   if (type == "Any" or type.find(',') != type.npos) {
-    return "py::object * const";
+    return "py::object";
   }
 
   return fix_type(type);
@@ -1089,10 +1089,10 @@ PyWsvValue from(const WsvValue& x);
 PyWsvValue from(const Wsv& x);
 PyWsvValue from(const std::shared_ptr<Wsv>& x);
 
-Wsv from(py::object * const x);
-Wsv from(const py::object * const x);
+Wsv from(py::object& x);
+Wsv from(const py::object& x);
 
-std::string type(const py::object * const x);
+std::string type(const py::object& x);
 
 template <WorkspaceGroup T>
 std::string type(const T* const);
@@ -1161,11 +1161,11 @@ PyWsvValue from(const std::shared_ptr<Wsv>& x) {
   return from(*x);
 }
 
-Wsv from(const py::object * const x) {
-  if (x == nullptr or x->is_none()) throw std::runtime_error("Cannot convert None to workspace variable.");
+Wsv from(const py::object& x) {
+  if (x.is_none()) throw std::runtime_error("Cannot convert None to workspace variable.");
 
   try {
-    return from(x->cast<PyWsvValue>());
+    return from(x.cast<PyWsvValue>());
   } catch (py::cast_error& ) {
     // Expected error for reference values that has to be copied,
     // but are not copyable by pybind standard.
@@ -1173,15 +1173,15 @@ Wsv from(const py::object * const x) {
     throw;
   }
 
-  py::object y = x->attr("__copy__")();
+  py::object y = x.attr("__copy__")();
   return from(y.cast<PyWsvValue>());
 }
 
-Wsv from(py::object * const x) {
-  if (x == nullptr or x->is_none()) throw std::runtime_error("Cannot convert None to workspace variable.");
+Wsv from(py::object& x) {
+  if (x.is_none()) throw std::runtime_error("Cannot convert None to workspace variable.");
 
   try {
-    return from(x->cast<PyWsvValue>());
+    return from(x.cast<PyWsvValue>());
   } catch (py::cast_error& e) {
     throw std::runtime_error(var_string(
         "Cannot use one of the passed python objects as a workspace variable.\n\n",
@@ -1195,10 +1195,10 @@ Wsv from(py::object * const x) {
   }
 }
 
-std::string type(const py::object * const x) {
-  if (x == nullptr or x->is_none()) return "NoneType";
+std::string type(const py::object& x) {
+  if (x.is_none()) return "NoneType";
 
-  return py::str(x->get_type()).cast<std::string>();
+  return py::str(x.get_type()).cast<std::string>();
 }
 }  // namespace Python
 )--";

--- a/src/python_interface/python_interface.h
+++ b/src/python_interface/python_interface.h
@@ -122,14 +122,14 @@ template <WorkspaceGroup T, PythonWorkspaceGroup U>
 T& select_out(std::optional<U* const>& x,
               Workspace& ws,
               const char* const name) {
-  return x ? *x.value() : ws.get_or<T>(name);
+  return (x and x.value()) ? *x.value() : ws.get_or<T>(name);
 }
 
 template <WorkspaceGroup T>
 T& select_out(std::optional<ValueHolder<T>* const>& x,
               Workspace& ws,
               const char* const name) {
-  return x ? static_cast<T&>(*x.value()) : ws.get_or<T>(name);
+  return (x and x.value()) ? static_cast<T&>(*x.value()) : ws.get_or<T>(name);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -137,17 +137,17 @@ T& select_out(std::optional<ValueHolder<T>* const>& x,
 
 template <WorkspaceGroup T, PythonWorkspaceGroup U>
 T& select_gout(std::optional<U* const>& x, const char* const name) {
-  return x ? *x.value()
-           : throw std::runtime_error(
-                 var_string("Unknown ouput: ", std::quoted(name)));
+  return (x and x.value()) ? *x.value()
+                           : throw std::runtime_error(var_string(
+                                 "Unknown ouput: ", std::quoted(name)));
 }
 
 template <WorkspaceGroup T>
 T& select_gout(std::optional<ValueHolder<T>* const>& x,
                const char* const name) {
-  return x ? *x.value()
-           : throw std::runtime_error(
-                 var_string("Unknown ouput: ", std::quoted(name)));
+  return (x and x.value()) ? *x.value()
+                           : throw std::runtime_error(var_string(
+                                 "Unknown ouput: ", std::quoted(name)));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -157,14 +157,14 @@ template <WorkspaceGroup T, PythonWorkspaceGroup U>
 T& select_inout(std::optional<U* const> x,
                 const Workspace& ws,
                 const char* const name) {
-  return x ? *x.value() : ws.get<T>(name);
+  return (x and x.value()) ? *x.value() : ws.get<T>(name);
 }
 
 template <WorkspaceGroup T>
 T& select_inout(std::optional<ValueHolder<T>* const>& x,
                 const Workspace& ws,
                 const char* const name) {
-  return x ? static_cast<T&>(*x.value()) : ws.get<T>(name);
+  return (x and x.value()) ? static_cast<T&>(*x.value()) : ws.get<T>(name);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -174,14 +174,15 @@ template <WorkspaceGroup T, PythonWorkspaceGroup U>
 const T& select_in(const std::optional<const U* const>& x,
                    const Workspace& ws,
                    const char* const name) {
-  return x ? *x.value() : ws.get<T>(name);
+  return (x and x.value()) ? *x.value() : ws.get<T>(name);
 }
 
 template <WorkspaceGroup T>
 const T& select_in(const std::optional<const ValueHolder<T>* const>& x,
                    const Workspace& ws,
                    const char* const name) {
-  return x ? static_cast<const T&>(*x.value()) : ws.get<T>(name);
+  return (x and x.value()) ? static_cast<const T&>(*x.value())
+                           : ws.get<T>(name);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -190,28 +191,28 @@ const T& select_in(const std::optional<const ValueHolder<T>* const>& x,
 template <WorkspaceGroup T, PythonWorkspaceGroup U>
 const T& select_gin(const std::optional<const U* const>& x,
                     const char* const name) {
-  return x ? *x.value()
-           : throw std::runtime_error(
-                 var_string("Unknown input: ", std::quoted(name)));
+  return (x and x.value()) ? *x.value()
+                           : throw std::runtime_error(var_string(
+                                 "Unknown input: ", std::quoted(name)));
 }
 
 template <WorkspaceGroup T>
 const T& select_gin(const std::optional<const ValueHolder<T>* const>& x,
                     const char* const name) {
-  return x ? *x.value()
-           : throw std::runtime_error(
-                 var_string("Unknown input: ", std::quoted(name)));
+  return (x and x.value()) ? *x.value()
+                           : throw std::runtime_error(var_string(
+                                 "Unknown input: ", std::quoted(name)));
 }
 
 template <WorkspaceGroup T, PythonWorkspaceGroup U>
 const T& select_gin(const std::optional<const U* const>& x, const T& defval) {
-  return x ? *x.value() : defval;
+  return (x and x.value()) ? *x.value() : defval;
 }
 
 template <WorkspaceGroup T>
 const T& select_gin(const std::optional<const ValueHolder<T>* const>& x,
                     const T& defval) {
-  return x ? static_cast<const T&>(*x.value()) : defval;
+  return (x and x.value()) ? static_cast<const T&>(*x.value()) : defval;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/python_interface/python_interface.h
+++ b/src/python_interface/python_interface.h
@@ -119,32 +119,33 @@ py::class_<PythonListable, std::shared_ptr<PythonListable>> artsarray(
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <WorkspaceGroup T, PythonWorkspaceGroup U>
-T& select_out(std::optional<std::shared_ptr<U>>& x,
+T& select_out(std::optional<U* const>& x,
               Workspace& ws,
               const char* const name) {
   return x ? *x.value() : ws.get_or<T>(name);
 }
 
 template <WorkspaceGroup T>
-T& select_out(std::optional<ValueHolder<T>>& x,
+T& select_out(std::optional<ValueHolder<T>* const>& x,
               Workspace& ws,
               const char* const name) {
-  return x ? static_cast<T&>(x.value()) : ws.get_or<T>(name);
+  return x ? static_cast<T&>(*x.value()) : ws.get_or<T>(name);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <WorkspaceGroup T, PythonWorkspaceGroup U>
-T& select_gout(std::optional<std::shared_ptr<U>>& x, const char* const name) {
+T& select_gout(std::optional<U* const>& x, const char* const name) {
   return x ? *x.value()
            : throw std::runtime_error(
                  var_string("Unknown ouput: ", std::quoted(name)));
 }
 
 template <WorkspaceGroup T>
-T& select_gout(std::optional<ValueHolder<T>>& x, const char* const name) {
-  return x ? x.value()
+T& select_gout(std::optional<ValueHolder<T>* const>& x,
+               const char* const name) {
+  return x ? *x.value()
            : throw std::runtime_error(
                  var_string("Unknown ouput: ", std::quoted(name)));
 }
@@ -153,41 +154,41 @@ T& select_gout(std::optional<ValueHolder<T>>& x, const char* const name) {
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <WorkspaceGroup T, PythonWorkspaceGroup U>
-T& select_inout(std::optional<std::shared_ptr<U>>& x,
+T& select_inout(std::optional<U* const> x,
                 const Workspace& ws,
                 const char* const name) {
   return x ? *x.value() : ws.get<T>(name);
 }
 
 template <WorkspaceGroup T>
-T& select_inout(std::optional<ValueHolder<T>>& x,
+T& select_inout(std::optional<ValueHolder<T>* const>& x,
                 const Workspace& ws,
                 const char* const name) {
-  return x ? static_cast<T&>(x.value()) : ws.get<T>(name);
+  return x ? static_cast<T&>(*x.value()) : ws.get<T>(name);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <WorkspaceGroup T, PythonWorkspaceGroup U>
-const T& select_in(const std::optional<const std::shared_ptr<U>>& x,
+const T& select_in(const std::optional<const U* const>& x,
                    const Workspace& ws,
                    const char* const name) {
   return x ? *x.value() : ws.get<T>(name);
 }
 
 template <WorkspaceGroup T>
-const T& select_in(const std::optional<const ValueHolder<T>>& x,
+const T& select_in(const std::optional<const ValueHolder<T>* const>& x,
                    const Workspace& ws,
                    const char* const name) {
-  return x ? static_cast<const T&>(x.value()) : ws.get<T>(name);
+  return x ? static_cast<const T&>(*x.value()) : ws.get<T>(name);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////
 
 template <WorkspaceGroup T, PythonWorkspaceGroup U>
-const T& select_gin(const std::optional<const std::shared_ptr<U>>& x,
+const T& select_gin(const std::optional<const U* const>& x,
                     const char* const name) {
   return x ? *x.value()
            : throw std::runtime_error(
@@ -195,23 +196,22 @@ const T& select_gin(const std::optional<const std::shared_ptr<U>>& x,
 }
 
 template <WorkspaceGroup T>
-const T& select_gin(const std::optional<const ValueHolder<T>>& x,
+const T& select_gin(const std::optional<const ValueHolder<T>* const>& x,
                     const char* const name) {
-  return x ? x.value()
+  return x ? *x.value()
            : throw std::runtime_error(
                  var_string("Unknown input: ", std::quoted(name)));
 }
 
 template <WorkspaceGroup T, PythonWorkspaceGroup U>
-const T& select_gin(const std::optional<const std::shared_ptr<U>>& x,
-                    const T& defval) {
+const T& select_gin(const std::optional<const U* const>& x, const T& defval) {
   return x ? *x.value() : defval;
 }
 
 template <WorkspaceGroup T>
-const T& select_gin(const std::optional<const ValueHolder<T>>& x,
+const T& select_gin(const std::optional<const ValueHolder<T>* const>& x,
                     const T& defval) {
-  return x ? static_cast<const T&>(x.value()) : defval;
+  return x ? static_cast<const T&>(*x.value()) : defval;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/tests/python/can-reference-into-array-into-method.py
+++ b/tests/python/can-reference-into-array-into-method.py
@@ -1,0 +1,19 @@
+"""
+This test exsts because we are using shared pointers in ARTS to deal with the
+workspace but pointers in the method interface to allow ws.method(a=b[0])-like
+constructs.
+
+It used to fail but should clearly work.
+"""
+
+import pyarts
+
+ws = pyarts.Workspace()
+
+ws.specs = pyarts.arts.ArrayOfArrayOfString([["O2"]])
+
+ws.absorption_speciesSet(species=ws.specs[0])
+
+x = pyarts.arts.ArrayOfArrayOfSpeciesTag()
+
+ws.absorption_speciesSet(x, species=ws.specs[0])


### PR DESCRIPTION
This used to fail in various ways:

```python

import pyarts

ws = pyarts.Workspace()

ws.specs = pyarts.arts.ArrayOfArrayOfString([["O2"]])

ws.absorption_speciesSet(species=ws.specs[0])

print("abs: ", ws.absorption_species)

x = pyarts.arts.ArrayOfArrayOfSpeciesTag()

ws.absorption_speciesSet(x, species=ws.specs[0])

print("x: ", x)

ws.propagation_path = [pyarts.arts.PropagationPathPoint()]

ws.spectral_radianceApplyUnit(propagation_path_point=ws.propagation_path[0])

```