### PR TITLE
Fix Python wheels

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -31,6 +31,12 @@ configure_file(
   @ONLY
 )
 
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
+  ${CMAKE_CURRENT_BINARY_DIR}/setup.py
+  COPYONLY
+)
+
 file(GLOB_RECURSE PYTHON_PYARTS_FILES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "${CMAKE_CURRENT_SOURCE_DIR}/src/pyarts/*.py")
 add_custom_target(
   pyarts_copy_python_source_files

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,1 +1,0 @@
-recursive-include pyarts/controlfiles *.arts

--- a/python/pyproject.toml.in
+++ b/python/pyproject.toml.in
@@ -28,3 +28,9 @@ pythonpath = [
     "src"
 ]
 
+[build-system]
+requires = ["setuptools>=69"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.package-data]
+pyarts = ["*.so", "*.pyd"]

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,11 @@
+from setuptools import Distribution, setup
+
+
+class BinaryDistribution(Distribution):
+    """Distribution which always forces a binary package with platform name"""
+
+    def has_ext_modules(foo):
+        return True
+
+
+setup(distclass=BinaryDistribution)


### PR DESCRIPTION
ARTS library was missing from wheel.
Add minimal setup.py to force platform dependent wheels.