### PR TITLE
Reenable full windows CI build

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -74,8 +74,8 @@ jobs:
           - name: windows-default-msvc
             os: windows-latest
             preset: default-msvc-conda
-            pyarts: "no"
-            check: "no"
+            pyarts: "yes"
+            check: "yes"
             doc: "no"
             devenv: "environment-dev-win.yml"
             jbuild: 4

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -8,7 +8,7 @@ dependencies:
         - lark-parser
         - libcxx
         - matplotlib
-        - nanobind
+        - nanobind>=2.1.0
         - netcdf4
         - ninja
         - numpy>=2

--- a/src/python_interface/py_agenda.cpp
+++ b/src/python_interface/py_agenda.cpp
@@ -33,7 +33,7 @@ std::filesystem::path correct_include_path(
 
   ARTS_USER_ERROR_IF(not std::filesystem::is_regular_file(path),
                      "Cannot find file: ",
-                     path_copy.c_str(),
+                     path_copy.string(),
                      '\n',
                      "Search path: ",
                      parameters.includepath)


### PR DESCRIPTION
Nanobind 2.1.0 contains a workaround for the MSVC ICE.

One problem remaining is that compiling `py_auto_options.cpp` takes a very loooooooong time.