### PR TITLE
Fix some documentation

### DIFF
--- a/doc/arts/guide.theory.absorption.cia.rst
+++ b/doc/arts/guide.theory.absorption.cia.rst
@@ -1,0 +1,4 @@
+Collision-induced Absorption
+############################
+
+TBD

--- a/doc/arts/guide.theory.absorption.faraday.rst
+++ b/doc/arts/guide.theory.absorption.faraday.rst
@@ -1,0 +1,4 @@
+Faraday Rotation
+################
+
+TBD

--- a/doc/arts/guide.theory.absorption.lbl.rst
+++ b/doc/arts/guide.theory.absorption.lbl.rst
@@ -1,0 +1,473 @@
+Line-by-line Absorption
+#######################
+
+This section describes the physical process of absorption lines of 
+different molecules absorbing and emitting spectral radiance
+in the atmosphere.
+
+These are the types of line-by-line absorption considered here:
+
+
+- :ref:`lbl-plain`, where each absorption line is considered separately.
+
+  - Without Zeeman effect
+  - With Zeeman effect
+
+- :ref:`lbl-ecs`,
+  where the absorption lines of similar energies of a molecule
+  are mixed together.
+
+.. _lbl-plain:
+
+Line-by-line Absorption Overview
+********************************
+
+The absorption in plain line-by-line absorption is simply the sum of all 
+absorption by each absorption line.  The absorption of a single absorption line
+is described by the following equations:
+
+.. math::
+
+  \alpha = S(\cdots) F(\cdots),
+
+where
+:math:`\alpha` is the absorption coefficient,
+:math:`S` is the :ref:`lbl-line-strength` operator, and
+:math:`F` is the :ref:`lbl-line-shape` operator.
+
+Both :math:`S` and :math:`F` change slightly if Zeeman effect is considered.
+The main way that Zeeman effect changes the calculations is via the polarization
+it introduces to the propagation matrix summation.
+
+Without Zeeman effect
+=====================
+
+The contribution to :ref:`propagation matrix <prop-mat>` from all non Zeeman-split absorption lines is simply
+
+.. math::
+
+  K_{A, lbl} = \mathrm{Re} \sum_i \alpha_{i},
+
+and from this the full matrix is
+
+.. math::
+
+  \mathbf{K}_{lbl} = \left[ \begin{array}{llll} K_{A, lbl}&0&0&0\\ 0&K_{A, lbl}&0&0\\0&0&K_{A, lbl}&0\\0&0&0&K_{A, lbl} \end{array} \right],
+
+where :math:`i` is the pseudo-index of the absorption line and ``lbl`` is the pseudo-index of the plain line-by-line absorption for the sake of :ref:`summing up absorption <eq-prop-mat-sumup>`.
+
+.. note::
+
+  Plain line-by-line absorption only contribute towards the diagonal of the :ref:`propagation matrix <prop-mat>`.
+
+With Zeeman effect
+==================
+
+When Zeeman effect is considered, there are effectively 3 separate kinds of polarized absorption added to the :ref:`propagation matrix <prop-mat>`
+
+.. math::
+
+  K_{\sigma_\pm, z} &= \sum_i \alpha_{i, \sigma_\pm} \\
+  K_{\pi, z} &= \sum_i \alpha_{i, \pi}
+
+and from this, the full matrix contribution is
+
+.. math::
+
+  \mathbf{K}_{z} =
+  \sum_\pm \left(
+  \mathrm{Re} K_{\sigma_\pm,z} \left[
+  \begin{array}{rrrr}
+  1 + \cos^2\theta_m &
+  \sin^2\theta_m\cos 2\eta_m &
+  \sin^2\theta_m\sin 2\eta_m &
+  \mp 2\cos\theta_m \\
+  \sin^2\theta_m\cos 2\eta_m  &
+  1 + \cos^2\theta_m  &
+  0 &
+  0 \\
+  \sin^2\theta_m\sin 2\eta_m &
+  0 &
+  1 + \cos^2\theta_m &
+  0 \\
+  \mp 2\cos\theta_m &
+  0 &
+  0 &
+  1 + \cos^2\theta_m 
+  \end{array}  \right] +
+  \mathrm{Im} K_{\sigma_\pm,z} \left[
+  \begin{array}{rrrr}
+  0 &
+  0 &
+  0 &
+  0 \\
+  0 &
+  0 &
+  \mp 4\cos\theta_m &
+  2\sin^2\theta_m\sin 2\eta_m  \\
+  0 &
+  \pm 4\cos\theta_m  &
+  0 &
+  - 2 \sin^2\theta_m\cos 2\eta_m \\
+  0 &
+  - 2\sin^2\theta_m\sin 2\eta_m &
+  2 \sin^2\theta_m\cos 2\eta_m &
+  0
+  \end{array}  \right]
+  \right) +
+  \\
+  \mathrm{Re} K_{\pi,z} \left[
+  \begin{array}{rrrr}
+  \sin^2\theta_m &
+  - \sin^2\theta_m\cos 2\eta_m  &
+  - \sin^2\theta_m\sin 2\eta_m  &
+  0 \\
+  - \sin^2\theta_m\cos 2\eta_m  &
+  \sin^2\theta_m  &
+  0 &
+  0 \\
+  - \sin^2\theta_m\sin 2\eta_m  &
+  0 &
+  \sin^2\theta_m  &
+  0 \\
+  0 &
+  0 &
+  0 &
+  \sin^2\theta_m 
+  \end{array}  \right] +
+  \mathrm{Im} K_{\pi,z} \left[
+  \begin{array}{rrrr}
+  0 &
+  0 &
+  0 &
+  0 \\
+  0 &
+  0 &
+  0 &
+  - 2\sin^2\theta_m\sin 2\eta_m \\
+  0 &
+  0 &
+  0 &
+  2 \sin^2\theta_m\cos 2\eta_m \\
+  0 &
+  2\sin^2\theta_m\sin 2\eta_m &
+  - 2 \sin^2\theta_m\cos 2\eta_m &
+  0
+  \end{array}  \right],
+
+where the somewhat weird :math:`\pm`-sum is over the sigma components.
+Here the angles :math:`\theta_m` and :math:`\eta_m` are the angles with regards to the magnetic field.
+
+Given a spherical coordinate observation system with zenith angle :math:`\theta_z` and aziumuth angle :math:`\eta_a` and a
+local magnetic field with upwards facing strength :math:`B_w`, eastward facing strength :math:`B_u` and northward facing strength :math:`B_v`,
+these angles are given by
+
+.. math::
+
+  \theta_m = \arccos\left(\frac{B_v \cos\eta_a \sin\theta_z + B_u \sin\eta_a \sin\theta_z + B_w \cos\theta_z}{ \sqrt{B_w^2 + B_u^2 + B_v^2} } \right)
+  \\
+  \eta_m = \mathrm{atan2}\left(B_u \cos\eta_a - B_v \sin\eta_a,\; B_w \cos\eta_a\cos\theta_z + B_u\sin\eta_a\cos\theta_z - B_w\sin\theta_z \right)
+
+.. _lbl-line-shape:
+
+Line Shapes
+===========
+
+Line shapes should distribute absorption as a function of frequency.
+By convention, the line shape is normalized to have an integral of 1.
+
+Voigt Line Shape
+----------------
+
+.. math::
+
+  F = \frac{1 + G_{lm} - iY_{lm}}{\sqrt{\pi}G_D} w(z),
+
+where
+
+.. math::
+
+  z = \frac{\nu - \nu_0 - \Delta\nu_{lm} - \Delta_nu_Z - \Delta\nu_{P,0} + iG_{P,0}}{G_D},
+
+where
+
+.. list-table::
+  :header-rows: 1
+
+  * - Parameter
+    - Description
+  * - :math:`\nu`
+    - The sampling frequency
+  * - :math:`\nu_0`
+    - The line center frequency
+  * - :math:`G_D`
+    - The scaled Doppler broadening half-width half-maximum
+  * - :math:`\Delta\nu_Z`
+    - The Zeeman shift
+  * - :math:`G_{P,0}`
+    - The pressure broadening - half width half maximum in the Lorentz profile
+  * - :math:`\Delta\nu_{P,0}`
+    - The pressure shift
+  * - :math:`Y_{lm}`
+    - The 1st order Line-mixing parameter
+  * - :math:`G_{lm}`
+    - The 2nd-order strength modifying line mixing parameter
+  * - :math:`\Delta\nu_{lm}`
+    - The 2nd-order line-mixing shift
+  * - :math:`w(z)`
+    - The Faddeeva function.
+
+For more information about how :math:`G_{P,0}`, :math:`\Delta\nu_{P,0}`, :math:`Y_{lm}`, :math:`G_{lm}`, and :math:`\Delta\nu_{lm}` are computed see :ref:`lbl-line-shape-params`.
+The scaled Doppler broadening half width half maximum is given by
+
+.. math::
+
+  G_D = \sqrt{\frac{2000 R T}{mc^2}} \nu_0,
+
+where
+
+.. list-table::
+  :header-rows: 1
+
+  * - Parameter
+    - Description
+  * - :math:`R`
+    - The ideal gas constant in Joules per mole per Kelvin,
+  * - :math:`T`
+    - The temperature in Kelvin,
+  * - :math:`m`
+    - The mass of the molecule in grams per mole, and
+  * - :math:`c`
+    - The speed of light in meters per second.
+
+The factor 2000 is to convert to SI units.
+
+The Faddeeva function is in ARTS
+computed using the MIT-licensed `Faddeeva package <http://ab-initio.mit.edu/faddeeva/>`_,
+which is based in large parts on the work by :cite:t:`zaghloul12:_algorithm916_acm`.
+
+The Zeeman line-shift is derived from the magnetic field strength and the magnetic quantum number of the transition.
+A linear Zeeman effect is assumed such that
+
+.. math::
+
+  \Delta\nu_Z = \frac{e} {4 \pi m_e} \left(M_l g_{l,z} - M_u g_{u,z} \right),
+
+where :math:`e` is the elementary charge, :math:`m_e` is the mass of an electron, 
+:math:`M_l` and :math:`M_u` are the projection of the lower and upper states, respectively, 
+of the angular momentum quantum number on the magnetic field, and :math:`g_{l,z}`
+and :math:`g_{u,z}` are the lower and upper state Landé g-factors, respectively.
+The latter are generally computed ahead of time, e.g., as by :cite:t:`larsson19:_updated_jqsrt,larsson20:_zeeman_jqsrt`.
+
+.. note::
+
+  It is important to not confuse the line-mixing parameters used here with full line mixing as described below.
+  The line-mixing paramters here are still plain line-by-line absorption, but it is important that there are no
+  cut lines and that the data for *all* line-paramters are derived toghether. 
+
+.. _lbl-line-shape-params:
+
+Line Shape Parameters
+---------------------
+
+The line shape parameters supported by ARTS are
+
+.. list-table::
+  :header-rows: 1
+
+  * - Parameter
+    - Description
+    - Pressure Dependency
+  * - :math:`G_{P,0}`
+    - Pressure broadening half width half maximum, collision-independent.
+    - :math:`P`
+  * - :math:`G_{P,2}`
+    - Pressure broadening half width half maximum, collision-dependent.
+    - :math:`P`
+  * - :math:`\Delta\nu_{P,0}`
+    - Pressure shift, collision-independent.
+    - :math:`P`
+  * - :math:`\Delta\nu_{P,2}`
+    - Pressure shift, collision-dependent.
+    - :math:`P`
+  * - :math:`\nu_{VC}`
+    - Velocity changing frequency.
+    - :math:`P`
+  * - :math:`\eta`
+    - Correlation parameter.
+    - :math:`-`
+  * - :math:`Y_{lm}`
+    - 1st order Line-mixing parameter.
+    - :math:`P`
+  * - :math:`G_{lm}`
+    - 2nd-order strength modifying line mixing parameter.
+    - :math:`P^2`
+  * - :math:`\Delta\nu_{lm}`
+    - 2nd-order line-mixing shift.
+    - :math:`P^2`
+
+These parameters are all computed species-by-species before being volume-mixing ratio weighted and summed up.
+In equation form:
+
+.. math::
+
+  L = \frac{\sum_i x_i L_i}{\sum_i x_i},
+
+where :math:`L` is a placeholder for any of the line shape parameters, and :math:`x` is the volume mixing ratio, and :math:`i` is a species index.
+The normalization is there to allow fewer than all species to contribute to the line shape parameters.
+
+The temperature dependencies of the individual :math:`L_i` are computed based on avaiable data.
+There is no general form avaiable, so instead the temperature dependencies are computed based on the data avaiable for each species as:
+
+.. list-table::
+  :header-rows: 1
+
+  * - Name
+    - Equation
+    - Description
+  * - ``T0``
+    - :math:`L_i(T) = X_0`
+    - Constant regardless of temperature
+  * - ``T1``
+    - :math:`L_i(T) = X_0 \left(\frac{T_0}{T}\right)^{X_1}`
+    - Simple power law
+  * - ``T2``
+    - :math:`L_i(T) = X_0 \left(\frac{T_0}{T}\right) ^ {X_1} \left[1 + X_2 \log\left(\frac{T_0}{T}\right)\right]`
+    - Power law with compensation.
+  * - ``T3``
+    - :math:`L_i(T) = X_0 + X_1 \left(T - T_0\right)`
+    - Linear in temperature
+  * - ``T4``
+    - :math:`L_i(T) = \left[X_0 + X_1 \left(\frac{T_0}{T} - 1\right)\right] \left(\frac{T_0}{T}\right)^{X_2}`
+    - Power law with compensation.  Used for line mixing.
+  * - ``T5``
+    - :math:`L_i(T) = X_0 \left(\frac{T_0}{T}\right)^{\frac{1}{4} + \frac{3}{2}X_1}`
+    - Power law with offset.
+  * - ``AER``
+    - :math:`L_i(200) = X_0`, :math:`L_i(250) = X_1`, :math:`L_i(296) = X_2`, :math:`L_i(340) = X_3`.  Linear interpolation inbetween.
+    - Inspired by the way `AER <http://rtweb.aer.com/lblrtm.html>`_ deals with linemixing.
+  * - ``DPL``
+    - :math:`L_i(T) = X_0 \left(\frac{T_0}{T}\right) ^ {X_1} + X_2 \left(\frac{T_0}{T}\right) ^ {X_3}`
+    - Double power law.
+  * - ``POLY``
+    - :math:`L_i(T) = X_0 + X_1 T + X_2 T ^ 2 + X_3 T ^ 3 + \cdots`
+    - Polynomial in temperature.  Used internal in ARTS when training our own linemixing.
+
+here, :math:`X_0` ... :math:`X_N` are all model supplied constants whereas :math:`T` is the temperature in Kelvin and :math:`T_0` is the reference temperature of the model parameters.
+
+.. _lbl-line-strength:
+
+Line Strength
+=============
+
+.. _lbl-lte:
+
+Local thermodynamic equilibrium
+-------------------------------
+
+For local thermodynamic equilibrium (LTE), the line strength is given by
+
+.. math::
+
+  S_{LTE} = \rho \frac{c^2\nu}{8\pi} \left[1 - \exp\left(-\frac{h\nu}{kT}\right)\right]
+  \frac{g_u\exp\left(-\frac{E_l}{kT}\right)}{Q(T)} \frac{A_{lu}}{\nu_0^3}
+
+.. _lbl-nlte:
+
+Non-local thermodynamic equilibrium
+-----------------------------------
+
+For non-LTE, the line strength is given by
+
+.. math::
+
+  S_{NLTE} = \rho \frac{c^2\nu}{8\pi} \left(r_l \frac{g_u}{g_l} - r_u\right) \frac{A_{lu}} {\nu_0^3},
+
+and the added emissions are given by
+
+.. math::
+
+  K_{NLTE} = \rho \frac{c^2\nu}{8\pi} \left\{r_u\left[
+  1 - \exp\left(\frac{h\nu_0}{kT}\right)\right] - \left(r_l \frac{g_u}{g_l} - r_u\right)
+  \right\} \frac{ A_{lu}}{\nu_0^3},
+
+where :math:`r_l` and :math:`r_u` are the ratios of the populations of the lower and upper states, respectively.
+Note that :math:`K_{LTE} = 0`, as it represents "additional" emission due to non-LTE conditions.
+Also note that :math:`K_{NLTE}` may be negative.
+
+To ensure ourselves that this can be turned into the expression for LTE,
+we can rewrite the above for the expression that :math:`r_l` and :math:`r_u`
+would have in LTE according to the Boltzmann distribution:
+
+.. math::
+
+  r_l = \frac{g_l\exp\left(-\frac{E_l}{kT}\right)}{Q(T)}
+
+and
+
+.. math::
+
+  r_u = \frac{g_u\exp\left(-\frac{E_u}{kT}\right)}{Q(T)}
+
+Putting this into the ratio-expression for :math:`S_{NLTE}` with the following simplification steps:
+
+Expansion:
+
+.. math::
+
+  \left(r_l \frac{g_u}{g_l} - r_u\right) =
+  \frac{g_u}{Q(T)}\left[\exp\left(-\frac{E_l}{kT}\right) - \exp\left(-\frac{E_u}{kT}\right)\right].
+
+Extract lower state energies:
+
+.. math::
+
+  \frac{g_u}{Q(T)}\left[\exp\left(-\frac{E_l}{kT}\right) - \exp\left(-\frac{E_u}{kT}\right)\right]
+  \frac{\exp\left(-\frac{E_l}{kT}\right)}{\exp\left(-\frac{E_l}{kT}\right)} \rightarrow
+  \left[1 - \exp\left(-\frac{h\nu_0}{kT}\right)\right]\frac{g_u\exp\left(-\frac{E_l}{kT}\right)}{Q(T)},
+
+where this last step is possible because we estimate that :math:`E_u-E_l = h\nu_0`.  Note how the
+expression for :math:`K_{NLTE}` is 0 under LTE conditions. As it should be.
+This is seen by putting the above RHS and the expression for :math:`r_u` into the expression for :math:`K_{NLTE}`:
+
+.. math::
+
+  K_{NLTE} = \rho \frac{c^2\nu}{8\pi} \left\{\frac{g_u\exp\left(-\frac{E_u}{kT}\right)}{Q(T)}\left[
+    1 - \exp\left(\frac{h\nu_0}{kT}\right)\right] - \left[1 - \exp\left(-\frac{h\nu_0}{kT}\right)\right]\frac{g_u\exp\left(-\frac{E_l}{kT}\right)}{Q(T)}
+    \right\} \frac{ A_{lu}}{\nu_0^3} = 0.
+
+The ratio between LTE and non-LTE line strength remaining is:
+
+.. math::
+
+  \frac{S_{NLTE}}{S_{LTE}} = \frac{1 - \exp\left(-\frac{h\nu_0}{kT}\right)}{1 - \exp\left(-\frac{h\nu}{kT}\right)}.
+
+It is clear that the non-LTE expression is the one that is incorrect here.
+The energy of the emitted photon is not :math:`h\nu_0` but :math:`h\nu`, and
+as such the actual energy of the transition is :math:`E'_u-E'_l = h\nu`, but
+this should be relatively close in cases where we actually care about non-LTE
+(which is low density, low collision atmospheres).
+
+Zeeman effect
+-------------
+
+If Zeeman effect is considered, the emission and absorption terms above are modified by quantum number state distribution.
+For O :sub:`2`, for example, this introduces a factor of
+
+.. math::
+
+  S_z = f(\Delta M) \left( \begin{array}{ccc} J_l & 1 & J_u \\ M_l & \Delta M & - M_u \end{array} \right)^2,
+
+where :math:`\Delta M \in \left[-1,\;0,\;1\right]` is the change in quantum number for angular rotational momentum projection along the magnetic field
+for :math:`\sigma_-`, :math:`\pi`, and :math:`\sigma_+`, respectively,
+:math:`f(\Delta M)` is the 0.75 for :math:`\sigma_\pm` and 1.5 for :math:`\pi`,
+and :math:`J_l` and :math:`J_u` are the lower and upper total angular rotational momentum quantum number.
+The :math:`(:::)` construct is the Wigner 3-j symbol.
+It can be `computed using software <https://fy.chalmers.se/subatom/wigxjpf/>`_ such as that by :cite:t:`johansson2016`.
+
+.. _lbl-ecs:
+
+Line-mixing using Error-corrected Sudden
+****************************************
+
+TBD

