### PR TITLE
[ARTS-2.6] Improve reading performance

### DIFF
--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -23,6 +23,7 @@ dependencies:
         - pytest
         - python-build
         - scipy
+        - setuptools
         - sphinx
         - sphinx-favicon
         - sphinx_rtd_theme

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -19,6 +19,7 @@ dependencies:
         - pytest
         - python-build
         - scipy
+        - setuptools
         - sphinx
         - sphinx-favicon
         - sphinx_rtd_theme

--- a/src/xml_io.cc
+++ b/src/xml_io.cc
@@ -145,6 +145,12 @@ void xml_find_and_open_input_file(std::shared_ptr<istream>& ifs,
     xml_open_input_file(
         *(static_cast<ifstream*>(ifs.get())), xml_file, verbosity);
   }
+
+  // Read the file into memory first to significantly speed up
+  // the parsing (13x to 18x faster).
+  std::shared_ptr<std::stringstream> buffer(new std::stringstream());
+  *buffer << ifs->rdbuf();
+  ifs = buffer;
 }
 
 ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Many calls to `tellg`/`seekg` significantly impacted reading performance on `ifstream`. We are now reading the input file into memory before parsing.

Reading all lines from all species
Before fix:	09:32.57
After fix:		00:13.80

Reading a Tensor3 1000x100x100
Before fix:	00:26.11
After fix:		00:01.29