### PR TITLE
[ARTS-2.6] Fix wigner getting stuck

### DIFF
--- a/3rdparty/wigner/wigxjpf/cfg/wigxjpf_config.h
+++ b/3rdparty/wigner/wigxjpf/cfg/wigxjpf_config.h
@@ -60,7 +60,7 @@
  * limited.
  */
 
-#define PRIME_LIST_VECT_SIZE        16
+#define PRIME_LIST_VECT_SIZE        32
 
 /* Size in bytes of each word in multi-word integers.  4 or 8. */
 

--- a/3rdparty/wigner/wigxjpf/cfg/wigxjpf_config.h
+++ b/3rdparty/wigner/wigxjpf/cfg/wigxjpf_config.h
@@ -51,7 +51,7 @@
  * improvements for large symbols, and some 20 % for small symbols.
  */
 
-#define PRIME_LIST_USE_VECTOR       0
+#define PRIME_LIST_USE_VECTOR       1
 
 /* Size in bytes of the vector instances.  SSE: 16, AVX:32 */
 


### PR DESCRIPTION
Wigner gets sometimes stuck in an infinite loop in `pexpo_prime_factor` due to a negative `fpf` being passed in. We don't know why/how these negative values come into existence, but enabling `PRIME_LIST_USE_VECTOR` to use vector types / instructions such as SSE / AVX for the exponents, fixes it. So we go with that for now to fix `TestMolOxyAdaptation`.