--- a/doc/arts/guide.theory.absorption.lookup.rst
+++ b/doc/arts/guide.theory.absorption.lookup.rst
@@ -1,0 +1,4 @@
+Lookup-table Absorption
+#######################
+
+TBD

--- a/doc/arts/guide.theory.absorption.predef.rst
+++ b/doc/arts/guide.theory.absorption.predef.rst
@@ -1,0 +1,4 @@
+Predefined Absorption Models
+############################
+
+TBD

--- a/doc/arts/guide.theory.absorption.rst
+++ b/doc/arts/guide.theory.absorption.rst
@@ -1,213 +1,157 @@
-.. _Sec Absorption:
-
 Absorption
 ##########
 
 Absorption is the physical process that reduces 
-the `<Spectral Radiance_>`_ of a beam of light as it passes through a medium.
+the spectral radiance of a beam of light as it passes through a medium.
 It can be described be Beer's law:
 
 .. math::
-  \vec{I}(r) = \vec{I}(0) \exp(-\mathbf{K} z),
 
-where :math:`\vec{I}(r)` is the `<Spectral Radiance_>`_ of the light at some distance
-:math:`r`, and :math:`\mathbf{K}` is the `<Propagation Matrix_>`_ of the medium.
+  \vec{I}(r) = \vec{I}(0) \exp(-\mathbf{K} r),
+
+where :math:`\vec{I}(r)` is the spectral radiance as a :ref:`Stokes vector <stok-vec>` of the light at some distance
+:math:`r`, and :math:`\mathbf{K}` is the :ref:`propagation matrix <prop-mat>` of the medium.
+
+The unit of spectral radiance is W sr :math:`^{-1}` m :math:`^{-2}` Hz :math:`^{-1}`.  The unit of the propagation matrix is m :math:`^{-1}`.
+
+.. _stok-vec:
+
+The Stokes Vector
+*****************
+
+In ARTS, the spectral radiance is represented by the Stokes vector, which is a 4-long column vector.
+
+.. math::
+
+  \vec{I} = \left[ \begin{array}{c} I_I \\ I_Q \\ I_U \\ I_V \end{array} \right],
+
+where 
+:math:`I_I` is the total spectral radiance,
+:math:`I_Q` is the difference in spectral radiance between horizontal and vertical linear polarizations,
+:math:`I_U` is the difference in spectral radiance between plus 45 and minus 45 linear polarizations, and
+:math:`I_V` is the difference in spectral radiance between right and left circular polarizations.
+The unit of all of these is W sr :math:`^{-1}` m :math:`^{-2}` Hz :math:`^{-1}`.
+
+This is the same definition as, e.g., :cite:t:`Mishchenko:02`.
+
+.. tip::
+
+  Because of the nature of circular polarization, it is not uncommon to see different :math:`I_V` definitions
+  in different context.  Be sure to check the definition of :math:`I_V` in the context you are working in.
+  It has caused confusion in the past, for both users and developers of ARTS.
+
+The Stokes Vector Unit Conversion
+=================================
+
+All ARTS simulations expect the incoming spectral radiance to be in W sr :math:`^{-1}` m :math:`^{-2}` Hz :math:`^{-1}`.
+
+However, several ways to convert the Stokes vector to other units are available.  These are listed below in no particular order.
+
+Rayleigh Jeans Brightness Temperature
+--------------------------------------
+
+As the spectral temperature of the Rayleigh Jeans interpretation of black body spectral radiance.   The conversion is given by
+
+.. math::
+  \vec{I}_{RJBT} = \frac{c^2}{2k\nu^2} \left[ \begin{array}{c} I_I \\ I_Q \\ I_U \\ I_V \end{array} \right],
+
+where :math:`k` is the Boltzmann constant, :math:`c` is the speed of light, and :math:`\nu` is the frequency.
+
+The unit of all of these is K.
+
+Planck Brightness Temperature
+-----------------------------
+
+As the spectral temperature of the black body spectral radiance.   The conversion is given by
+
+.. math::
+
+  \vec{I}_{Tb} = \frac{h \nu}{k} \left[ \begin{array}{lcr} 
+  \log\left(1 + \frac{2h\nu^3}{c^2I_I}\right)^{-1} &&\\
+  \log\left(1 + \frac{4h\nu^3}{c^2(I_I + I_Q)}\right)^{-1} &-& \log\left(1 + \frac{4h\nu^3}{c^2(I_I - I_Q)}\right)^{-1} \\
+  \log\left(1 + \frac{4h\nu^3}{c^2(I_I + I_U)}\right)^{-1} &-& \log\left(1 + \frac{4h\nu^3}{c^2(I_I - I_U)}\right)^{-1} \\
+  \log\left(1 + \frac{4h\nu^3}{c^2(I_I + I_V)}\right)^{-1} &-& \log\left(1 + \frac{4h\nu^3}{c^2(I_I - I_V)}\right)^{-1}
+  \end{array} \right],
+
+where :math:`k` is the Boltzmann constant, :math:`h` is the Planck constant, :math:`c` is the speed of light, and :math:`\nu` is the frequency.
+
+The unit of all of these is K.
+
+The Spectral Radiance per Wavelength
+------------------------------------
+
+As the spectral temperature of the Rayleigh Jeans interpretation of black body spectral radiance.   The conversion is given by
+
+.. math::
+
+  \vec{I}_{\lambda} = \frac{\nu^2}{c} \left[ \begin{array}{c} I_I \\ I_Q \\ I_U \\ I_V \end{array} \right],
+
+where :math:`c` is the speed of light, and :math:`\nu` is the frequency.
+
+The unit of all of these is W sr :math:`^{-1}` m :math:`^{-2}` m :math:`^{-1}`.
+
+The Spectral Radiance per Kayser
+--------------------------------
+
+As the spectral temperature of the Rayleigh Jeans interpretation of black body spectral radiance.   The conversion is given by
+
+.. math::
+
+  \vec{I}_{cm} = \frac{1}{c} \left[ \begin{array}{c} I_I \\ I_Q \\ I_U \\ I_V \end{array} \right],
+
+where :math:`c` is the speed of light.
+
+The unit of all of these is W sr :math:`^{-1}` m :math:`^{-2}` m.
+
+.. _prop-mat:
 
 Propagation Matrix
 ******************
 
