### PR TITLE
Fix Zeeman state calculations and test them

### DIFF
--- a/controlfiles-python/artscomponents/zeeman/ycalc.py
+++ b/controlfiles-python/artscomponents/zeeman/ycalc.py
@@ -30,8 +30,6 @@ DO_SAVE = False
 
 CF_SAVE = True
 
-DO_PRINT_PPVAR = False
-
 # %% Optional imports
 
 if SHOW_PLOTS:
@@ -66,23 +64,11 @@ arts.Copy(arts.ppath_agenda, ppath_agenda_step_by_step)
 
 arts.mat = pyarts.arts.Matrix()
 
-if DO_PRINT_PPVAR:
-
-    @pyarts.workspace.arts_agenda(ws=arts)
-    def iy_main_agenda_emission(arts):
-        arts.ppathCalc()
-        arts.iyEmissionStandard()
-        arts.zeeman_magnetic_fieldFromPath(arts.mat)
-        arts.Print(arts.mat, 0)
-        arts.VectorSet(arts.geo_pos, [])
-
-else:
-
-    @pyarts.workspace.arts_agenda(ws=arts)
-    def iy_main_agenda_emission(arts):
-        arts.ppathCalc()
-        arts.iyEmissionStandard()
-        arts.VectorSet(arts.geo_pos, [])
+@pyarts.workspace.arts_agenda(ws=arts)
+def iy_main_agenda_emission(arts):
+    arts.ppathCalc()
+    arts.iyEmissionStandard()
+    arts.VectorSet(arts.geo_pos, [])
 
 
 arts.Copy(arts.iy_main_agenda, iy_main_agenda_emission)

--- a/controlfiles-python/artscomponents/zeeman/ycalc.py
+++ b/controlfiles-python/artscomponents/zeeman/ycalc.py
@@ -46,7 +46,7 @@ CENTRAL_LINE_FREQ = 118750348044.712
 SPECTROMETER_HW = 5e6
 
 # %% Silly ARTS-isms
-    
+
 arts.abs_f_interp_order = 100_000_000
 arts.Touch(arts.iy_aux_vars)
 arts.Touch(arts.surface_props_data)
@@ -55,15 +55,19 @@ arts.Touch(arts.transmitter_pos)
 
 # %% Agendas
 
+
 @pyarts.workspace.arts_agenda(ws=arts)
 def ppath_agenda_step_by_step(arts):
     arts.Ignore(arts.rte_pos2)
     arts.ppathStepByStep()
+
+
 arts.Copy(arts.ppath_agenda, ppath_agenda_step_by_step)
 
 arts.mat = pyarts.arts.Matrix()
 
 if DO_PRINT_PPVAR:
+
     @pyarts.workspace.arts_agenda(ws=arts)
     def iy_main_agenda_emission(arts):
         arts.ppathCalc()
@@ -71,20 +75,28 @@ if DO_PRINT_PPVAR:
         arts.zeeman_magnetic_fieldFromPath(arts.mat)
         arts.Print(arts.mat, 0)
         arts.VectorSet(arts.geo_pos, [])
+
 else:
+
     @pyarts.workspace.arts_agenda(ws=arts)
     def iy_main_agenda_emission(arts):
         arts.ppathCalc()
         arts.iyEmissionStandard()
         arts.VectorSet(arts.geo_pos, [])
+
+
 arts.Copy(arts.iy_main_agenda, iy_main_agenda_emission)
+
 
 @pyarts.workspace.arts_agenda(ws=arts)
 def surface_rtprop_agenda(arts):
     arts.InterpSurfaceFieldToPosition(output=arts.surface_skin_t, field=arts.t_surface)
     arts.surfaceBlackbody()
+
+
 arts.Copy(arts.surface_rtprop_agenda, surface_rtprop_agenda)
- 
+
+
 @pyarts.workspace.arts_agenda(ws=arts)
 def ppath_step_agenda_geometric(arts):
     arts.Ignore(arts.t_field)
@@ -92,26 +104,37 @@ def ppath_step_agenda_geometric(arts):
     arts.Ignore(arts.f_grid)
     arts.Ignore(arts.ppath_lraytrace)
     arts.ppath_stepGeometric()
+
+
 arts.Copy(arts.ppath_step_agenda, ppath_step_agenda_geometric)
+
 
 @pyarts.workspace.arts_agenda(ws=arts)
 def iy_space_agenda_cosmic_background(arts):
     arts.Ignore(arts.rtp_pos)
     arts.Ignore(arts.rtp_los)
     arts.MatrixCBR(arts.iy, arts.stokes_dim, arts.f_grid)
+
+
 arts.Copy(arts.iy_space_agenda, iy_space_agenda_cosmic_background)
+
 
 @pyarts.workspace.arts_agenda(ws=arts)
 def iy_surface_agenda(arts):
     arts.SurfaceDummy()
     arts.iySurfaceRtpropAgenda()
+
+
 arts.Copy(arts.iy_surface_agenda, iy_surface_agenda)
+
 
 @pyarts.workspace.arts_agenda(ws=arts)
 def water_psat_agenda(arts):
     arts.water_p_eq_fieldMK05()
