### PR TITLE
Improve reading performance

### DIFF
--- a/src/core/util/debug.h
+++ b/src/core/util/debug.h
@@ -60,7 +60,7 @@ std::string artsformat();
   }                                                                            \
   catch (std::exception & e) {                                                 \
     throw std::runtime_error(std::format(                                      \
-        "{}\n{}", CURRENT_SOURCE_FUNCTION, '\n', std::string_view(e.what()))); \
+        "{}\n{}", CURRENT_SOURCE_FUNCTION, std::string_view(e.what())));       \
   }
 
 #ifndef NDEBUG

--- a/src/xml_io.cc
+++ b/src/xml_io.cc
@@ -144,6 +144,12 @@ void xml_find_and_open_input_file(std::shared_ptr<std::istream>& ifs,
     ifs = std::shared_ptr<std::istream>(new std::ifstream());
     xml_open_input_file(*(static_cast<std::ifstream*>(ifs.get())), xml_file);
   }
+
+  // Read the file into memory first to significantly speed up
+  // the parsing (13x to 18x faster).
+  std::shared_ptr<std::stringstream> buffer(new std::stringstream());
+  *buffer << ifs->rdbuf();
+  ifs = buffer;
 }
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Many calls to `tellg`/`seekg` significantly impacted reading performance on `ifstream`. We are now reading the input file into memory before parsing.

In addition, the catalog reading routine reads isotopologues in parallel now.

Reading all lines from all species:
Before fix:	04:29.17
After fix:		00:20.18
Parallel:		00:05.04 (Apple M3 8 cores)

Reading a Tensor3 of size 1000x100x100:
Before fix:	00:26.35
After fix:		00:01.34