-The propagation matrix conceptually describes how `<Spectral Radiance_>`_
+The propagation matrix conceptually describes how :ref:`the Stokes vector <stok-vec>`
 propagates through a system. The propagation matrix is a square matrix
 with strict symmetries, and it has the form
 
 .. math::
 
    \mathbf{K} = \left[ \begin{array}{rrrr}
-        A & B & C & D \\
-        B & A & U & V \\
-        C &-U & A & W \\
-        D &-V &-W & A
+        K_A & K_B & K_C & K_D \\
+        K_B & K_A & K_U & K_V \\
+        K_C &-K_U & K_A & K_W \\
+        K_D &-K_V &-K_W & K_A
     \end{array} \right],
 
 where
-:math:`A` describes the total power reduction,
-:math:`B` describes the difference in power reduction between horizontal and vertical linear polarizations,
-:math:`C` describes the difference in power reduction between plus 45 and minus 45 linear polarizations,
-:math:`D` describes the difference in power reduction between right and left circular polarizations,
-:math:`U` describes the phase delay between right and left circular polarizations,
-:math:`V` describes the phase delay between plus 45 and minus 45 linear polarizations, and
-:math:`W` describes the phase delay between horizontal and vertical linear polarizations.
+:math:`K_A` describes the total power reduction,
+:math:`K_B` describes the difference in power reduction between horizontal and vertical linear polarizations,
+:math:`K_C` describes the difference in power reduction between plus 45 and minus 45 linear polarizations,
+:math:`K_D` describes the difference in power reduction between right and left circular polarizations,
+:math:`K_U` describes the phase delay between right and left circular polarizations,
+:math:`K_V` describes the phase delay between plus 45 and minus 45 linear polarizations, and
+:math:`K_W` describes the phase delay between horizontal and vertical linear polarizations.
 The unit of all of these is m :math:`^{-1}`.
 
