### PR TITLE
Generate Python stubs for ARTS library

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ don't use more than 6-8 cores. With 8GB, don't use more than 2-3 cores.
 Development install of the PyARTS Python package:
 
 ```
-python3 -m pip install --user -e build/python
+python3 -m pip install --use-pep517 --config-settings editable_mode=compat --user -e build/python
 ```
 
 You only have to do the python package install once.

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -63,7 +63,7 @@ configure_file(MANIFEST.in MANIFEST.in)
 
 add_custom_target(pyarts
   ALL
-  DEPENDS pyarts_cpp pyarts_copy_python_source_files pyarts_copy_test_python_source_files pyarts_copy_bin_python_source_files
+  DEPENDS pyarts_cpp pyarts_cpp_stub pyarts_copy_python_source_files pyarts_copy_test_python_source_files pyarts_copy_bin_python_source_files
   COMMENT "Updating ARTS python package.")
 add_custom_target(pyarts-package
   ALL

--- a/python/pyarts/workspace/workspace.py
+++ b/python/pyarts/workspace/workspace.py
@@ -25,7 +25,7 @@ _group_types = tuple(eval(f"cxx.{x}") for x in list(cxx.globals.workspace_groups
 _wsvs = cxx.globals.workspace_variables()
 
 
-class Workspace(cxx._Workspace):
+class Workspace(cxx.CxxWorkspace):
     """
     A wrapper for the C++ workspace object
     """

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1,4 +1,4 @@
-""" PyARTS, the Python interface for ARTS
+"""PyARTS, the Python interface for ARTS
 
 PyARTS provides:
 
@@ -7,20 +7,13 @@ PyARTS provides:
 - reading and writing of ARTS XML data files
 """
 
-import logging
-import sys
-import subprocess
-import shutil
-
 # Always prefer setuptools over distutils
 from setuptools import setup, find_packages, Distribution
 
 # To use a consistent encoding
 from codecs import open
-from os import remove, listdir
-from os.path import abspath, dirname, isfile, join, splitext
+from os.path import abspath, dirname, join
 
-import builtins
 
 DOCLINES = (__doc__ or "").split("\n")
 __version__ = open(join("@ARTS_SRC_DIR@", "VERSION")).read().strip()
@@ -30,10 +23,13 @@ STABLE = int(VERSION_TUPLE[1]) % 2 == 0
 
 here = abspath(dirname(__file__))
 
+
 class BinaryDistribution(Distribution):
     """Distribution which always forces a binary package with platform name"""
+
     def has_ext_modules(foo):
         return True
+
 
 setup(
     name="pyarts",
@@ -63,9 +59,15 @@ setup(
     ],
     extras_require={
         "docs": ["sphinx_rtd_theme"],
-        "tests": ["pytest", "pint", "gdal",],
+        "tests": [
+            "pytest",
+            "pint",
+            "gdal",
+        ],
     },
-    package_data={"": ["*.so", "*.pyd"],},
+    package_data={
+        "": ["*.so", "*.pyd"],
+    },
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],
     include_package_data=True,

--- a/src/python_interface/CMakeLists.txt
+++ b/src/python_interface/CMakeLists.txt
@@ -160,3 +160,12 @@ target_include_directories(pyarts_cpp PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 set_target_properties(
     pyarts_cpp PROPERTIES LIBRARY_OUTPUT_DIRECTORY
     "${ARTS_BINARY_DIR}/python/pyarts/")
+
+nanobind_add_stub(
+    pyarts_cpp_stub
+    MODULE arts
+    OUTPUT ${ARTS_BINARY_DIR}/python/pyarts/arts.pyi
+    PYTHON_PATH ${ARTS_BINARY_DIR}/python/pyarts
+    DEPENDS pyarts_cpp
+)
+

--- a/src/python_interface/py_module.cpp
+++ b/src/python_interface/py_module.cpp
@@ -65,7 +65,7 @@ void py_retrieval(py::module_& m);
  */
 NB_MODULE(arts, m) try {
   m.doc() = "Interface directly to the C++ types via python";
-  py::class_<Workspace> ws(m, "_Workspace");
+  py::class_<Workspace> ws(m, "CxxWorkspace");
 
   static bool init = true;
   if (init) {


### PR DESCRIPTION
This enables completion in LSPs (pylance, pylsp, jedi) in IDEs for ARTS types and the ARTS Workspace class.