### PR TITLE
V2.6.x disort bugfix

### DIFF
--- a/src/disort.cc
+++ b/src/disort.cc
@@ -656,7 +656,7 @@ void get_pfct(Tensor3& pfct_bulk_par,
       Numeric sca =
           (ext_bulk_par(f_index, ip) + ext_bulk_par(f_index, ip + 1)) -
           (abs_bulk_par(f_index, ip) + abs_bulk_par(f_index, ip + 1));
-      if (std::isnormal(sca)){
+      if (std::isnormal(static_cast<float>(sca))) {
         // Calculate layer averaged Z (omitting factor 0.5) and rescale from
         // Z (Csca) to P (4Pi)
         for (Index ia = 0; ia < nang; ia++)

--- a/src/disort.cc
+++ b/src/disort.cc
@@ -656,7 +656,7 @@ void get_pfct(Tensor3& pfct_bulk_par,
       Numeric sca =
           (ext_bulk_par(f_index, ip) + ext_bulk_par(f_index, ip + 1)) -
           (abs_bulk_par(f_index, ip) + abs_bulk_par(f_index, ip + 1));
-      if (sca != 0.) {
+      if (std::isnormal(sca)){
         // Calculate layer averaged Z (omitting factor 0.5) and rescale from
         // Z (Csca) to P (4Pi)
         for (Index ia = 0; ia < nang; ia++)


### PR DESCRIPTION
Add bugfix for phase function calculation

* The old check did not catch cases if the scattering cross section is greater than zero but so small that the inverse of it results in infinity.