-Spectral Radiance
-*****************
+In practice, the propagation matrix is a sum of multiple physical processes:
 
-The unit of spectral radiance is W sr :math:`^{-1}` m :math:`^{-2}` Hz :math:`^{-1}`.
-
-Line-by-line Absorption
-***********************
-
-This section describes the physical process of absorption lines of 
-different molecules absorbing and emitting `<Spectral Radiance_>`_
-in the atmosphere.
-
-These are the types of line-by-line absorption considered here:
-
-#. `Plain line-by-line absorption <Plain Line-by-line Absorption_>`_,
-   where each absorption line is considered separately.
-#. Zeeman splitting, where the otherwise single absorption line is split
-   into multiple lines due to the presence of a magnetic field.
-#. Line-mixing by means of error-corrected sudden approximation,
-   where the absorption lines of similar energies of a molecule
-   are mixed together.
-
-Plain Line-by-line Absorption
-=============================
-
-The absorption in plain line-by-line absorption is simply the sum of all 
-absorption by each absorption line.  The absorption of a single absorption line
-is described by the following equations:
+.. _eq-prop-mat-sumup:
 
 .. math::
 
-  \alpha = S(\cdots) F(\cdots),
+  \mathbf{K} = \sum_i \mathbf{K}_i
 
-where
-:math:`\alpha` is the absorption coefficient,
-:math:`S` is the `<Line Strength_>`_ operator, and
-:math:`F` is the `<Line Shape_>`_ operator.
+where :math:`i` is the pseudo-index of the physical process.  A physical process here
+refers to line-by-line absorption, collision-induced absorption, Faraday rotation, scattering, etc.
+Think of this sum as if each contribtion the the propagation matrix is completely independent of the others.
 
