### PR TITLE
Fix sphinx build with Python 3.13

### DIFF
--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -29,11 +29,13 @@ dependencies:
         - python-build
         - requests
         - scipy
-        - sphinx
+        - sphinx<8.1.0
         - sphinx-favicon
-        - sphinx_rtd_theme
+        - sphinxcontrib-jquery
         - sphinxcontrib-mermaid
         - xarray
         - zlib
+        - pip:
+          - sphinx-rtd-theme
 channels:
         - conda-forge

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -26,11 +26,13 @@ dependencies:
         - python-build
         - requests
         - scipy
-        - sphinx
+        - sphinx<8.1.0
         - sphinx-favicon
+        - sphinxcontrib-jquery
         - sphinxcontrib-mermaid
-        - sphinx_rtd_theme
         - xarray
         - zlib
+        - pip:
+          - sphinx-rtd-theme
 channels:
         - conda-forge

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -20,11 +20,13 @@ dependencies:
         - python-build
         - requests
         - scipy
-        - sphinx
+        - sphinx<8.1.0
         - sphinx-favicon
+        - sphinxcontrib-jquery
         - sphinxcontrib-mermaid
-        - sphinx_rtd_theme
         - xarray
         - zlib
+        - pip:
+          - sphinx-rtd-theme
 channels:
         - conda-forge


### PR DESCRIPTION
sphinx-rtd-theme 2.0.0 is not installable with Python 3.13. Because 3.0.1 is not available in conda-forge yet, we need to install it via pip.
We also have to stay with sphinx<8.1.0 for now, because the mermaid
extension is not working in the latest version.