### PR TITLE
Include lib file in python installation on Windows

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -65,7 +65,7 @@ setup(
         "docs": ["sphinx_rtd_theme"],
         "tests": ["pytest", "pint", "gdal",],
     },
-    package_data={"": ["*.so"],},
+    package_data={"": ["*.so", "*.pyd"],},
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     include_package_data=True,


### PR DESCRIPTION
ARTS library was not included in pip installation on Windows due to different file extension.