-Line Shape
-==========
+The way to compute different :math:`\mathbf{K}_i` are described in these sections:
 
-Line shapes should distribute absorption as a function of frequency.
-By convention, the line shape is normalized to have an integral of 1.
-
-The following line shapes are available in ARTS 3.
-
-Voigt Line Shape
-----------------
-
-.. math::
-
-  F = \frac{1 + G_{lm} - iY_{lm}}{\sqrt{\pi}G_D} w(z),
-
-where
-
-.. math::
-
-  z = \frac{\nu - \nu_0 - \Delta\nu_{lm} - \Delta\nu_Z - \Delta\nu_{P,0} + iG_{P,0}}{G_D},
-
-:math:`\nu` is the frequency,
-:math:`\nu_0` is the line center frequency,
-:math:`\Delta\nu_{lm}` is the line mixing shift,
-:math:`\Delta\nu_Z` is the Zeeman splitting,
-:math:`\Delta\nu_{P,0}` is the pressure shift, 
-:math:`G_{P,0}` is the pressure broadening - half width half maximum in the Lorentz profile, 
-:math:`G_{lm}` is the strength modifying line mixing parameter,
-:math:`Y_{lm}` is the phase-introducing line mixing parameter, and
-:math:`G_D` is the scaled Doppler broadening half-width half-maximum.
-:math:`\nu` is just a sampling frequency, it can be anything positive.
-:math:`\nu_0` is provided by the absorption line catalog.
-The :math:`\Delta\nu_{lm}`, :math:`\Delta\nu_{P,0}`, and :math:`G_{P,0}` are Line Shape Parameters.  :math:`\Delta\nu_Z`
-is the Zeeman splitting, which depends on molecule and magnetic field strength as is described
-in Zeeman Effect.  The scaled Doppler broadening half width half maximum is given by
-
-.. math::
-
-  G_D = \sqrt{\frac{2000 R T}{mc^2}} \nu_0,
-
-where
-:math:`R` is the ideal gas constant in Joules per mole per Kelvin,
-:math:`T` is the temperature in Kelvin,
-:math:`m` is the mass of the molecule in grams per mole, and
-:math:`c` is the speed of light in meters per second.
-The factor 2000 is to convert to SI units.
-
-Line Strength
-=============
-
-Local thermodynamic equilibrium
--------------------------------
-
-For local thermodynamic equilibrium (LTE), the line strength is given by
-
-.. math::
-
-  S_{LTE} = \rho \frac{c^2\nu}{8\pi} \left[1 - \exp\left(-\frac{h\nu}{kT}\right)\right]
-  \frac{g_u\exp\left(-\frac{E_l}{kT}\right)}{Q(T)} \frac{A_{lu}}{\nu_0^3}
-
-Non-local thermodynamic equilibrium
------------------------------------
-
-For non-LTE, the line strength is given by
-
-.. math::
-
-  S_{NLTE} = \rho \frac{c^2\nu}{8\pi} \left(r_l \frac{g_u}{g_l} - r_u\right) \frac{A_{lu}} {\nu_0^3},
-
-and the added emissions are given by
-
-.. math::
-
-  K_{NLTE} = \rho \frac{c^2\nu}{8\pi} \left\{r_u\left[
-  1 - \exp\left(\frac{h\nu_0}{kT}\right)\right] - \left(r_l \frac{g_u}{g_l} - r_u\right)
-  \right\} \frac{ A_{lu}}{\nu_0^3},
-
-where :math:`r_l` and :math:`r_u` are the ratios of the populations of the lower and upper states, respectively.
-Note that :math:`K_{LTE} = 0`, as it represents "additional" emission due to non-LTE conditions.
-Also note that :math:`K_{NLTE}` may be negative.
-
-To ensure ourselves that this can be turned into the expression for LTE,
-we can rewrite the above for the expression that :math:`r_l` and :math:`r_u`
-would have in LTE according to the Boltzmann distribution:
-
-.. math::
-
-  r_l = \frac{g_l\exp\left(-\frac{E_l}{kT}\right)}{Q(T)}
-
-and
-
-.. math::
-
-  r_u = \frac{g_u\exp\left(-\frac{E_u}{kT}\right)}{Q(T)}
-
-Putting this into the ratio-expression for :math:`S_{NLTE}` with the following simplification steps:
-
-Expansion:
-
-.. math::
-
-  \left(r_l \frac{g_u}{g_l} - r_u\right) =
-  \frac{g_u}{Q(T)}\left[\exp\left(-\frac{E_l}{kT}\right) - \exp\left(-\frac{E_u}{kT}\right)\right].
-
-Extract lower state energies:
-
-.. math::
-
-  \frac{g_u}{Q(T)}\left[\exp\left(-\frac{E_l}{kT}\right) - \exp\left(-\frac{E_u}{kT}\right)\right]
-  \frac{\exp\left(-\frac{E_l}{kT}\right)}{\exp\left(-\frac{E_l}{kT}\right)} \rightarrow
-  \left[1 - \exp\left(-\frac{h\nu_0}{kT}\right)\right]\frac{g_u\exp\left(-\frac{E_l}{kT}\right)}{Q(T)},
-
-where this last step is possible because we estimate that :math:`E_u-E_l = h\nu_0`.  Note how the
-expression for :math:`K_{NLTE}` is 0 under LTE conditions. As it should be.
-This is seen by putting the above RHS and the expression for :math:`r_u` into the expression for :math:`K_{NLTE}`:
-
-.. math::
-
-  K_{NLTE} = \rho \frac{c^2\nu}{8\pi} \left\{\frac{g_u\exp\left(-\frac{E_u}{kT}\right)}{Q(T)}\left[
-    1 - \exp\left(\frac{h\nu_0}{kT}\right)\right] - \left[1 - \exp\left(-\frac{h\nu_0}{kT}\right)\right]\frac{g_u\exp\left(-\frac{E_l}{kT}\right)}{Q(T)}
-    \right\} \frac{ A_{lu}}{\nu_0^3} = 0.
-
-The ratio between LTE and non-LTE line strength remaining is:
-
-.. math::
-
-  \frac{S_{NLTE}}{S_{LTE}} = \frac{1 - \exp\left(-\frac{h\nu_0}{kT}\right)}{1 - \exp\left(-\frac{h\nu}{kT}\right)}.
-
-It is clear that the non-LTE expression is the one that is incorrect here.
-The energy of the emitted photon is not :math:`h\nu_0` but :math:`h\nu`, and
-as such the actual energy of the transition is :math:`E'_u-E'_l = h\nu`, but
-this should be relatively close in cases where we actually care about non-LTE
-(which is low density, low collision atmospheres).
-
+.. toctree::
+   :maxdepth: 2
+   
+   guide.theory.absorption.cia
+   guide.theory.absorption.faraday
+   guide.theory.absorption.lbl
+   guide.theory.absorption.lookup
+   guide.theory.absorption.predef
+   guide.theory.absorption.xsec
+  

