### PR TITLE
Add libcxx-devel to mac environment

### DIFF
--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -14,6 +14,7 @@ dependencies:
         - lark-parser
         - libclang
         - libcxx
+        - libcxx-devel
         - libmicrohttpd
         - llvm-openmp
         - matplotlib


### PR DESCRIPTION
Not needed on mac since it's pulled in by clangxx, but this environment can also be used to install dependencies for compilation with clang on Linux where libcxx-devel is required but not an explicit dependency of clangxx.