+
+
 arts.Copy(arts.water_p_eq_agenda, water_psat_agenda)
-    
+
 # %% Calculations
 
 arts.jacobianOff()
@@ -125,27 +148,26 @@ arts.nlteOff()
 # %% Species and line absorption
 
 arts.abs_speciesSet(species=[f"O2-Z-66-{CENTRAL_LINE_FREQ-1}-{CENTRAL_LINE_FREQ+1}"])
-arts.abs_lines_per_speciesReadSpeciesSplitCatalog(basename = os.path.join(LINEPATH, ""))
+arts.abs_lines_per_speciesReadSpeciesSplitCatalog(basename=os.path.join(LINEPATH, ""))
 arts.Wigner6Init()
 
 # %% Use the automatic agenda setter
-arts.propmat_clearsky_agendaAuto(manual_mag_field=not DYNMAG,
-                                         H=MAGSTR,
-                                         theta=MAGTHE,
-                                         eta=MAGETA)
+arts.propmat_clearsky_agendaAuto(
+    manual_mag_field=not DYNMAG, H=MAGSTR, theta=MAGTHE, eta=MAGETA
+)
 
 # %% Grids and planet
 
 arts.p_grid = np.logspace(np.log10(105000), np.log10(0.1))
 arts.lat_grid = np.linspace(-90, 90)
 arts.lon_grid = np.linspace(-180, 180)
-arts.refellipsoidEarth(model = "Sphere")
+arts.refellipsoidEarth(model="Sphere")
 arts.z_surfaceConstantAltitude(altitude=0.0)
 arts.t_surface = 293.15 + np.ones_like(arts.z_surface.value)
 
 # %% Atmosphere
 
-arts.AtmRawRead(basename = os.path.join(ATMPATH, ""))
+arts.AtmRawRead(basename=os.path.join(ATMPATH, ""))
 arts.AtmosphereSet3D()
 arts.AtmFieldsCalcExpand1D()
 arts.Touch(arts.wind_u_field)
@@ -184,7 +206,7 @@ arts.propmat_clearsky_agenda_checkedCalc()
 
 arts.yCalc()
 
-#%% Plot current
+# %% Plot current
 
 if SHOW_PLOTS:
     f = (arts.f_grid.value - CENTRAL_LINE_FREQ) / 1e6  # MHz
@@ -192,69 +214,88 @@ if SHOW_PLOTS:
     plt.xlabel("Freq offset [MHz]")
     plt.ylabel("I [K]")
     plt.title("Downlooking at 0-longitude")
-    plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc='lower left')
+    plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc="lower left")
     plt.show()
-    
+
     plt.plot(f, arts.y.value[1::4].reshape(NR, NF).T)
     plt.xlabel("Freq offset [MHz]")
     plt.ylabel("Q [K]")
     plt.title("Downlooking at 0-longitude")
-    plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc='lower left')
+    plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc="lower left")
     plt.show()
-    
+
     plt.plot(f, arts.y.value[2::4].reshape(NR, NF).T)
     plt.xlabel("Freq offset [MHz]")
     plt.ylabel("U [K]")
     plt.title("Downlooking at 0-longitude")
-    plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc='lower left')
+    plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc="lower left")
     plt.show()
-    
+
     plt.plot(f, arts.y.value[3::4].reshape(NR, NF).T)
     plt.xlabel("Freq offset [MHz]")
     plt.ylabel("V [K]")
     plt.title("Downlooking at 0-longitude")
-    plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc='lower left')
+    plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc="lower left")
     plt.show()
 
 # %% Save and compare data
 
 if DO_SAVE:
-    pyarts.xml.save(arts.y.value, os.path.join(testdir, "refdata.xml"), precision='g')
+    pyarts.xml.save(arts.y.value, os.path.join(testdir, "refdata.xml"), precision="g")
 
 if CF_SAVE:
     arts.VectorCreate("yref")
     arts.ReadXML(arts.yref, "refdata.xml")
-    
+
     if SHOW_PLOTS:
         f = (arts.f_grid.value - CENTRAL_LINE_FREQ) / 1e6  # MHz
         y = arts.yref.value
-        
+
         plt.plot(f, y[::4].reshape(NR, NF).T)
         plt.xlabel("Freq offset [MHz]")
         plt.ylabel("I [K]")
         plt.title("Downlooking at 0-longitude [REFERENCE]")
-        plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc='lower left')
+        plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc="lower left")
         plt.show()
-        
+
         plt.plot(f, y[1::4].reshape(NR, NF).T)
         plt.xlabel("Freq offset [MHz]")
         plt.ylabel("Q [K]")
         plt.title("Downlooking at 0-longitude [REFERENCE]")
-        plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc='lower left')
+        plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc="lower left")
         plt.show()
-        
+
         plt.plot(f, y[2::4].reshape(NR, NF).T)
         plt.xlabel("Freq offset [MHz]")
         plt.ylabel("U [K]")
         plt.title("Downlooking at 0-longitude [REFERENCE]")
-        plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc='lower left')
+        plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc="lower left")
         plt.show()
