### PR TITLE
Resolve incompatibility with nanobind 2.2.0

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -92,8 +92,6 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
-          channels: conda-forge
-          channel-priority: true
           activate-environment: arts
           environment-file: ${{ matrix.devenv }}
       - shell: bash -l {0}

--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -18,7 +18,7 @@ dependencies:
         - libclang
         - libcxx
         - llvm-openmp
-        - nanobind=2.1.0
+        - nanobind
         - nbsphinx
         - matplotlib
         - netcdf4

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -16,7 +16,7 @@ dependencies:
         - libmicrohttpd
         - llvm-openmp
         - matplotlib
-        - nanobind=2.1.0
+        - nanobind
         - nbsphinx
         - netcdf4
         - ninja

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -9,7 +9,7 @@ dependencies:
         - lark-parser
         - libcxx
         - matplotlib
-        - nanobind=2.1.0
+        - nanobind
         - nbsphinx
         - netcdf4
         - ninja

--- a/src/python_interface/hpy_matpack.h
+++ b/src/python_interface/hpy_matpack.h
@@ -72,7 +72,7 @@ void matpack_interface(py::class_<matpack::matpack_data<T, ndim>>& c) {
         std::ranges::copy(v.shape(), shape.begin());
 
         auto np = py::module_::import_("numpy");
-        auto x  = nd(v.data_handle(), ndim, shape.data(), py::handle());
+        auto x  = nd(v.data_handle(), ndim, shape.data(), py::cast(v));
         return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
       },
       "dtype"_a.none() = py::none(),
@@ -107,7 +107,7 @@ void matpack_constant_interface(
             static_cast<size_t>(ndim)...};
 
         auto np = py::module_::import_("numpy");
-        auto x = nd(v.data.data(), sizeof...(ndim), shape.data(), py::handle());
+        auto x = nd(v.data.data(), sizeof...(ndim), shape.data(), py::cast(v));
         return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
       },
       "dtype"_a.none() = py::none(),
@@ -145,7 +145,7 @@ void matpack_grid_interface(py::class_<matpack::grid<Compare>>& c) {
         std::array<size_t, 1> shape{static_cast<size_t>(v.size())};
 
         auto np = py::module_::import_("numpy");
-        auto x  = nd(v.data_handle(), 1, shape.data(), py::handle());
+        auto x  = nd(v.data_handle(), 1, shape.data(), py::cast(v));
         return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
       },
       "dtype"_a.none() = py::none(),

--- a/src/python_interface/py_basic.cpp
+++ b/src/python_interface/py_basic.cpp
@@ -33,7 +33,7 @@ void py_basic(py::module_& m) try {
            std::array<size_t, 0> shape{};
 
            auto np = py::module_::import_("numpy");
-           auto x  = nd(n.val.get(), 0, shape.data(), py::handle());
+           auto x  = nd(n.val.get(), 0, shape.data(), py::cast(n));
            return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
          },
          "dtype"_a.none() = py::none(),
@@ -55,7 +55,7 @@ void py_basic(py::module_& m) try {
            std::array<size_t, 0> shape{};
 
            auto np = py::module_::import_("numpy");
-           auto x  = nd(n.val.get(), 0, shape.data(), py::handle());
+           auto x  = nd(n.val.get(), 0, shape.data(), py::cast(n));
            return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
          },
          "dtype"_a.none() = py::none(),
@@ -80,7 +80,7 @@ void py_basic(py::module_& m) try {
            std::array<size_t, 1> shape{static_cast<size_t>(v.size())};
 
            auto np = py::module_::import_("numpy");
-           auto x  = nd(v.data(), 1, shape.data(), py::handle());
+           auto x  = nd(v.data(), 1, shape.data(), py::cast(v));
            return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
          },
          "dtype"_a.none() = py::none(),
@@ -103,7 +103,7 @@ void py_basic(py::module_& m) try {
            std::array<size_t, 1> shape{static_cast<size_t>(v.size())};
 
            auto np = py::module_::import_("numpy");
-           auto x  = nd(v.data(), 1, shape.data(), py::handle());
+           auto x  = nd(v.data(), 1, shape.data(), py::cast(v));
            return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
          },
          "dtype"_a.none() = py::none(),

--- a/src/python_interface/py_rtepack.cpp
+++ b/src/python_interface/py_rtepack.cpp
@@ -41,7 +41,7 @@ void rtepack_array(py::class_<matpack::matpack_data<T, M>> &c) {
         std::ranges::copy(std::array{N...}, shape.begin() + M);
         auto np = py::module_::import_("numpy");
         auto x  = py::ndarray<py::numpy, Numeric, py::ndim<n>, py::c_contig>(
-            v.data_handle(), n, shape.data(), py::handle());
+            v.data_handle(), n, shape.data(), py::cast(v));
         return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
       },
       "dtype"_a.none() = py::none(),
@@ -95,7 +95,7 @@ void py_rtepack(py::module_ &m) try {
             auto np                     = py::module_::import_("numpy");
             auto x =
                 py::ndarray<py::numpy, Numeric, py::shape<4>, py::c_contig>(
-                    v.data.data(), 1, shape.data(), py::handle());
+                    v.data.data(), 1, shape.data(), py::cast(v));
             return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
           },
           "dtype"_a.none() = py::none(),
@@ -157,7 +157,7 @@ void py_rtepack(py::module_ &m) try {
             auto np                     = py::module_::import_("numpy");
             auto w =
                 py::ndarray<py::numpy, Numeric, py::shape<7>, py::c_contig>(
-                    x.data.data(), 1, shape.data(), py::handle());
+                    x.data.data(), 1, shape.data(), py::cast(x));
             return np.attr("asarray")(w, "dtype"_a = dtype, "copy"_a = copy);
           },
           "dtype"_a.none() = py::none(),
@@ -210,7 +210,7 @@ void py_rtepack(py::module_ &m) try {
             auto np                     = py::module_::import_("numpy");
             auto w =
                 py::ndarray<py::numpy, Numeric, py::shape<4, 4>, py::c_contig>(
-                    x.data.data(), 2, shape.data(), py::handle());
+                    x.data.data(), 2, shape.data(), py::cast(x));
             return np.attr("asarray")(w, "dtype"_a = dtype, "copy"_a = copy);
           },
           "dtype"_a.none() = py::none(),

--- a/src/python_interface/py_sensor.cpp
+++ b/src/python_interface/py_sensor.cpp
@@ -22,7 +22,7 @@ void py_sensor(py::module_& m) try {
             auto np                     = py::module_::import_("numpy");
             auto w =
                 py::ndarray<py::numpy, Numeric, py::shape<5>, py::c_contig>(
-                    &x, 1, shape.data(), py::handle());
+                    &x, 1, shape.data(), py::cast(x));
             return np.attr("asarray")(w, "dtype"_a = dtype, "copy"_a = copy);
           },
           "dtype"_a.none() = py::none(),
@@ -48,7 +48,7 @@ void py_sensor(py::module_& m) try {
             auto np                     = py::module_::import_("numpy");
             auto w =
                 py::ndarray<py::numpy, Numeric, py::shape<-1, 5>, py::c_contig>(
-                    x.data_handle(), 2, shape.data(), py::handle());
+                    x.data_handle(), 2, shape.data(), py::cast(x));
             return np.attr("asarray")(w, "dtype"_a = dtype, "copy"_a = copy);
           },
           "dtype"_a.none() = py::none(),


### PR DESCRIPTION
Replace `py::handle` with `py::cast` to ensure converting ARTS types to numpy arrays by reference works correctly.