### PR TITLE
Extend nb stubs to all arts submodules

### DIFF
--- a/cmake/modules/ArtsNanobindStubs.cmake
+++ b/cmake/modules/ArtsNanobindStubs.cmake
@@ -1,0 +1,27 @@
+function (ARTS_ADD_CPP_STUBS)
+
+  foreach (MODULENAME IN LISTS ARGN)
+    nanobind_add_stub(
+      pyarts_${MODULENAME}_cpp_stub
+      MODULE arts.${MODULENAME}
+      OUTPUT ${ARTS_BINARY_DIR}/python/src/pyarts/arts/${MODULENAME}.pyi
+      PYTHON_PATH ${ARTS_BINARY_DIR}/python/src/pyarts
+      DEPENDS pyarts_cpp
+    )
+    list(APPEND deplist "pyarts_${MODULENAME}_cpp_stub")
+  endforeach()
+
+  nanobind_add_stub(
+    pyarts_cpp_stub
+    MODULE arts
+    OUTPUT ${ARTS_BINARY_DIR}/python/src/pyarts/arts/__init__.pyi
+    PYTHON_PATH ${ARTS_BINARY_DIR}/python/src/pyarts
+    DEPENDS pyarts_cpp "${deplist}"
+  )
+  set_property(
+    TARGET pyarts_cpp_stub
+    APPEND
+    PROPERTY ADDITIONAL_CLEAN_FILES ${ARTS_BINARY_DIR}/python/src/pyarts/arts
+  )
+
+endfunction()

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -1,8 +1,8 @@
 dependencies:
         - boost
         - ccache
-        - clang
-        - clangxx
+        - clang>=19
+        - clangxx>=19
         - cmake
         - docutils
         - doxygen

--- a/python/test/test_pyi.py
+++ b/python/test/test_pyi.py
@@ -1,0 +1,36 @@
+from inspect import getmembers, ismodule
+from pathlib import Path
+
+import pyarts
+from pyarts import arts
+
+
+class TestStubFiles:
+    def walk_modules(self, m):
+        submodules = getmembers(m, ismodule)
+        for submodule in submodules:
+            if submodule[1].__name__.startswith("pyarts.arts."):
+                yield submodule[1].__name__
+                yield from self.walk_modules(submodule[1])
+
+    def test_pyi(self):
+        missing_stubs = []
+        for module in self.walk_modules(arts):
+            if (
+                not Path(pyarts.__path__[0])
+                .joinpath(module.replace("pyarts.", "").replace(".", "/") + ".pyi")
+                .is_file()
+            ):
+                missing_stubs.append(module.replace("pyarts.arts.", ""))
+
+        assert len(missing_stubs) == 0, (
+            f"Missing stub file(s) for arts submodule(s): \n"
+            f"  {"\n  ".join(missing_stubs)}\n"
+            f"Add them to the `arts_add_cpp_stubs` call in "
+            f"src/python_interface/CMakeLists.txt"
+        )
+
+
+if __name__ == "__main__":
+    a = TestStubFiles()
+    a.test_pyi()

--- a/src/python_interface/CMakeLists.txt
+++ b/src/python_interface/CMakeLists.txt
@@ -164,11 +164,19 @@ set_target_properties(
     pyarts_cpp PROPERTIES LIBRARY_OUTPUT_DIRECTORY
     "${ARTS_BINARY_DIR}/python/src/pyarts/")
 
-nanobind_add_stub(
-    pyarts_cpp_stub
-    MODULE arts
-    OUTPUT ${ARTS_BINARY_DIR}/python/src/pyarts/arts.pyi
-    PYTHON_PATH ${ARTS_BINARY_DIR}/python/src/pyarts
-    DEPENDS pyarts_cpp
+include (ArtsNanobindStubs)
+arts_add_cpp_stubs(
+  constants
+  convert
+  disort
+  file
+  globals
+  hitran
+  interp
+  lbl
+  math
+  physics
+  predef
+  rtepack
+  zeeman
 )
-


### PR DESCRIPTION
Adds completion support for all nb submodules inside the arts module.
.pyi files are now written to an `arts` subfolder. Getting access to the new completions requires deleting either the whole build directory or removing `build/python/src/pyarts/arts.pyi` manually.