### PR TITLE
Require nanobind < 2.5.0 for now

### DIFF
--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -19,7 +19,7 @@ dependencies:
         - libclang
         - libcxx
         - llvm-openmp
-        - nanobind
+        - nanobind < 2.5.0
         - nbsphinx
         - matplotlib
         - netcdf4

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -18,7 +18,7 @@ dependencies:
         - libmicrohttpd
         - llvm-openmp
         - matplotlib
-        - nanobind
+        - nanobind < 2.5.0
         - nbsphinx
         - netcdf4
         - ninja

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -9,7 +9,7 @@ dependencies:
         - lark-parser
         - libcxx
         - matplotlib
-        - nanobind
+        - nanobind < 2.5.0
         - nbsphinx
         - netcdf4
         - ninja


### PR DESCRIPTION
nb 2.5.0 prohibits enum types as a target for implicitly_convertible, breaking a lot of our code.