--- a/doc/arts/guide.theory.absorption.xsec.rst
+++ b/doc/arts/guide.theory.absorption.xsec.rst
@@ -1,0 +1,4 @@
+Polynomial Cross-section Absorption
+###################################
+
+TBD

--- a/doc/arts/guide.user.atmospheric_field.rst
+++ b/doc/arts/guide.user.atmospheric_field.rst
@@ -1,7 +1,9 @@
 .. _Sec Atmospheric Field:
 
-The atmosphere
+The Atmosphere
 ##############
+
+The atmosphere of ARTS is always fully 3D with coordinates of altitude, geodetic latitude, and longitude.
 
 The atmosphere in ARTS is represented by three key components:
 the atmospheric field, the atmospheric field data, and the atmospheric point.
@@ -27,9 +29,7 @@ Key notations:
 The full atmospheric field
 **************************
 
-An atmospheric field is represented by the class :class:`~pyarts.arts.AtmField`.  It is
-often presumed in ARTS that it is possible to draw a path through the atmosphere that
-either hits the top of the atmosphere or the surface of the planet.
+An atmospheric field is represented by the class :class:`~pyarts.arts.AtmField`.
 
 The atmospheric field holds a collection of atmospheric field data, :class:`~pyarts.arts.AtmData`,
 that can be accessed and modified through a :class:`dict`-like interface.