-        
+
         plt.plot(f, y[3::4].reshape(NR, NF).T)
         plt.xlabel("Freq offset [MHz]")
         plt.ylabel("V [K]")
         plt.title("Downlooking at 0-longitude [REFERENCE]")
-        plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc='lower left')
+        plt.legend(arts.sensor_pos.value[:, 1], title="Latitude", loc="lower left")
         plt.show()
-    
+
     arts.CompareRelative(arts.yref, arts.y, 1e-5, "y reference validation failed")
+
+matx = pyarts.arts.ArrayOfMatrix()
+path = pyarts.arts.ArrayOfPpath()
+arts.zeeman_magnetic_fieldCalc(matx, path)
+
+assert np.allclose(
+    [x[0, 0] for x in matx],
+    [
+        4.414169339007655e-05,
+        2.924084795330217e-05,
+        2.3345231233672053e-05,
+        2.7087530308000868e-05,
+        3.015775010835977e-05,
+        3.4444079230109504e-05,
+        4.283875296168632e-05,
+        4.8730077343922454e-05,
+        5.253072559785391e-05,
+    ],
+), "Magnetic field strength incorrect"

--- a/src/m_zeeman.cc
+++ b/src/m_zeeman.cc
@@ -128,6 +128,12 @@ void ppvar_magFromPath(Matrix& ppvar_mag,
   const Index np = ppath.np;
   const Index atmosphere_dim = ppath.dim;
 
+  ARTS_USER_ERROR_IF(mag_u_field.shape() != mag_v_field.shape() or
+                         mag_u_field.shape() != mag_w_field.shape() or
+                         mag_u_field.size() == 0,
+                     "Magnetic field sizes not correct");
+  ARTS_USER_ERROR_IF(atmosphere_dim != 3, "Only for 3D atmospheres");
+
   Matrix itw_field;
   interp_atmfield_gp2itw(
       itw_field, atmosphere_dim, ppath.gp_p, ppath.gp_lat, ppath.gp_lon);

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -13844,6 +13844,20 @@ R"(
       GIN_DEFAULT(),
       GIN_DESC()));
 
+  md_data_raw.push_back(
+      create_mdrecord(NAME("ppvar_magFromPath"),
+                      DESCRIPTION("Sets *ppvar_mag* from *ppath*.\n"),
+                      AUTHORS("Patrick Eriksson"),
+                      OUT("ppvar_mag"),
+                      GOUT(),
+                      GOUT_TYPE(),
+                      GOUT_DESC(),
+                      IN("mag_u_field", "mag_v_field", "mag_w_field", "ppath"),
+                      GIN(),
+                      GIN_TYPE(),
+                      GIN_DEFAULT(),
+                      GIN_DESC()));
+
   md_data_raw.push_back(create_mdrecord(
       NAME("ppvar_optical_depthFromPpvar_trans_cumulat"),
       DESCRIPTION(
@@ -24563,15 +24577,33 @@ Options are:
                       PASSWORKSPACE(true)));
 
   md_data_raw.push_back(create_mdrecord(
-      NAME("zeeman_magnetic_fieldFromPath"),
-      DESCRIPTION(R"--(Get the magnetic field components used by the Zeeman calculations.
+      NAME("zeeman_magnetic_fieldCalc"),
+      DESCRIPTION(
+          R"--(Get the Zeeman internal magnetic field components from the magnetic field.
+
+The calculations induce *ppath_agenda* for every *sensor_los* / *sensor_pos* pair.
+These generated *ppath* are used to call *ppvar_magFromPath*, and its results
+are passed to the internal magnetic field component calculations of the Zeeman
+effect.
 )--"),
       AUTHORS("Richard Larsson"),
       OUT(),
-      GOUT("zeeman_magnetic_field"),
-      GOUT_TYPE("Matrix"),
-      GOUT_DESC("The magnetic field components for Zeeman effect [np, 3] - last axis is H, theta, eta"),
-      IN("ppath", "ppvar_mag"),
+      GOUT("zeeman_magnetic_field", "zeeman_magnetic_field_path"),
+      GOUT_TYPE("ArrayOfMatrix", "ArrayOfPpath"),
+      GOUT_DESC(
+          "The magnetic field components for Zeeman effect [paths][np, 12] - last axis is H, theta, eta, dH_du, dH_dv, dH_dw, dtheta_du, dtheta_dv, dtheta_dw, deta_du, deta_dv, deta_dw",
+          "The path matching the magnetic field components [paths]"),
+      IN("ppath_agenda",
+         "ppath_lmax",
+         "ppath_lraytrace",
+         "f_grid",
+         "cloudbox_on",
+         "ppath_inside_cloudbox_do",
+         "sensor_pos",
+         "sensor_los",
+         "mag_u_field",
+         "mag_v_field",
+         "mag_w_field"),
       GIN(),
       GIN_TYPE(),
       GIN_DEFAULT(),


### PR DESCRIPTION
Bugfix for the method that computes the Zeeman components along paths.  This makes it so that the same stage as when `yCalc` can be called, also `zeeman_magnetic_fieldCalc` can be called.  I think.  It works in test.