@@ -37,13 +37,13 @@ An atmospheric field has a maximum altitude, :attr:`~pyarts.arts.AtmField.top_of
 It has no minimum altitude, instead relying on an external ellipsoid and elevation field to define the surface of the planet below it.
 The ellipsoid and the elevation field are (often) part of the :class:`~pyarts.arts.SurfaceField` class
 and are described in :ref:`Sec Surface Field`.
-The atmospheric field can be called as if it were a function taking altitude, latitude, and longitude 
+The atmospheric field can be called as if it were a function taking altitude, geodetic latitude, and longitude 
 coordinate arguments to compute or extract the local atmospheric state, :class:`~pyarts.arts.AtmPoint`.
 
 The core operations on ``atm_field`` are:
 
 - ``atm_field[key]``: Accessing relevant atmospheric field data: :class:`~pyarts.arts.AtmData`. See `Atmospheric field/point data access`_ for more information on what constitutes a valid ``key``
-- ``atm_field.top_of_atmosphere``: The maximum altitude of the atmosphere in meters.
+- ``atm_field.top_of_atmosphere``: The maximum altitude of the atmosphere.
   This is the altitude above which the atmospheric field is undefined.
 - ``atm_field(alt, lat, lon)``: Compute the local atmospheric state (:class:`~pyarts.arts.AtmPoint`) at the given coordinate.
   It is an error to call this with ``alt > atm_field.top_of_atmosphere``.
@@ -201,8 +201,8 @@ The atmospheric field data is a core component of the atmospheric field.
 It is stored in an instance of :class:`~pyarts.arts.AtmData`.
 This type holds the entire atmospheric data for a single atmospheric property,
 such as the full 3D temperature field, the full 3D pressure field, etc.
-It also holds the logic for how to interpolate and extrapolate this data to any altitude, latitude, and longitude point.
-As such, atmospheric field data can also be called as if it were a function taking altitude, latitude, and longitude
+It also holds the logic for how to interpolate and extrapolate this data to any altitude, geodetic latitude, and longitude point.
+As such, atmospheric field data can also be called as if it were a function taking altitude, geodetic latitude, and longitude
 to return the local floating point state of the atmospheric property it holds.
 
 These are the core operations on ``atm_data``:
@@ -212,16 +212,16 @@ These are the core operations on ``atm_data``:
   What is "allowed" is defined by the data type.
 - ``atm_data.alt_low``: The settings for how to extrapolate below the allowed altitude.
   What is "allowed" is defined by the data type.
-- ``atm_data.lat_upp``: The settings for how to extrapolate above the allowed latitude.
+- ``atm_data.lat_upp``: The settings for how to extrapolate above the allowed geodetic latitude.
   What is "allowed" is defined by the data type.
-- ``atm_data.lat_low``: The settings for how to extrapolate below the allowed latitude.
+- ``atm_data.lat_low``: The settings for how to extrapolate below the allowed geodetic latitude.
   What is "allowed" is defined by the data type.
 - ``atm_data.lon_upp``: The settings for how to extrapolate above the allowed longitude.
   What is "allowed" is defined by the data type.
 - ``atm_data.lon_low``: The settings for how to extrapolate below the allowed longitude.
   What is "allowed" is defined by the data type.
 - ``atm_data(alt, lat, lon)``: Extract the floating point value of the data at one
-  specific altitude, latitude, and longitude.  Returns a single float.
+  specific altitude, geodetic latitude, and longitude.  Returns a single float.
   Cannot respect the top of the atmosphere because it is not available to the data.
   Instead, will strictly respect the extrapolation settings.
 
@@ -313,7 +313,7 @@ GriddedField3
 ^^^^^^^^^^^^^
 
 If the atmospheric data is of the type :class:`~pyarts.arts.GriddedField3`,
-the data is defined on a grid of altitude, latitude, and longitude.
+the data is defined on a grid of altitude, geodetic latitude, and longitude.
 It interpolates linearly between the grid points when extracting point-wise data.
 For sake of this linear interpolation, longitude is treated as a cyclic coordinate.
 This data type fully respects the rules of extrapolation outside its grid.
@@ -359,7 +359,7 @@ NumericTernaryOperator
 ^^^^^^^^^^^^^^^^^^^^^^
 
 This operator (:class:`~pyarts.arts.NumericTernaryOperator`) represents that the atmospheric property is purely
-a function of altitude, latitude, and longitude.  The operator takes three arguments and returns a float.
+a function of altitude, geodetic latitude, and longitude.  The operator takes three arguments and returns a float.
 Extrapolation rules are not relevant for this data type as it is a function.
 An example of using :class:`~pyarts.arts.NumericTernaryOperator` as atmospheric field data is given in the following code block.
 

--- a/doc/arts/guide.user.surface_field.rst
+++ b/doc/arts/guide.user.surface_field.rst
@@ -3,6 +3,9 @@
 The surface and planet
 ######################
 
+The surface of ARTS is always fully 2D in geodetic latitude and longitude.
+It holds the basic shape of the planet, the ellipsoid.
+
 The surface in ARTS is represented by three key components: the surface field,
 the surface field data, and the surface point.
 
@@ -29,7 +32,6 @@ The full surface field
 **********************
 
 A surface field is represented by the class :class:`~pyarts.arts.SurfaceField`.
-It is presumed that a surface field can be intersected by a ray.
 
 The surface field holds a collection of surface field data, :class:`~pyarts.arts.SurfaceData`,
 that can be accessed and modified through a :class:`dict`-like interface.
@@ -38,7 +40,7 @@ planet it represents.
 It may contain an elevation field that modifies the shape of the surface.  It is often accompanied by an
 atmospheric field that defines the state of the surface above the surface.  See :ref:`Sec surface Field`
 for more details on the atmospheric field.
-The surface field can be called as if it were a function taking latitude and longitude 
+The surface field can be called as if it were a function taking geodetic latitude and longitude 
 coordinate arguments to compute or extract the local surface state, :class:`~pyarts.arts.SurfacePoint`.
 
 The core operations on ``surf_field`` are:
@@ -176,23 +178,23 @@ The surface field data is a core component of the surface field.
 It is stored in an instance of :class:`~pyarts.arts.SurfaceData`.
 This type holds the entire surface data for a single surface property,
 such as the full 2D temperature field, the full 2D elevation field, etc.
-It also holds the logic for how to interpolate and extrapolate this data to any latitude and longitude point.
-As such, surface field data can also be called as if it were a function taking latitude and longitude
+It also holds the logic for how to interpolate and extrapolate this data to any geodetic latitude and longitude point.
+As such, surface field data can also be called as if it were a function taking geodetic latitude and longitude
 to return the local floating point state of the surface property it holds.
 
 These are the core operations on ``surf_data``:
 
 - ``surf_data.data``: The core data in variant form.  See `Data types`_ for what it represents.
-- ``surf_data.lat_upp``: The settings for how to extrapolate above the allowed latitude.
+- ``surf_data.lat_upp``: The settings for how to extrapolate above the allowed geodetic latitude.
   What is "allowed" is defined by the data type.
-- ``surf_data.lat_low``: The settings for how to extrapolate below the allowed latitude.
+- ``surf_data.lat_low``: The settings for how to extrapolate below the allowed geodetic latitude.
   What is "allowed" is defined by the data type.
 - ``surf_data.lon_upp``: The settings for how to extrapolate above the allowed longitude.
   What is "allowed" is defined by the data type.
 - ``surf_data.lon_low``: The settings for how to extrapolate below the allowed longitude.
   What is "allowed" is defined by the data type.
 - ``surf_data(lat, lon)``: Extract the floating point value of the data at one
-  specific latitude and longitude.  Returns a single float.
+  specific geodetic latitude and longitude.  Returns a single float.
 
 Shorthand graph:
 
@@ -271,7 +273,7 @@ GriddedField2
 ^^^^^^^^^^^^^
 
 If the surface data is of the type :class:`~pyarts.arts.GriddedField2`,
-the data is defined on a grid of latitude and longitude.
+the data is defined on a grid of geodetic latitude and longitude.
 It interpolates linearly between the grid points when extracting point-wise data.
 For sake of this linear interpolation, longitude is treated as a cyclic coordinate.
 This data type fully respects the rules of extrapolation outside its grid.
@@ -286,7 +288,7 @@ NumericBinaryOperator
 ^^^^^^^^^^^^^^^^^^^^^
 
 This operator (:class:`~pyarts.arts.NumericBinaryOperator`) represents that the surface property is purely
-a function of latitude and longitude.  The operator takes two arguments and returns a float.
+a function of geodetic latitude and longitude.  The operator takes two arguments and returns a float.
 Extrapolation rules are not relevant for this data type as it is a function.
 
 .. tip::

--- a/doc/arts/references.bib
+++ b/doc/arts/references.bib
@@ -2016,3 +2016,21 @@ abstract = {Total internal partition sums (TIPS) are reported for the 181 isotop
   doi =          {10.1016/j.jqsrt.2019.04.001},
   file =         {kochanov19_infrared_jqsrt.pdf},
 }
+
+@article{johansson2016,
+author = {Johansson, H. and Forssén, C.},
+title = {Fast and Accurate Evaluation of {W}igner $3j$, $6j$, and $9j$ Symbols Using Prime Factorization and Multiword Integer Arithmetic},
+journal = {SIAM Journal on Scientific Computing},
+volume = {38},
+number = {1},
+pages = {A376-A384},
+year = {2016},
+doi = {10.1137/15M1021908},
+URL = { 
+        https://doi.org/10.1137/15M1021908 
+},
+eprint = { 
+        https://doi.org/10.1137/15M1021908
+    
+}
+}


### PR DESCRIPTION
This fixes some of the documentation concerns of @erikssonpatrick 

Three points I have not fixed and could use feedback:

1) I did not add a list of available species.  It is available via the SpeciesEnum link.  I added a small table to SpeciesIsotope so that also the species there are seen.
2) There is no limitation in ARTS 3 for the isotopologue ratio to be a constant.  By default, I use the same as for ARTS 2, which is a scalar, but you are free to change this just as you are the temperature or pressure to any other style.
3) All the method's that initialize a surface field set the surface elevation to 0 by default.  I find this a good compromise.  But there's no builtin assumption.  If you manage to create a bare-bone surface field, it will not have any elevation and you will run into trouble if you try to use it.  This is in agreement with past discussions we've had about easy things being easy and errors are thrown when required.