### PR TITLE
Profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ option (ENABLE_CCACHE "Turn on CCACHE" ON)
 option (ENABLE_CXX23 "Turn on C++23 (Don't use, only for future updates)" OFF)
 option (ENABLE_IPO "Turn on IPO (experimental)" OFF)
 option (ENABLE_MPI "Turn on MPI" OFF)
+option (ENABLE_ARTS_PROFILING "Turn on the profiling macro" OFF)
 option (ENABLE_NETCDF "Turn on NETCDF support" OFF)
 option (ENABLE_PCH "Turn on precomnpiled headers" OFF)
 option (DISABLE_SHTNS "Turn off SHTns" OFF)
@@ -94,6 +95,16 @@ endif()
 
 if(ENABLE_ARTS_LGPL)
   message(STATUS "Compiling ARTS under LGPL")
+endif()
+
+########### ARTS Profiling flag ##########
+
+if (ENABLE_ARTS_PROFILING)
+  add_definitions(-DARTS_PROFILING=1)
+  message(STATUS "Compiling ARTS with time profiling information")
+else()
+  add_definitions(-DARTS_PROFILING=0)
+  message(STATUS "Compiling ARTS without time profiling information")
 endif()
 
 ########### C++20/23 Support ##########

--- a/doc/arts/guide.theory.absorption.lbl.rst
+++ b/doc/arts/guide.theory.absorption.lbl.rst
@@ -313,7 +313,7 @@ In equation form:
 
   L = \frac{\sum_i x_i L_i}{\sum_i x_i},
 
-where :math:`L` is a placeholder for any of the line shape parameters, and :math:`x` is the volume mixing ratio, and :math:`i` is a species index.
+where :math:`L` is a placeholder for any of the line shape parameters, and :math:`x` is the volume-mixing ratio, and :math:`i` is a species index.
 The normalization is there to allow fewer than all species to contribute to the line shape parameters.
 
 The temperature dependencies of the individual :math:`L_i` are computed based on avaiable data.
@@ -370,7 +370,15 @@ For local thermodynamic equilibrium (LTE), the line strength is given by
 .. math::
 
   S_{LTE} = \rho \frac{c^2\nu}{8\pi} \left[1 - \exp\left(-\frac{h\nu}{kT}\right)\right]
-  \frac{g_u\exp\left(-\frac{E_l}{kT}\right)}{Q(T)} \frac{A_{lu}}{\nu_0^3}
+  \frac{g_u\exp\left(-\frac{E_l}{kT}\right)}{Q(T)} \frac{A_{lu}}{\nu_0^3},
+
+where :math:`\rho` is the number density of the absorbing species,
+
+.. math::
+
+  \rho = \mathrm{VMR}\frac{P}{kT},
+
+where VMR is the volume-mixing ratio of the absorbing species.
 
 .. _lbl-nlte:
 

--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -31,7 +31,7 @@ dependencies:
         - requests
         - scipy
         - setuptools
-        - sphinx=8
+        - sphinx >=8,<8.2.0
         - sphinx-copybutton
         - sphinx-favicon
         - sphinx-rtd-theme=3

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -29,7 +29,7 @@ dependencies:
         - requests
         - scipy
         - setuptools
-        - sphinx=8
+        - sphinx >=8,<8.2.0
         - sphinx-copybutton
         - sphinx-favicon
         - sphinx-rtd-theme=3

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -21,7 +21,7 @@ dependencies:
         - requests
         - scipy
         - setuptools
-        - sphinx=8
+        - sphinx >=8,<8.2.0
         - sphinx-copybutton
         - sphinx-favicon
         - sphinx-rtd-theme=3

--- a/src/core/artstime/CMakeLists.txt
+++ b/src/core/artstime/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(artstime STATIC artstime.cc)
+add_library(artstime STATIC artstime.cc time_report.cc)
 
 target_include_directories(artstime PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 target_link_libraries(artstime PUBLIC matpack)

--- a/src/core/artstime/time_report.cc
+++ b/src/core/artstime/time_report.cc
@@ -41,8 +41,13 @@ std::string get_report(bool clear) {
     const auto min = *stdr::min_element(deltas);
 
     total_time.push_back(sum);
-    vec.push_back(std::format(
-        "| {0} | {1} | {2} | {3} | {4} | {5} |\n", name, avg, N, min, max, sum));
+    vec.push_back(std::format("| {0} | {1} | {2} | {3} | {4} | {5} |\n",
+                              name,
+                              avg,
+                              N,
+                              min,
+                              max,
+                              sum));
   }
 
   if (clear) profile_report.clear();
@@ -53,7 +58,8 @@ std::string get_report(bool clear) {
       vec);
 
   return std::format(
-      "| Function | Average Time | Times called | Min delta | Max delta | Total time |\n"
+      "| Function | Average time | Times called | Min time | Max time | Total time |\n"
+      "| -------- | ------------ | ------------ | -------- | -------- | ---------- |\n"
       "{}",
       vec);
 }

--- a/src/core/artstime/time_report.cc
+++ b/src/core/artstime/time_report.cc
@@ -42,13 +42,13 @@ std::string get_report(bool clear) {
     const auto min = *stdr::min_element(deltas);
 
     total_time.push_back(sum);
-    vec.push_back(std::format("| {0} | {1}ms | {2} | {3}ms | {4}ms | {5}ms |\n",
+    vec.push_back(std::format("| {0} | {1}μs | {3}μs | {4}μs | {5}μs | {2} |\n",
                               name,
-                              std::chrono::duration_cast<std::chrono::milliseconds>(avg).count(),
+                              std::chrono::duration_cast<std::chrono::microseconds>(avg).count(),
                               N,
-                              std::chrono::duration_cast<std::chrono::milliseconds>(min).count(),
-                              std::chrono::duration_cast<std::chrono::milliseconds>(max).count(),
-                              std::chrono::duration_cast<std::chrono::milliseconds>(sum).count()));
+                              std::chrono::duration_cast<std::chrono::microseconds>(min).count(),
+                              std::chrono::duration_cast<std::chrono::microseconds>(max).count(),
+                              std::chrono::duration_cast<std::chrono::microseconds>(sum).count()));
   }
 
   if (clear) profile_report.clear();
@@ -59,8 +59,8 @@ std::string get_report(bool clear) {
       vec);
 
   return std::format(
-      "| Function | Average time | Times called | Min time | Max time | Total time |\n"
-      "| -------- | ------------ | ------------ | -------- | -------- | ---------- |\n"
+      "| Function | Average time | Min time | Max time | Total time | Times called |\n"
+      "| -------- | ------------ | -------- | -------- | ---------- | ------------ |\n"
       "{}",
       vec);
 }

--- a/src/core/artstime/time_report.cc
+++ b/src/core/artstime/time_report.cc
@@ -2,6 +2,7 @@
 
 #include <sorting.h>
 
+#include <chrono>
 #include <mutex>
 
 namespace {
@@ -41,13 +42,13 @@ std::string get_report(bool clear) {
     const auto min = *stdr::min_element(deltas);
 
     total_time.push_back(sum);
-    vec.push_back(std::format("| {0} | {1} | {2} | {3} | {4} | {5} |\n",
+    vec.push_back(std::format("| {0} | {1}ms | {2} | {3}ms | {4}ms | {5}ms |\n",
                               name,
-                              avg,
+                              std::chrono::duration_cast<std::chrono::milliseconds>(avg).count(),
                               N,
-                              min,
-                              max,
-                              sum));
+                              std::chrono::duration_cast<std::chrono::milliseconds>(min).count(),
+                              std::chrono::duration_cast<std::chrono::milliseconds>(max).count(),
+                              std::chrono::duration_cast<std::chrono::milliseconds>(sum).count()));
   }
 
   if (clear) profile_report.clear();

--- a/src/core/artstime/time_report.cc
+++ b/src/core/artstime/time_report.cc
@@ -1,10 +1,14 @@
 #include "time_report.h"
 
+#include <sorting.h>
+
 #include <mutex>
 
+namespace {
 using Delta = Time::InternalTimeStep;
 std::unordered_map<std::string, std::vector<Delta>> profile_report;
 std::mutex m;
+};  // namespace
 
 namespace arts {
 profiler::~profiler() {
@@ -15,13 +19,18 @@ profiler::~profiler() {
 }
 
 std::string get_report(bool clear) {
-  if (profile_report.empty()) return "No profiling data available.\n";
+  if (profile_report.empty()) {
+#if ARTS_PROFILING
+    return "No profiling data available.\n";
+#else
+    return "Automatic profiling is disabled and no manual profiling performed.\n";
+#endif
+  }
 
   std::scoped_lock lock{m};
 
-  std::string out{
-      "| Function-name | Average Time | Times Called | Min Time | Max Time |\n"};
-  auto inc = std::back_inserter(out);
+  std::vector<std::string> vec{};
+  std::vector<Delta> total_time{};
   for (const auto& [name, deltas] : profile_report) {
     const Size N = deltas.size();
     if (N == 0) continue;
@@ -30,12 +39,22 @@ std::string get_report(bool clear) {
     const auto avg = sum / N;
     const auto max = *stdr::max_element(deltas);
     const auto min = *stdr::min_element(deltas);
-    std::format_to(
-        inc, "| {0} | {1} | {2} | {3} | {4} |\n", name, avg, N, min, max);
+
+    total_time.push_back(sum);
+    vec.push_back(std::format(
+        "| {0} | {1} | {2} | {3} | {4} | {5} |\n", name, avg, N, min, max, sum));
   }
 
   if (clear) profile_report.clear();
 
-  return out;
+  bubble_sort_by(
+      [&](Index i, Index j) { return total_time[i] < total_time[j]; },
+      total_time,
+      vec);
+
+  return std::format(
+      "| Function | Average Time | Times called | Min delta | Max delta | Total time |\n"
+      "{}",
+      vec);
 }
 }  // namespace arts

--- a/src/core/artstime/time_report.cc
+++ b/src/core/artstime/time_report.cc
@@ -1,0 +1,41 @@
+#include "time_report.h"
+
+#include <mutex>
+
+using Delta = Time::InternalTimeStep;
+std::unordered_map<std::string, std::vector<Delta>> profile_report;
+std::mutex m;
+
+namespace arts {
+profiler::~profiler() {
+  const Time end{};
+  const auto diff = end - start;
+  std::scoped_lock lock{m};
+  profile_report[name].push_back(diff);
+}
+
+std::string get_report(bool clear) {
+  if (profile_report.empty()) return "No profiling data available.\n";
+
+  std::scoped_lock lock{m};
+
+  std::string out{
+      "| Function-name | Average Time | Times Called | Min Time | Max Time |\n"};
+  auto inc = std::back_inserter(out);
+  for (const auto& [name, deltas] : profile_report) {
+    const Size N = deltas.size();
+    if (N == 0) continue;
+
+    const auto sum = std::accumulate(deltas.begin(), deltas.end(), Delta{});
+    const auto avg = sum / N;
+    const auto max = *stdr::max_element(deltas);
+    const auto min = *stdr::min_element(deltas);
+    std::format_to(
+        inc, "| {0} | {1} | {2} | {3} | {4} |\n", name, avg, N, min, max);
+  }
+
+  if (clear) profile_report.clear();
+
+  return out;
+}
+}  // namespace arts

--- a/src/core/artstime/time_report.h
+++ b/src/core/artstime/time_report.h
@@ -18,7 +18,7 @@ struct profiler {
 std::string get_report(bool clear=true);
 }  // namespace arts
 
-#if ARTS_PROFILER
+#if ARTS_PROFILING
 #define ARTS_TIME_REPORT arts::profiler _arts_prof_var_name_{};
 #else
 #define ARTS_TIME_REPORT

--- a/src/core/artstime/time_report.h
+++ b/src/core/artstime/time_report.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <source_location>
+
+#include "artstime.h"
+
+namespace arts {
+struct profiler {
+  std::string name;
+  Time start;
+
+  profiler(std::source_location loc = std::source_location::current())
+      : name(loc.function_name()), start(Time{}) {}
+
+  ~profiler();
+};
+
+std::string get_report(bool clear=true);
+}  // namespace arts
+
+#if ARTS_PROFILER
+#define ARTS_TIME_REPORT arts::profiler _arts_prof_var_name_{};
+#else
+#define ARTS_TIME_REPORT
+#endif

--- a/src/m_abs.cc
+++ b/src/m_abs.cc
@@ -34,6 +34,7 @@
 #endif
 
 void mirror_los(Vector& los_mirrored, const ConstVectorView& los) {
+  ARTS_TIME_REPORT
   los_mirrored.resize(2);
   los_mirrored[0] = 180 - los[0];
   los_mirrored[1] = los[1] + 180;
@@ -46,6 +47,7 @@ Numeric dotprod_with_los(const ConstVectorView& los,
                          const Numeric& u,
                          const Numeric& v,
                          const Numeric& w) {
+  ARTS_TIME_REPORT
   // Strength of field
   const Numeric f = sqrt(u * u + v * v + w * w);
 
@@ -73,6 +75,7 @@ void absorption_speciesSet(  // WS Output:
     ArrayOfArrayOfSpeciesTag& absorption_species,
     // Control Parameters:
     const ArrayOfString& names) try {
+  ARTS_TIME_REPORT
   absorption_species.resize(names.size());
 
   //cout << "Names: " << names << "\n";
@@ -92,6 +95,8 @@ void absorption_speciesDefineAllInScenario(  // WS Output:
     ArrayOfArrayOfSpeciesTag& tgs,
     // Control Parameters:
     const String& basename) {
+  ARTS_TIME_REPORT
+
   // We want to make lists of included and excluded species:
   ArrayOfString included(0), excluded(0);
 
@@ -122,6 +127,8 @@ void absorption_speciesDefineAllInScenario(  // WS Output:
 /* Workspace method: Doxygen documentation will be auto-generated */
 void absorption_speciesDefineAll(  // WS Output:
     ArrayOfArrayOfSpeciesTag& absorption_species) {
+  ARTS_TIME_REPORT
+
   // Species lookup data:
 
   // We want to make lists of all species
@@ -166,6 +173,8 @@ void propagation_matrixInit(  //WS Output
     //WS Input
     const JacobianTargets& jacobian_targets,
     const AscendingGrid& frequency_grid) {
+  ARTS_TIME_REPORT
+
   const Index nf = frequency_grid.size();
   const Index nq = jacobian_targets.target_count();
 
@@ -198,6 +207,8 @@ void propagation_matrixAddFaraday(
     const JacobianTargets& jacobian_targets,
     const AtmPoint& atm_point,
     const PropagationPathPoint& path_point) {
+  ARTS_TIME_REPORT
+
   Index ife = -1;
   for (Size sp = 0; sp < absorption_species.size() && ife < 0; sp++) {
     if (absorption_species[sp].FreeElectrons()) {
@@ -296,11 +307,15 @@ void propagation_matrixAddFaraday(
 /* Workspace method: Doxygen documentation will be auto-generated */
 void propagation_matrixZero(PropmatVector& propagation_matrix,
                             const AscendingGrid& frequency_grid) {
+  ARTS_TIME_REPORT
+
   propagation_matrix = PropmatVector(frequency_grid.size());
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
 void propagation_matrixForceNegativeToZero(PropmatVector& propagation_matrix) {
+  ARTS_TIME_REPORT
+
   for (Size i = 0; i < propagation_matrix.size(); i++)
     if (propagation_matrix[i].A() < 0.0) propagation_matrix[i] = 0.0;
   ;
@@ -309,12 +324,16 @@ void propagation_matrixForceNegativeToZero(PropmatVector& propagation_matrix) {
 /* Workspace method: Doxygen documentation will be auto-generated */
 void isotopologue_ratiosInitFromBuiltin(
     SpeciesIsotopologueRatios& isotopologue_ratios) {
+  ARTS_TIME_REPORT
+
   isotopologue_ratios = Species::isotopologue_ratiosInitFromBuiltin();
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
 void isotopologue_ratiosInitFromHitran(
     SpeciesIsotopologueRatios& isotopologue_ratios) {
+  ARTS_TIME_REPORT
+
   isotopologue_ratios = Hitran::isotopologue_ratios();
 }
 
@@ -333,6 +352,8 @@ void propagation_matrix_agendaAuto(
     const Index& water_interp_order,
     const Index& f_interp_order,
     const Numeric& extpolfac) {
+  ARTS_TIME_REPORT
+
   AgendaCreator agenda("propagation_matrix_agenda");
 
   const SpeciesTagTypeStatus any_species(absorption_species);

--- a/src/m_atm.cc
+++ b/src/m_atm.cc
@@ -32,12 +32,16 @@
 void atmospheric_fieldInit(AtmField &atmospheric_field,
                            const Numeric &top_of_atmosphere,
                            const String &default_isotopologue) {
+  ARTS_TIME_REPORT
+
   atmospheric_field = AtmField{to<IsoRatioOption>(default_isotopologue)};
   atmospheric_field.top_of_atmosphere = top_of_atmosphere;
 }
 
 void atmospheric_pointInit(AtmPoint &atmospheric_point,
                            const String &default_isotopologue) {
+  ARTS_TIME_REPORT
+
   atmospheric_point = AtmPoint{to<IsoRatioOption>(default_isotopologue)};
 }
 
@@ -110,6 +114,8 @@ void atmospheric_fieldAppendBaseData(AtmField &atmospheric_field,
                                      const Index &replace_existing,
                                      const Index &allow_missing_pressure,
                                      const Index &allow_missing_temperature) {
+  ARTS_TIME_REPORT
+
   std::unordered_map<AtmKey, Index> keys;
 
   for (auto &key : enumtyps::AtmKeyTypes) {
@@ -202,6 +208,8 @@ void atmospheric_fieldAppendLineSpeciesData(
     const String &extrapolation,
     const Index &missing_is_zero,
     const Index &replace_existing) {
+  ARTS_TIME_REPORT
+
   std::unordered_map<SpeciesEnum, Index> keys;
   keysSpecies(keys, absorption_bands);
 
@@ -231,6 +239,8 @@ void atmospheric_fieldAppendLineIsotopologueData(
     const String &extrapolation,
     const Index &missing_is_zero,
     const Index &replace_existing) {
+  ARTS_TIME_REPORT
+
   std::unordered_map<SpeciesIsotope, Index> keys;
   keysIsotopologue(keys, absorption_bands);
 
@@ -265,6 +275,8 @@ void atmospheric_fieldAppendLineLevelData(
     const String &extrapolation,
     const Index &missing_is_zero,
     const Index &replace_existing) {
+  ARTS_TIME_REPORT
+
   std::unordered_map<QuantumIdentifier, Index> keys;
   keysNLTE(keys, absorption_bands);
 
@@ -299,6 +311,8 @@ void atmospheric_fieldAppendTagsSpeciesData(
     const String &extrapolation,
     const Index &missing_is_zero,
     const Index &replace_existing) {
+  ARTS_TIME_REPORT
+
   std::unordered_map<SpeciesEnum, Index> keys;
   keysSpecies(keys, absorption_species);
 
@@ -330,6 +344,8 @@ void atmospheric_fieldAppendCIASpeciesData(
     const String &extrapolation,
     const Index &missing_is_zero,
     const Index &replace_existing) {
+  ARTS_TIME_REPORT
+
   std::unordered_map<SpeciesEnum, Index> keys;
   keysSpecies(keys, absorption_cia_data);
 
@@ -359,6 +375,8 @@ void atmospheric_fieldAppendXsecSpeciesData(
     const String &extrapolation,
     const Index &missing_is_zero,
     const Index &replace_existing) {
+  ARTS_TIME_REPORT
+
   std::unordered_map<SpeciesEnum, Index> keys;
   keysSpecies(keys, absorption_xsec_fit_data);
 
@@ -388,6 +406,8 @@ void atmospheric_fieldAppendPredefSpeciesData(
     const String &extrapolation,
     const Index &missing_is_zero,
     const Index &replace_existing) {
+  ARTS_TIME_REPORT
+
   std::unordered_map<SpeciesEnum, Index> keys;
   keysSpecies(keys, absorption_predefined_model_data);
 
@@ -409,6 +429,8 @@ void atmospheric_fieldAppendAbsorptionData(const Workspace &ws,
                                            const Index &replace_existing,
                                            const Index &load_isot,
                                            const Index &load_nlte) {
+  ARTS_TIME_REPORT
+
   std::unordered_map<SpeciesEnum, Index> keys;
 
   if (const String lines_str = "absorption_bands";
@@ -471,6 +493,8 @@ void atmospheric_fieldAppendAbsorptionData(const Workspace &ws,
 }
 
 void atmospheric_fieldIGRF(AtmField &atmospheric_field, const Time &time) {
+  ARTS_TIME_REPORT
+
   using IGRF::igrf;
 
   //! We need explicit planet-size as IGRF requires the radius
@@ -610,6 +634,8 @@ void atmospheric_fieldHydrostaticPressure(
     const Numeric &fixed_specific_gas_constant,
     const Numeric &fixed_atm_temperature,
     const String &hydrostatic_option) {
+  ARTS_TIME_REPORT
+
   using enum atmospheric_fieldHydrostaticPressureDataOptions;
   using enum HydrostaticPressureOption;
 
@@ -721,6 +747,8 @@ void atmospheric_fieldHydrostaticPressure(
     const Numeric &fixed_specific_gas_constant,
     const Numeric &fixed_atm_temperature,
     const String &hydrostatic_option) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(
       not atmospheric_field.has(AtmKey::t),
       "Must have a temperature field to call this workspace method with a single Numeric reference pressure, so that latitude and longitude grids can be extracted")
@@ -802,8 +830,11 @@ void atmospheric_fieldRegrid(AtmField &atmospheric_field,
                              const AscendingGrid &lat,
                              const AscendingGrid &lon,
                              const String &extrapolation) {
-  ARTS_USER_ERROR_IF(
-      not atmospheric_field.contains(key), R"(No scattering species key "{}" in atmospheric_field)", key)
+  ARTS_TIME_REPORT
+
+  ARTS_USER_ERROR_IF(not atmospheric_field.contains(key),
+                     R"(No scattering species key "{}" in atmospheric_field)",
+                     key)
 
   atmospheric_fieldRegridTemplate(
       atmospheric_field[key], key, alt, lat, lon, extrapolation);
@@ -815,8 +846,11 @@ void atmospheric_fieldRegrid(AtmField &atmospheric_field,
                              const AscendingGrid &lat,
                              const AscendingGrid &lon,
                              const String &extrapolation) {
-  ARTS_USER_ERROR_IF(
-      not atmospheric_field.contains(key), R"(No VMR key "{}" in atmospheric_field)", key)
+  ARTS_TIME_REPORT
+
+  ARTS_USER_ERROR_IF(not atmospheric_field.contains(key),
+                     R"(No VMR key "{}" in atmospheric_field)",
+                     key)
 
   atmospheric_fieldRegridTemplate(
       atmospheric_field[key], key, alt, lat, lon, extrapolation);
@@ -828,8 +862,11 @@ void atmospheric_fieldRegrid(AtmField &atmospheric_field,
                              const AscendingGrid &lat,
                              const AscendingGrid &lon,
                              const String &extrapolation) {
-  ARTS_USER_ERROR_IF(
-      not atmospheric_field.contains(key), R"(No isotopologue ratio key "{}" in atmospheric_field)", key)
+  ARTS_TIME_REPORT
+
+  ARTS_USER_ERROR_IF(not atmospheric_field.contains(key),
+                     R"(No isotopologue ratio key "{}" in atmospheric_field)",
+                     key)
 
   atmospheric_fieldRegridTemplate(
       atmospheric_field[key], key, alt, lat, lon, extrapolation);
@@ -841,8 +878,11 @@ void atmospheric_fieldRegrid(AtmField &atmospheric_field,
                              const AscendingGrid &lat,
                              const AscendingGrid &lon,
                              const String &extrapolation) {
-  ARTS_USER_ERROR_IF(
-      not atmospheric_field.contains(key), R"(No NLTE key "{}" in atmospheric_field)", key)
+  ARTS_TIME_REPORT
+
+  ARTS_USER_ERROR_IF(not atmospheric_field.contains(key),
+                     R"(No NLTE key "{}" in atmospheric_field)",
+                     key)
 
   atmospheric_fieldRegridTemplate(
       atmospheric_field[key], key, alt, lat, lon, extrapolation);
@@ -854,8 +894,11 @@ void atmospheric_fieldRegrid(AtmField &atmospheric_field,
                              const AscendingGrid &lat,
                              const AscendingGrid &lon,
                              const String &extrapolation) {
-  ARTS_USER_ERROR_IF(
-      not atmospheric_field.contains(key), R"(No atmospheric key "{}" in atmospheric_field)", key)
+  ARTS_TIME_REPORT
+
+  ARTS_USER_ERROR_IF(not atmospheric_field.contains(key),
+                     R"(No atmospheric key "{}" in atmospheric_field)",
+                     key)
 
   atmospheric_fieldRegridTemplate(
       atmospheric_field[key], key, alt, lat, lon, extrapolation);
@@ -866,6 +909,8 @@ void atmospheric_fieldRegridAll(AtmField &atmospheric_field,
                                 const AscendingGrid &lat,
                                 const AscendingGrid &lon,
                                 const String &extrapolation) {
+  ARTS_TIME_REPORT
+
   for (auto &[key, data] : atmospheric_field.map<ScatteringSpeciesProperty>()) {
     atmospheric_fieldRegridTemplate(data, key, alt, lat, lon, extrapolation);
   }

--- a/src/m_background.cc
+++ b/src/m_background.cc
@@ -19,6 +19,8 @@ void spectral_radiance_backgroundAgendasAtEndOfPath(
     const SurfaceField& surface_field,
     const Agenda& spectral_radiance_space_agenda,
     const Agenda& spectral_radiance_surface_agenda) try {
+  ARTS_TIME_REPORT
+
   using enum PathPositionType;
   switch (ray_path_point.los_type) {
     case atm:
@@ -27,9 +29,7 @@ void spectral_radiance_backgroundAgendasAtEndOfPath(
     case subsurface:
       ARTS_USER_ERROR("Undefined what to do with a subsurface background")
       break;
-    case unknown:
-      ARTS_USER_ERROR("Undefined background type");
-      break;
+    case unknown: ARTS_USER_ERROR("Undefined background type"); break;
     case space:
       spectral_radiance_space_agendaExecute(
           ws,
@@ -89,7 +89,9 @@ StokvecVector from_temp(const ConstVectorView& frequency_grid,
 
 void spectral_radianceUniformCosmicBackground(
     StokvecVector& spectral_radiance, const AscendingGrid& frequency_grid) {
-  constexpr auto t = Constant::cosmic_microwave_background_temperature;
+  ARTS_TIME_REPORT
+
+  constexpr auto t  = Constant::cosmic_microwave_background_temperature;
   spectral_radiance = detail::from_temp(frequency_grid, t);
 }
 
@@ -99,6 +101,8 @@ void spectral_radianceSunOrCosmicBackground(
     const ArrayOfPropagationPathPoint& sun_path,
     const Sun& sun,
     const SurfaceField& surface_field) try {
+  ARTS_TIME_REPORT
+
   spectral_radiance.resize(frequency_grid.size());
 
   if (set_spectral_radiance_if_sun_intersection(
@@ -106,7 +110,8 @@ void spectral_radianceSunOrCosmicBackground(
     return;
 
   spectral_radianceUniformCosmicBackground(spectral_radiance, frequency_grid);
-} ARTS_METHOD_ERROR_CATCH
+}
+ARTS_METHOD_ERROR_CATCH
 
 void spectral_radianceSunsOrCosmicBackground(
     StokvecVector& spectral_radiance,
@@ -114,6 +119,8 @@ void spectral_radianceSunsOrCosmicBackground(
     const PropagationPathPoint& ray_path_point,
     const ArrayOfSun& suns,
     const SurfaceField& surface_field) {
+  ARTS_TIME_REPORT
+
   spectral_radiance.resize(frequency_grid.size());
 
   for (auto& sun : suns) {
@@ -133,6 +140,8 @@ void spectral_radianceSurfaceBlackbody(
     const SurfaceField& surface_field,
     const JacobianTargets& jacobian_targets,
     const PropagationPathPoint& ray_path_point) {
+  ARTS_TIME_REPORT
+
   constexpr auto key = SurfaceKey::t;
 
   ARTS_USER_ERROR_IF(not surface_field.contains(key),
@@ -148,7 +157,7 @@ void spectral_radianceSurfaceBlackbody(
   if (auto pair =
           jacobian_targets.find<Jacobian::SurfaceTarget>(SurfaceKeyVal{key});
       pair.first) {
-    const auto x_start = pair.second->x_start;
+    const auto x_start    = pair.second->x_start;
     const auto& surf_data = surface_field[key];
     const auto weights =
         surf_data.flat_weights(ray_path_point.pos[1], ray_path_point.pos[2]);
@@ -171,18 +180,24 @@ void spectral_radianceSurfaceBlackbody(
 void transmission_matrix_backgroundFromPathPropagationBack(
     MuelmatVector& transmission_matrix_background,
     const ArrayOfMuelmatVector& ray_path_transmission_matrix_cumulative) try {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(ray_path_transmission_matrix_cumulative.size() == 0,
                      "Cannot extract from empty list.")
-  transmission_matrix_background = ray_path_transmission_matrix_cumulative.back();
+  transmission_matrix_background =
+      ray_path_transmission_matrix_cumulative.back();
 }
 ARTS_METHOD_ERROR_CATCH
 
 void transmission_matrix_backgroundFromPathPropagationFront(
     MuelmatVector& transmission_matrix_background,
     const ArrayOfMuelmatVector& ray_path_transmission_matrix_cumulative) try {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(ray_path_transmission_matrix_cumulative.size() == 0,
                      "Cannot extract from empty list.")
-  transmission_matrix_background = ray_path_transmission_matrix_cumulative.front();
+  transmission_matrix_background =
+      ray_path_transmission_matrix_cumulative.front();
 }
 ARTS_METHOD_ERROR_CATCH
 
@@ -191,6 +206,8 @@ void spectral_radianceDefaultTransmission(
     StokvecMatrix& spectral_radiance_background,
     const AscendingGrid& frequency_grid,
     const JacobianTargets& jacobian_targets) {
+  ARTS_TIME_REPORT
+
   const Index nf = frequency_grid.size();
   const Index nq = jacobian_targets.x_size();
 

--- a/src/m_cat.cc
+++ b/src/m_cat.cc
@@ -9,6 +9,8 @@ void ReadCatalogData(PredefinedModelData& absorption_predefined_model_data,
                      const ArrayOfArrayOfSpeciesTag& absorption_species,
                      const String& basename,
                      const Index& ignore_missing) try {
+  ARTS_TIME_REPORT
+
   absorption_bandsReadSpeciesSplitCatalog(absorption_bands,
                                           absorption_species,
                                           basename + "lines/",

--- a/src/m_cia.cc
+++ b/src/m_cia.cc
@@ -40,6 +40,8 @@ void propagation_matrixAddCIA(  // WS Output:
     // WS Generic Input:
     const Numeric& T_extrapolfac,
     const Index& ignore_errors) {
+  ARTS_TIME_REPORT
+
   // Size of problem
   const Index nf = f_grid.size();
   const Index nq = jacobian_targets.target_count();
@@ -193,6 +195,8 @@ void CIARecordReadFromFile(  // WS GOutput:
     // WS Generic Input:
     const String& species_tag,
     const String& filename) {
+  ARTS_TIME_REPORT
+
   SpeciesTag species(species_tag);
 
   ARTS_USER_ERROR_IF(species.Type() != SpeciesTagType::Cia,
@@ -211,6 +215,8 @@ void absorption_cia_dataAddCIARecord(  // WS Output:
     // WS GInput:
     const CIARecord& cia_record,
     const Index& clobber) {
+  ARTS_TIME_REPORT
+
   Index cia_index = cia_get_index(
       absorption_cia_data, cia_record.Species(0), cia_record.Species(1));
   if (cia_index == -1)
@@ -227,6 +233,8 @@ void absorption_cia_dataReadFromCIA(  // WS Output:
     // WS Input:
     const ArrayOfArrayOfSpeciesTag& abs_species,
     const String& catalogpath) {
+  ARTS_TIME_REPORT
+
   ArrayOfString subfolders;
   subfolders.push_back("Main-Folder/");
   subfolders.push_back("Alternate-Folder/");
@@ -310,6 +318,8 @@ void absorption_cia_dataReadFromXML(  // WS Output:
     // WS Input:
     const ArrayOfArrayOfSpeciesTag& abs_species,
     const String& filename) {
+  ARTS_TIME_REPORT
+
   xml_read_from_file(filename, absorption_cia_data);
 
   // Check that all CIA tags from abs_species are present in the
@@ -358,6 +368,8 @@ void absorption_cia_dataReadSpeciesSplitCatalog(
     const ArrayOfArrayOfSpeciesTag& abs_species,
     const String& basename,
     const Index& ignore_missing_) try {
+  ARTS_TIME_REPORT
+
   const bool ignore_missing = static_cast<bool>(ignore_missing_);
 
   ArrayOfString names{};

--- a/src/m_covmat.cc
+++ b/src/m_covmat.cc
@@ -56,6 +56,8 @@ Target: {}
 
 void model_state_covariance_matrixInit(
     CovarianceMatrix& model_state_covariance_matrix) {
+  ARTS_TIME_REPORT
+
   model_state_covariance_matrix = CovarianceMatrix{};
 }
 
@@ -65,6 +67,8 @@ void model_state_covariance_matrixAdd(
     const AtmKeyVal& new_target,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(not jacobian_targets.finalized,
                      "Jacobian targets not finalized.");
 
@@ -88,6 +92,8 @@ void model_state_covariance_matrixAdd(
     const SurfaceKeyVal& new_target,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(not jacobian_targets.finalized,
                      "Jacobian targets not finalized.");
 
@@ -111,6 +117,8 @@ void model_state_covariance_matrixAdd(
     const LblLineKey& new_target,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(not jacobian_targets.finalized,
                      "Jacobian targets not finalized.");
 
@@ -134,6 +142,8 @@ void model_state_covariance_matrixAdd(
     const SensorKey& new_target,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(not jacobian_targets.finalized,
                      "Jacobian targets not finalized.");
 
@@ -157,6 +167,8 @@ void model_state_covariance_matrixAdd(
     const ErrorKey& new_target,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(not jacobian_targets.finalized,
                      "Jacobian targets not finalized.");
 
@@ -180,6 +192,8 @@ void model_state_covariance_matrixAddAtmosphere(
     const AtmKey& key,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   model_state_covariance_matrixAdd(model_state_covariance_matrix,
                                    jacobian_targets,
                                    AtmKeyVal{key},
@@ -193,6 +207,8 @@ void model_state_covariance_matrixAddAtmosphere(
     const SpeciesEnum& key,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   model_state_covariance_matrixAdd(model_state_covariance_matrix,
                                    jacobian_targets,
                                    AtmKeyVal{key},
@@ -206,6 +222,8 @@ void model_state_covariance_matrixAddAtmosphere(
     const SpeciesIsotope& key,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   model_state_covariance_matrixAdd(model_state_covariance_matrix,
                                    jacobian_targets,
                                    AtmKeyVal{key},
@@ -219,6 +237,8 @@ void model_state_covariance_matrixAddAtmosphere(
     const QuantumIdentifier& key,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   model_state_covariance_matrixAdd(model_state_covariance_matrix,
                                    jacobian_targets,
                                    AtmKeyVal{key},
@@ -232,6 +252,8 @@ void model_state_covariance_matrixAddSpeciesVMR(
     const SpeciesEnum& species,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   model_state_covariance_matrixAdd(model_state_covariance_matrix,
                                    jacobian_targets,
                                    AtmKeyVal{species},
@@ -245,6 +267,8 @@ void model_state_covariance_matrixAddIsotopologueRatio(
     const SpeciesIsotope& species,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   model_state_covariance_matrixAdd(model_state_covariance_matrix,
                                    jacobian_targets,
                                    AtmKeyVal{species},
@@ -258,6 +282,8 @@ void model_state_covariance_matrixAddMagneticField(
     const String& component,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   model_state_covariance_matrixAdd(model_state_covariance_matrix,
                                    jacobian_targets,
                                    to_mag(component),
@@ -271,6 +297,8 @@ void model_state_covariance_matrixAddWindField(
     const String& component,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   model_state_covariance_matrixAdd(model_state_covariance_matrix,
                                    jacobian_targets,
                                    to_wind(component),
@@ -283,6 +311,8 @@ void model_state_covariance_matrixAddTemperature(
     const JacobianTargets& jacobian_targets,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   model_state_covariance_matrixAdd(model_state_covariance_matrix,
                                    jacobian_targets,
                                    AtmKey::t,
@@ -295,6 +325,8 @@ void model_state_covariance_matrixAddPressure(
     const JacobianTargets& jacobian_targets,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   model_state_covariance_matrixAdd(model_state_covariance_matrix,
                                    jacobian_targets,
                                    AtmKey::p,
@@ -310,6 +342,8 @@ void measurement_vector_error_covariance_matrixConstant(
     CovarianceMatrix& measurement_vector_error_covariance_matrix,
     const ArrayOfSensorObsel& measurement_sensor,
     const Numeric& x) {
+  ARTS_TIME_REPORT
+
   measurement_vector_error_covariance_matrix = CovarianceMatrix{};
 
   const Size N = measurement_sensor.size();
@@ -333,6 +367,8 @@ void RetrievalFinalizeDiagonal(CovarianceMatrix& model_state_covariance_matrix,
                                const SurfaceField& surface_field,
                                const AbsorptionBands& absorption_bands,
                                const ArrayOfSensorObsel& measurement_sensor) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsFinalize(jacobian_targets,
                            atmospheric_field,
                            surface_field,

--- a/src/m_disort.cc
+++ b/src/m_disort.cc
@@ -22,6 +22,8 @@ void disort_spectral_radiance_fieldCalc(Tensor4& disort_spectral_radiance_field,
                                         Vector& disort_quadrature_weights,
                                         const DisortSettings& disort_settings,
                                         const Vector& phis) {
+  ARTS_TIME_REPORT
+
   using Conversion::acosd;
 
   const Index nv    = disort_settings.nfreq;
@@ -53,11 +55,14 @@ void disort_spectral_radiance_fieldCalc(Tensor4& disort_spectral_radiance_field,
     }
   }
 
-  ARTS_USER_ERROR_IF(error.size(), "Error occurred in disort-spectral:\n{}", error);
+  ARTS_USER_ERROR_IF(
+      error.size(), "Error occurred in disort-spectral:\n{}", error);
 }
 
 void disort_spectral_flux_fieldCalc(Tensor3& disort_spectral_flux_field,
                                     const DisortSettings& disort_settings) {
+  ARTS_TIME_REPORT
+
   const Index nv = disort_settings.nfreq;
   const Index np = disort_settings.nlay;
 
@@ -93,11 +98,15 @@ void spectral_radianceIntegrateDisort(
     const Tensor4& /*disort_spectral_radiance_field*/,
     const Vector& /*disort_quadrature_angles*/,
     const Vector& /*disort_quadrature_weights*/) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR("Not implemented")
 }
 
 void SpectralFluxDisort(Matrix& /*spectral_flux_field_up*/,
                         Matrix& /*spectral_flux_field_down*/,
                         const Tensor3& /*disort_spectral_flux_field*/) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR("Not implemented")
 }

--- a/src/m_disort_settings.cc
+++ b/src/m_disort_settings.cc
@@ -23,6 +23,8 @@ void disort_settingsInit(DisortSettings& disort_settings,
                          const Index& quadrature_dimension,
                          const Index& legendre_polynomial_dimension,
                          const Index& fourier_mode_dimension) {
+  ARTS_TIME_REPORT
+
   disort_settings   = DisortSettings();
   const Index nfreq = frequency_grid.size();
   const Index nlay  = ray_path.size() - 1;
@@ -38,6 +40,8 @@ void disort_settingsInit(DisortSettings& disort_settings,
 ////////////////////////////////////////////////////////////////////////////////
 
 void disort_settingsNoSun(DisortSettings& disort_settings) {
+  ARTS_TIME_REPORT
+
   disort_settings.solar_source        = 0.0;
   disort_settings.solar_zenith_angle  = 0.0;
   disort_settings.solar_azimuth_angle = 0.0;
@@ -48,6 +52,8 @@ void disort_settingsSetSun(DisortSettings& disort_settings,
                            const SurfaceField& surface_field,
                            const Sun& sun,
                            const PropagationPathPoint& ray_path_point) {
+  ARTS_TIME_REPORT
+
   const Numeric h =
       surface_field.single_value(SurfaceKey::h, sun.latitude, sun.longitude);
 
@@ -85,6 +91,8 @@ sun.spectrum.nrows():                {}
 ////////////////////////////////////////////////////////////////////////////////
 
 void disort_settingsNoLayerThermalEmission(DisortSettings& disort_settings) {
+  ARTS_TIME_REPORT
+
   disort_settings.source_polynomial.resize(
       disort_settings.nfreq, disort_settings.nlay, 0);
 }
@@ -93,6 +101,8 @@ void disort_settingsLayerThermalEmissionLinearInTau(
     DisortSettings& disort_settings,
     const ArrayOfAtmPoint& ray_path_atmospheric_point,
     const AscendingGrid& frequency_grid) {
+  ARTS_TIME_REPORT
+
   const auto nv = frequency_grid.size();
   const auto N  = ray_path_atmospheric_point.size();
 
@@ -133,6 +143,8 @@ void disort_settingsLayerThermalEmissionLinearInTau(
 ////////////////////////////////////////////////////////////////////////////////
 
 void disort_settingsNoSurfaceEmission(DisortSettings& disort_settings) {
+  ARTS_TIME_REPORT
+
   disort_settings.positive_boundary_condition = 0.0;
 }
 
@@ -141,6 +153,8 @@ void disort_settingsSurfaceEmissionByTemperature(
     const AscendingGrid& frequency_grid,
     const PropagationPathPoint& ray_path_point,
     const SurfaceField& surface_field) {
+  ARTS_TIME_REPORT
+
   const auto nv = frequency_grid.size();
 
   const Numeric T = surface_field.single_value(
@@ -170,11 +184,15 @@ void disort_settingsSurfaceEmissionByTemperature(
 ////////////////////////////////////////////////////////////////////////////////
 
 void disort_settingsNoSpaceEmission(DisortSettings& disort_settings) {
+  ARTS_TIME_REPORT
+
   disort_settings.negative_boundary_condition = 0.0;
 }
 
 void disort_settingsCosmicMicrowaveBackgroundRadiation(
     DisortSettings& disort_settings, const AscendingGrid& frequency_grid) {
+  ARTS_TIME_REPORT
+
   const Index nv = frequency_grid.size();
 
   disort_settings.negative_boundary_condition = 0.0;
@@ -200,6 +218,8 @@ void disort_settingsCosmicMicrowaveBackgroundRadiation(
 ////////////////////////////////////////////////////////////////////////////////
 
 void disort_settingsNoLegendre(DisortSettings& disort_settings) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(
       disort_settings.legendre_coefficients.nrows() < 1,
       "Must have at least one Legendre mode to use the Legendre coefficients.")
@@ -213,6 +233,8 @@ void disort_settingsNoLegendre(DisortSettings& disort_settings) {
 ////////////////////////////////////////////////////////////////////////////////
 
 void disort_settingsNoFractionalScattering(DisortSettings& disort_settings) {
+  ARTS_TIME_REPORT
+
   disort_settings.fractional_scattering = 0.0;
 }
 
@@ -224,6 +246,8 @@ void disort_settingsOpticalThicknessFromPath(
     DisortSettings& disort_settings,
     const ArrayOfPropagationPathPoint& ray_path,
     const ArrayOfPropmatVector& ray_path_propagation_matrix) {
+  ARTS_TIME_REPORT
+
   const Index N  = disort_settings.nlay;
   const Index nv = disort_settings.nfreq;
 
@@ -304,12 +328,16 @@ Frequency grid point: {}
 ////////////////////////////////////////////////////////////////////////////////
 
 void disort_settingsNoSurfaceScattering(DisortSettings& disort_settings) {
+  ARTS_TIME_REPORT
+
   disort_settings.bidirectional_reflectance_distribution_functions.resize(
       disort_settings.nfreq, 0);
 }
 
 void disort_settingsSurfaceLambertian(DisortSettings& disort_settings,
                                       const Vector& vec) {
+  ARTS_TIME_REPORT
+
   disort_settings.bidirectional_reflectance_distribution_functions.resize(
       disort_settings.nfreq, 1);
 
@@ -323,6 +351,8 @@ void disort_settingsSurfaceLambertian(DisortSettings& disort_settings,
 
 void disort_settingsSurfaceLambertian(DisortSettings& disort_settings,
                                       const Numeric& value) {
+  ARTS_TIME_REPORT
+
   disort_settings.bidirectional_reflectance_distribution_functions.resize(
       disort_settings.nfreq, 1);
 
@@ -338,6 +368,8 @@ void disort_settingsSurfaceLambertian(DisortSettings& disort_settings,
 ////////////////////////////////////////////////////////////////////////////////
 
 void disort_settingsNoSingleScatteringAlbedo(DisortSettings& disort_settings) {
+  ARTS_TIME_REPORT
+
   disort_settings.single_scattering_albedo = 0.0;
 }
 
@@ -348,6 +380,8 @@ void disort_settingsNoSingleScatteringAlbedo(DisortSettings& disort_settings) {
 void disort_settingsLegendreCoefficientsFromPath(
     DisortSettings& disort_settings,
     const ArrayOfSpecmatMatrix& ray_path_phase_matrix_scattering_spectral) try {
+  ARTS_TIME_REPORT
+
   const Size N  = disort_settings.nlay;
   const Index F = disort_settings.nfreq;
   const Index L = disort_settings.legendre_polynomial_dimension;
@@ -419,6 +453,8 @@ void disort_settingsSingleScatteringAlbedoFromPath(
     DisortSettings& disort_settings,
     const ArrayOfPropmatVector& ray_path_propagation_matrix_scattering,
     const ArrayOfStokvecVector& ray_path_absorption_vector_scattering) try {
+  ARTS_TIME_REPORT
+
   const Size N  = disort_settings.nlay;
   const Index F = disort_settings.nfreq;
 
@@ -482,6 +518,8 @@ void disort_settings_agendaSetup(
     const disort_settings_agenda_setup_sun_type& sun_setting,
     const disort_settings_agenda_setup_surface_type& surface_setting,
     const Vector& surface_lambertian_value) {
+  ARTS_TIME_REPORT
+
   AgendaCreator agenda("disort_settings_agenda");
 
   agenda.add("jacobian_targetsOff");
@@ -574,6 +612,8 @@ void disort_settings_agendaSetup(Agenda& disort_settings_agenda,
                                  const String& sun_setting,
                                  const String& surface_setting,
                                  const Vector& surface_lambertian_value) {
+  ARTS_TIME_REPORT
+
   disort_settings_agendaSetup(
       disort_settings_agenda,
       to<disort_settings_agenda_setup_layer_emission_type>(

--- a/src/m_frequency_grid.cc
+++ b/src/m_frequency_grid.cc
@@ -1,14 +1,11 @@
-#include <atm.h>
-#include <jacobian.h>
-#include <path_point.h>
-#include <rtepack.h>
-
-#include "arts_constants.h"
+#include <workspace.h>
 
 void frequency_gridWindShift(AscendingGrid& frequency_grid,
                              Vector3& frequency_grid_wind_shift_jacobian,
                              const AtmPoint& atmospheric_point,
                              const PropagationPathPoint& ray_path_point) {
+  ARTS_TIME_REPORT
+
   constexpr Numeric c = Constant::speed_of_light;
 
   const auto& [u, v, w] = atmospheric_point.wind;
@@ -51,9 +48,8 @@ ray_path_point.los:     {:B,}
   // shift the frequency grid
   {
     ExtendAscendingGrid tmp = frequency_grid;
-    stdr::transform(tmp, tmp.begin(), [fac](const Numeric& f) {
-      return fac * f;
-    });
+    stdr::transform(
+        tmp, tmp.begin(), [fac](const Numeric& f) { return fac * f; });
   }
 
   {
@@ -93,6 +89,8 @@ void propagation_matrix_jacobianWindFix(
     const AscendingGrid& frequency_grid,
     const JacobianTargets& jacobian_targets,
     const Vector3& frequency_grid_wind_shift_jacobian) {
+  ARTS_TIME_REPORT
+
   using enum AtmKey;
 
   const auto& atm = jacobian_targets.atm();

--- a/src/m_fwd.cc
+++ b/src/m_fwd.cc
@@ -25,6 +25,8 @@ void spectral_radiance_operatorClearsky1D(
     const Numeric& longitude,
     const Numeric& cia_extrapolation,
     const Index& cia_robust) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(altitude_grid.size() < 2, "Must have some type of path")
 
   using lines_t  = AbsorptionBands;
@@ -67,6 +69,8 @@ void spectral_radiance_fieldFromOperatorPlanarGeometric(
     const AscendingGrid& frequency_grid,
     const AscendingGrid& zenith_grid,
     const AscendingGrid& azimuth_grid) {
+  ARTS_TIME_REPORT
+
   const AscendingGrid& altitude_grid  = spectral_radiance_operator.altitude();
   const AscendingGrid& latitude_grid  = spectral_radiance_operator.latitude();
   const AscendingGrid& longitude_grid = spectral_radiance_operator.longitude();
@@ -180,6 +184,8 @@ void spectral_radiance_fieldFromOperatorPath(
     const AscendingGrid& frequency_grid,
     const AscendingGrid& zenith_grid,
     const AscendingGrid& azimuth_grid) {
+  ARTS_TIME_REPORT
+
   const AscendingGrid& altitude_grid  = spectral_radiance_operator.altitude();
   const AscendingGrid& latitude_grid  = spectral_radiance_operator.latitude();
   const AscendingGrid& longitude_grid = spectral_radiance_operator.longitude();
@@ -285,6 +291,8 @@ void measurement_vectorFromOperatorPath(
     const ArrayOfSensorObsel& measurement_vector_sensor,
     const SpectralRadianceOperator& spectral_radiance_operator,
     const Agenda& ray_path_observer_agenda) try {
+  ARTS_TIME_REPORT
+
   measurement_vector.resize(measurement_vector_sensor.size());
   measurement_vector = 0.0;
   if (measurement_vector_sensor.empty()) return;
@@ -314,7 +322,7 @@ void measurement_vectorFromOperatorPath(
                          return spectral_radiance_operator(f, path);
                        });
 
-        for (Size iv=0; iv<measurement_vector_sensor.size(); ++iv) {
+        for (Size iv = 0; iv < measurement_vector_sensor.size(); ++iv) {
           const SensorObsel& obsel = measurement_vector_sensor[iv];
           if (obsel.same_freqs(f_grid_ptr)) {
             measurement_vector[iv] += obsel.sumup(spectral_radiance, ip);

--- a/src/m_ignore.h
+++ b/src/m_ignore.h
@@ -16,10 +16,14 @@
 
 /* Workspace method: Doxygen documentation will be auto-generated */
 template <WorkspaceGroup T>
-void Ignore(const T&) {}
+void Ignore(const T&) {
+  ARTS_TIME_REPORT
+}
 
 /* Workspace method: Doxygen documentation will be auto-generated */
 template <WorkspaceGroup T>
-void Touch(T&) {}
+void Touch(T&) {
+  ARTS_TIME_REPORT
+}
 
 #endif  // m_ignore_h

--- a/src/m_jactargets.cc
+++ b/src/m_jactargets.cc
@@ -1,13 +1,16 @@
-#include <enumsFieldComponent.h>
-#include <jacobian.h>
+#include <workspace.h>
 
 #include <ranges>
 
 void jacobian_targetsOff(JacobianTargets& jacobian_targets) {
+  ARTS_TIME_REPORT
+
   jacobian_targets.clear();
 }
 
 void jacobian_targetsInit(JacobianTargets& jacobian_targets) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsOff(jacobian_targets);
 }
 
@@ -16,6 +19,8 @@ void jacobian_targetsFinalize(JacobianTargets& jacobian_targets,
                               const SurfaceField& surface_field,
                               const AbsorptionBands& absorption_bands,
                               const ArrayOfSensorObsel& measurement_sensor) {
+  ARTS_TIME_REPORT
+
   jacobian_targets.finalize(
       atmospheric_field, surface_field, absorption_bands, measurement_sensor);
 }
@@ -23,52 +28,70 @@ void jacobian_targetsFinalize(JacobianTargets& jacobian_targets,
 void jacobian_targetsAddSurface(JacobianTargets& jacobian_targets,
                                 const SurfaceKey& key,
                                 const Numeric& d) {
+  ARTS_TIME_REPORT
+
   jacobian_targets.emplace_back(SurfaceKeyVal{key}, d);
 }
 
 void jacobian_targetsAddSurface(JacobianTargets& jacobian_targets,
                                 const SurfacePropertyTag& key,
                                 const Numeric& d) {
+  ARTS_TIME_REPORT
+
   jacobian_targets.emplace_back(SurfaceKeyVal{key}, d);
 }
 
 void jacobian_targetsAddAtmosphere(JacobianTargets& jacobian_targets,
                                    const AtmKey& key,
                                    const Numeric& d) {
+  ARTS_TIME_REPORT
+
   jacobian_targets.emplace_back(AtmKeyVal{key}, d);
 }
 
 void jacobian_targetsAddAtmosphere(JacobianTargets& jacobian_targets,
                                    const SpeciesEnum& key,
                                    const Numeric& d) {
+  ARTS_TIME_REPORT
+
   jacobian_targets.emplace_back(AtmKeyVal{key}, d);
 }
 
 void jacobian_targetsAddAtmosphere(JacobianTargets& jacobian_targets,
                                    const SpeciesIsotope& key,
                                    const Numeric& d) {
+  ARTS_TIME_REPORT
+
   jacobian_targets.emplace_back(AtmKeyVal{key}, d);
 }
 
 void jacobian_targetsAddAtmosphere(JacobianTargets& jacobian_targets,
                                    const QuantumIdentifier& key,
                                    const Numeric& d) {
+  ARTS_TIME_REPORT
+
   jacobian_targets.emplace_back(AtmKeyVal{key}, d);
 }
 
 void jacobian_targetsAddTemperature(JacobianTargets& jacobian_targets,
                                     const Numeric& d) {
+  ARTS_TIME_REPORT
+
   jacobian_targets.emplace_back(AtmKeyVal{AtmKey::t}, d);
 }
 
 void jacobian_targetsAddPressure(JacobianTargets& jacobian_targets,
                                  const Numeric& d) {
+  ARTS_TIME_REPORT
+
   jacobian_targets.emplace_back(AtmKeyVal{AtmKey::p}, d);
 }
 
 void jacobian_targetsAddMagneticField(JacobianTargets& jacobian_targets,
                                       const String& component,
                                       const Numeric& d) {
+  ARTS_TIME_REPORT
+
   using enum FieldComponent;
   switch (to<FieldComponent>(component)) {
     case u: jacobian_targets.emplace_back(AtmKeyVal{AtmKey::mag_u}, d); break;
@@ -80,6 +103,8 @@ void jacobian_targetsAddMagneticField(JacobianTargets& jacobian_targets,
 void jacobian_targetsAddWindField(JacobianTargets& jacobian_targets,
                                   const String& component,
                                   const Numeric& d) {
+  ARTS_TIME_REPORT
+
   using enum FieldComponent;
   switch (to<FieldComponent>(component)) {
     case u: jacobian_targets.emplace_back(AtmKeyVal{AtmKey::wind_u}, d); break;
@@ -91,6 +116,8 @@ void jacobian_targetsAddWindField(JacobianTargets& jacobian_targets,
 void jacobian_targetsAddSpeciesVMR(JacobianTargets& jacobian_targets,
                                    const SpeciesEnum& species,
                                    const Numeric& d) {
+  ARTS_TIME_REPORT
+
   jacobian_targets.emplace_back(AtmKeyVal{species}, d);
 }
 
@@ -98,6 +125,8 @@ void jacobian_targetsAddSpeciesIsotopologueRatio(
     JacobianTargets& jacobian_targets,
     const SpeciesIsotope& species,
     const Numeric& d) {
+  ARTS_TIME_REPORT
+
   jacobian_targets.emplace_back(AtmKeyVal{species}, d);
 }
 
@@ -107,6 +136,8 @@ void jacobian_targetsAddSensorFrequencyPolyFit(
     const Numeric& d,
     const Index& sensor_elem,
     const Index& polyorder) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(
       polyorder < 0, "Polyorder must be non-negative: {}", polyorder)
 

--- a/src/m_lbl.cc
+++ b/src/m_lbl.cc
@@ -49,6 +49,8 @@ std::vector<std::pair<Index, Index>> omp_offset_count(const Index N,
 void absorption_bandsSelectFrequencyByLine(AbsorptionBands& absorption_bands,
                                            const Numeric& fmin,
                                            const Numeric& fmax) try {
+  ARTS_TIME_REPORT
+
   std::vector<QuantumIdentifier> to_remove;
 
   for (auto& [key, band] : absorption_bands) {
@@ -73,6 +75,8 @@ ARTS_METHOD_ERROR_CATCH
 void absorption_bandsSelectFrequencyByBand(AbsorptionBands& absorption_bands,
                                            const Numeric& fmin,
                                            const Numeric& fmax) try {
+  ARTS_TIME_REPORT
+
   std::vector<QuantumIdentifier> to_remove;
 
   for (auto& [key, band] : absorption_bands) {
@@ -90,6 +94,8 @@ ARTS_METHOD_ERROR_CATCH
 
 void absorption_bandsRemoveID(AbsorptionBands& absorption_bands,
                               const QuantumIdentifier& id) try {
+  ARTS_TIME_REPORT
+
   absorption_bands.erase(id);
 }
 ARTS_METHOD_ERROR_CATCH
@@ -99,6 +105,8 @@ void sortedIndexOfBands(ArrayOfIndex& sorted_idxs,
                         const String& criteria,
                         const Index& reverse,
                         const Numeric& temperature) try {
+  ARTS_TIME_REPORT
+
   struct order {
     QuantumIdentifier qid;
     Numeric value;
@@ -164,6 +172,8 @@ ARTS_METHOD_ERROR_CATCH
 void absorption_bandsKeepID(AbsorptionBands& absorption_bands,
                             const QuantumIdentifier& id,
                             const Index& line) try {
+  ARTS_TIME_REPORT
+
   if (auto ptr = absorption_bands.find(id); ptr != absorption_bands.end()) {
     const auto& [key, band] = *ptr;
 
@@ -190,6 +200,8 @@ void absorption_bandsReadSpeciesSplitCatalog(
     const ArrayOfArrayOfSpeciesTag& absorbtion_species,
     const String& basename,
     const Index& ignore_missing_) try {
+  ARTS_TIME_REPORT
+
   const bool ignore_missing = static_cast<bool>(ignore_missing_);
   absorption_bands.clear();
 
@@ -246,6 +258,8 @@ ARTS_METHOD_ERROR_CATCH
 
 void absorption_bandsReadSplit(AbsorptionBands& absorption_bands,
                                const String& dir) try {
+  ARTS_TIME_REPORT
+
   absorption_bands = {};
 
   std::vector<std::filesystem::path> paths;
@@ -291,6 +305,8 @@ ARTS_METHOD_ERROR_CATCH
 
 void absorption_bandsSaveSplit(const AbsorptionBands& absorption_bands,
                                const String& dir) try {
+  ARTS_TIME_REPORT
+
   auto create_if_not = [](const std::filesystem::path& path) {
     if (not std::filesystem::exists(path)) {
       std::filesystem::create_directories(path);
@@ -317,6 +333,8 @@ void absorption_bandsSetZeeman(AbsorptionBands& absorption_bands,
                                const Numeric& fmin,
                                const Numeric& fmax,
                                const Index& _on) try {
+  ARTS_TIME_REPORT
+
   const bool on = static_cast<bool>(_on);
 
   for (auto& [key, band] : absorption_bands) {
@@ -343,6 +361,8 @@ void propagation_matrixAddLines(PropmatVector& pm,
                                 const AtmPoint& atm_point,
                                 const PropagationPathPoint& path_point,
                                 const Index& no_negative_absorption) try {
+  ARTS_TIME_REPORT
+
   const Size n = arts_omp_get_max_threads();
   if (n == 1 or static_cast<Size>(arts_omp_in_parallel()) or
       n > f_grid.size()) {
@@ -397,6 +417,8 @@ void absorption_bandsReadHITRAN(AbsorptionBands& absorption_bands,
                                 const Vector2& frequency_range,
                                 const String& line_strength_option,
                                 const Index& compute_zeeman_parameters) try {
+  ARTS_TIME_REPORT
+
   using namespace Quantum::Number;
 
   const AbsorptionBand default_band{.lines        = {},
@@ -444,6 +466,8 @@ void absorption_bandsLineMixingAdaptation(
     const QuantumIdentifier& band_key,
     const Index& rosenkranz_fit_order,
     const Index& polynomial_fit_degree) try {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(temperatures.empty() or temperatures.front() <= 0.0,
                      "Need a positive temperature grid")
 

--- a/src/m_linemixing.cc
+++ b/src/m_linemixing.cc
@@ -1,24 +1,10 @@
-/**
- * @file m_linemixing.cc
- * @author Richard Larsson
- * @date 2020-06-23
- * 
- * @brief User interface for dealing with pure line mixing calculations
- * 
- * Note: If defined using parameterized form, the normal line-functions
- * approach is faster and more appropriate.  These functions should first
- * compute the relaxation, not simply use the relaxation
- */
-
-#include <matpack.h>
-
-#include <stdexcept>
-
-#include <lbl.h>
+#include <workspace.h>
 
 void ecs_dataAddMeanAir(LinemixingEcsData& ecs_data,
                         const Vector& vmrs,
                         const ArrayOfSpeciesEnum& specs) {
+                          ARTS_TIME_REPORT
+                        
   ARTS_USER_ERROR_IF(static_cast<Size>(vmrs.size()) != specs.size(),
                      "Mismatch dimension of vmrs and specs")
   ARTS_USER_ERROR_IF(
@@ -75,9 +61,13 @@ void ecs_dataAddMeanAir(LinemixingEcsData& ecs_data,
   }
 }
 
-void ecs_dataInit(LinemixingEcsData& ecs_data) { ecs_data.clear(); }
+void ecs_dataInit(LinemixingEcsData& ecs_data) {
+  ARTS_TIME_REPORT
+ ecs_data.clear(); }
 
 void ecs_dataAddMakarov2020(LinemixingEcsData& ecs_data) {
+  ARTS_TIME_REPORT
+
   using enum LineShapeModelType;
   using data = lbl::temperature::data;
 
@@ -98,6 +88,8 @@ void ecs_dataAddMakarov2020(LinemixingEcsData& ecs_data) {
 }
 
 void ecs_dataAddRodrigues1997(LinemixingEcsData& ecs_data) {
+  ARTS_TIME_REPORT
+
   using enum LineShapeModelType;
   using data = lbl::temperature::data;
 
@@ -121,6 +113,8 @@ void ecs_dataAddRodrigues1997(LinemixingEcsData& ecs_data) {
 }
 
 void ecs_dataAddTran2011(LinemixingEcsData& ecs_data) {
+  ARTS_TIME_REPORT
+
   using enum LineShapeModelType;
   using data = lbl::temperature::data;
 

--- a/src/m_lookup.cc
+++ b/src/m_lookup.cc
@@ -1,5 +1,4 @@
-#include <jacobian.h>
-#include <lookup_map.h>
+#include <workspace.h>
 
 #include <algorithm>
 #include <ranges>
@@ -7,6 +6,8 @@
 
 void absorption_lookup_tableInit(
     AbsorptionLookupTables& absorption_lookup_table) {
+  ARTS_TIME_REPORT
+
   absorption_lookup_table.clear();
 }
 
@@ -25,6 +26,8 @@ std::conditional_t<calc, Vector, void> _propagation_matrixAddLookup(
     const Index& water_interp_order,
     const Index& f_interp_order,
     const Numeric& extpolfac) {
+  ARTS_TIME_REPORT
+
   if constexpr (calc) {
     Vector absorption(frequency_grid.size(), 0.0);
 
@@ -151,6 +154,8 @@ void propagation_matrixAddLookup(
     const Index& water_interp_order,
     const Index& f_interp_order,
     const Numeric& extpolfac) try {
+  ARTS_TIME_REPORT
+
   _propagation_matrixAddLookup<false>(propagation_matrix,
                                       propagation_matrix_jacobian,
                                       frequency_grid,
@@ -172,6 +177,8 @@ void ray_path_atmospheric_pointExtendInPressure(
     const Numeric& extended_max_pressure,
     const Numeric& extended_min_pressure,
     const String& extrapolation_option) try {
+  ARTS_TIME_REPORT
+
   lookup::extend_atmosphere(
       ray_path_atmospheric_point,
       to<InterpolationExtrapolation>(extrapolation_option),
@@ -189,6 +196,8 @@ void absorption_lookup_tablePrecompute(
     const SpeciesEnum& select_species,
     const AscendingGrid& temperature_perturbation,
     const AscendingGrid& water_perturbation) {
+  ARTS_TIME_REPORT
+
   absorption_lookup_table[select_species] = {
       select_species,
       ray_path_atmospheric_point,
@@ -212,6 +221,8 @@ void absorption_lookup_tablePrecomputeAll(
     const AscendingGrid& temperature_perturbation,
     const AscendingGrid& water_perturbation,
     const ArrayOfSpeciesEnum& water_affected_species) {
+  ARTS_TIME_REPORT
+
   const AscendingGrid empty{};
 
   ArrayOfSpeciesEnum lut_species;
@@ -276,13 +287,16 @@ void absorption_lookup_tableFromProfiles(
     const AscendingGrid& water_perturbation,
     const ArrayOfSpeciesEnum& water_affected_species,
     const String& isoratio_option) {
+  ARTS_TIME_REPORT
+
   absorption_lookup_tableInit(absorption_lookup_table);
 
   ArrayOfAtmPoint ray_path_atmospheric_point(
       pressure_profile.size(), AtmPoint{to<IsoRatioOption>(isoratio_option)});
 
-  ARTS_USER_ERROR_IF(not same_shape<1>(pressure_profile.vec(), temperature_profile),
-                     "Pressure and temperature profiles must agree in size.");
+  ARTS_USER_ERROR_IF(
+      not same_shape<1>(pressure_profile.vec(), temperature_profile),
+      "Pressure and temperature profiles must agree in size.");
 
   for (Size i = 0; i < pressure_profile.size(); i++) {
     ray_path_atmospheric_point[i].pressure    = pressure_profile[i];
@@ -324,6 +338,8 @@ void absorption_lookup_tableSimpleWide(
     const Index& atmospheric_steps,
     const Index& temperature_perturbation_steps,
     const Index& water_vmr_perturbation_steps) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(pressure_range[1] <= pressure_range[0],
                      "Pressure range must be increasing, got {:B,}",
                      pressure_range);

--- a/src/m_measurement_vector.cc
+++ b/src/m_measurement_vector.cc
@@ -1,5 +1,4 @@
-#include <jacobian.h>
-#include <matpack.h>
+#include <workspace.h>
 
 #include <limits>
 
@@ -7,6 +6,8 @@ void measurement_vector_errorInitStandard(Vector& measurement_vector_error,
                                           Matrix& measuremen_jacobian_error,
                                           const Vector& measurement_vector,
                                           const Matrix& measuremen_jacobian) {
+  ARTS_TIME_REPORT
+
   measurement_vector_error.resize(measurement_vector.shape());
   measuremen_jacobian_error.resize(measuremen_jacobian.shape());
   measurement_vector_error  = 0.0;
@@ -18,6 +19,8 @@ void measurement_vector_errorAddErrorState(
     Matrix& measuremen_jacobian_error,
     const JacobianTargets& jacobian_targets,
     const Vector& model_state_vector) {
+  ARTS_TIME_REPORT
+
   for (auto& elem : jacobian_targets.error()) {
     elem.update_y(measurement_vector_error,
                   measuremen_jacobian_error,
@@ -29,6 +32,8 @@ void measurement_vectorAddError(Vector& measurement_vector,
                                 Matrix& measuremen_jacobian,
                                 const Vector& measurement_vector_error,
                                 const Matrix& measuremen_jacobian_error) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(
       measurement_vector.shape() != measurement_vector_error.shape(),
       R"(Mismatched shapes:
@@ -56,6 +61,8 @@ void model_state_vectorUpdateError(Vector& model_state_vector,
                                    const JacobianTargets& jacobian_targets,
                                    const Vector& measurement_vector,
                                    const Vector& measurement_vector_fitted) {
+  ARTS_TIME_REPORT
+
   for (auto& elem : jacobian_targets.error()) {
     elem.update_x(
         model_state_vector, measurement_vector, measurement_vector_fitted);
@@ -69,8 +76,10 @@ struct polyfit {
                   StridedMatrixView dy,
                   const ConstVectorView p) const {
     ARTS_USER_ERROR_IF(y.size() != t.size(), "Mismatched y and t sizes.")
-    ARTS_USER_ERROR_IF(static_cast<Index>(y.size()) != dy.nrows(), "Mismatched y and dy sizes.")
-    ARTS_USER_ERROR_IF(dy.ncols() != static_cast<Index>(p.size()), "Mismatched dy and p sizes.")
+    ARTS_USER_ERROR_IF(static_cast<Index>(y.size()) != dy.nrows(),
+                       "Mismatched y and dy sizes.")
+    ARTS_USER_ERROR_IF(dy.ncols() != static_cast<Index>(p.size()),
+                       "Mismatched dy and p sizes.")
 
     for (Size j = 0; j < t.size(); j++) {
       for (Size i = 0; i < p.size(); i++) {
@@ -81,8 +90,7 @@ struct polyfit {
     }
   }
 
-  void operator()(VectorView p,
-                  const ConstVectorView y) const {
+  void operator()(VectorView p, const ConstVectorView y) const {
     ARTS_USER_ERROR_IF(y.size() != t.size(), "Mismatched y and t sizes.")
     Jacobian::polyfit(p, t, y);
   }
@@ -94,6 +102,8 @@ void jacobian_targetsAddErrorPolyFit(
     const Vector& t,
     const Index& sensor_elem,
     const Index& polyorder) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(
       polyorder < 0, "Polyorder must be non-negative: {}", polyorder)
 

--- a/src/m_model_state.cc
+++ b/src/m_model_state.cc
@@ -1,17 +1,23 @@
-#include <jacobian.h>
+#include <workspace.h>
 
 void model_state_vectorSize(Vector& model_state_vector,
                             const JacobianTargets& jacobian_targets) {
+  ARTS_TIME_REPORT
+
   model_state_vector.resize(jacobian_targets.x_size());
 }
 
 void model_state_vectorZero(Vector& model_state_vector) {
+  ARTS_TIME_REPORT
+
   model_state_vector = 0.0;
 }
 
 void atmospheric_fieldFromModelState(AtmField& atmospheric_field,
                                      const Vector& model_state_vector,
                                      const JacobianTargets& jacobian_targets) {
+  ARTS_TIME_REPORT
+
   for (auto& target : jacobian_targets.atm()) {
     target.update(atmospheric_field, model_state_vector);
   }
@@ -20,6 +26,8 @@ void atmospheric_fieldFromModelState(AtmField& atmospheric_field,
 void model_state_vectorFromAtmosphere(Vector& model_state_vector,
                                       const AtmField& atmospheric_field,
                                       const JacobianTargets& jacobian_targets) {
+  ARTS_TIME_REPORT
+
   for (auto& target : jacobian_targets.atm()) {
     target.update(model_state_vector, atmospheric_field);
   }
@@ -28,6 +36,8 @@ void model_state_vectorFromAtmosphere(Vector& model_state_vector,
 void surface_fieldFromModelState(SurfaceField& surface_field,
                                  const Vector& model_state_vector,
                                  const JacobianTargets& jacobian_targets) {
+  ARTS_TIME_REPORT
+
   for (auto& target : jacobian_targets.surf()) {
     target.update(surface_field, model_state_vector);
   }
@@ -36,6 +46,8 @@ void surface_fieldFromModelState(SurfaceField& surface_field,
 void model_state_vectorFromSurface(Vector& model_state_vector,
                                    const SurfaceField& surface_field,
                                    const JacobianTargets& jacobian_targets) {
+  ARTS_TIME_REPORT
+
   for (auto& target : jacobian_targets.surf()) {
     target.update(model_state_vector, surface_field);
   }
@@ -44,6 +56,8 @@ void model_state_vectorFromSurface(Vector& model_state_vector,
 void absorption_bandsFromModelState(AbsorptionBands& absorption_bands,
                                     const Vector& model_state_vector,
                                     const JacobianTargets& jacobian_targets) {
+  ARTS_TIME_REPORT
+
   for (auto& target : jacobian_targets.line()) {
     target.update(absorption_bands, model_state_vector);
   }
@@ -52,6 +66,8 @@ void absorption_bandsFromModelState(AbsorptionBands& absorption_bands,
 void model_state_vectorFromBands(Vector& model_state_vector,
                                  const AbsorptionBands& absorption_bands,
                                  const JacobianTargets& jacobian_targets) {
+  ARTS_TIME_REPORT
+
   for (auto& target : jacobian_targets.line()) {
     target.update(model_state_vector, absorption_bands);
   }
@@ -60,6 +76,8 @@ void model_state_vectorFromBands(Vector& model_state_vector,
 void measurement_sensorFromModelState(ArrayOfSensorObsel& measurement_sensor,
                                       const Vector& model_state_vector,
                                       const JacobianTargets& jacobian_targets) {
+  ARTS_TIME_REPORT
+
   for (auto& target : jacobian_targets.sensor()) {
     target.update(measurement_sensor, model_state_vector);
   }
@@ -68,6 +86,8 @@ void measurement_sensorFromModelState(ArrayOfSensorObsel& measurement_sensor,
 void model_state_vectorFromSensor(Vector& model_state_vector,
                                   const ArrayOfSensorObsel& measurement_sensor,
                                   const JacobianTargets& jacobian_targets) {
+  ARTS_TIME_REPORT
+
   for (auto& target : jacobian_targets.sensor()) {
     target.update(model_state_vector, measurement_sensor);
   }

--- a/src/m_nc.cc
+++ b/src/m_nc.cc
@@ -11,6 +11,8 @@ template <WorkspaceGroup T>
 void ReaderNetCDF(  // WS Generic Input:
     T& v [[maybe_unused]],
     const String& f [[maybe_unused]]) {
+  ARTS_TIME_REPORT
+
 #ifdef ENABLE_NETCDF
   nca_read_from_file(f, v);
 #else
@@ -24,6 +26,8 @@ template <WorkspaceGroup T>
 void WriterNetCDF(  // WS Generic Input:
     const T& v [[maybe_unused]],
     const String& f [[maybe_unused]]) {
+  ARTS_TIME_REPORT
+
 #ifdef ENABLE_NETCDF
   String filename = f;
 
@@ -44,6 +48,8 @@ void WriterNetCDFIndexed(  //WS Input:
     // WS Generic Input:
     const T& v [[maybe_unused]],
     const String& f [[maybe_unused]]) {
+  ARTS_TIME_REPORT
+
 #ifdef ENABLE_NETCDF
   String filename = f;
 

--- a/src/m_obsel.cc
+++ b/src/m_obsel.cc
@@ -1,7 +1,7 @@
 #include <arts_omp.h>
-#include <matpack.h>
 #include <obsel.h>
 #include <rtepack.h>
+#include <workspace.h>
 
 #include <boost/math/distributions/normal.hpp>
 #include <numeric>
@@ -10,6 +10,8 @@
 #include "debug.h"
 
 void measurement_sensorInit(ArrayOfSensorObsel& measurement_sensor) {
+  ARTS_TIME_REPORT
+
   measurement_sensor = {};
 }
 
@@ -18,6 +20,8 @@ void measurement_sensorAddSimple(ArrayOfSensorObsel& measurement_sensor,
                                  const Vector3& pos,
                                  const Vector2& los,
                                  const Stokvec& pol) try {
+  ARTS_TIME_REPORT
+
   const Index n = frequency_grid.size();
   const Size sz = measurement_sensor.size();
 
@@ -41,10 +45,12 @@ void measurement_sensorAddVectorGaussian(ArrayOfSensorObsel& measurement_sensor,
                                          const Vector3& pos,
                                          const Vector2& los,
                                          const Stokvec& pol) try {
+  ARTS_TIME_REPORT
+
   using gauss = boost::math::normal_distribution<Numeric>;
   using boost::math::pdf;
 
-  const Size n      = frequency_grid.size();
+  const Size n       = frequency_grid.size();
   const Size sz      = measurement_sensor.size();
   const Size nonzero = pol.nonzero_components();
 
@@ -88,7 +94,9 @@ void measurement_sensorAddSimpleGaussian(ArrayOfSensorObsel& measurement_sensor,
                                          const Vector3& pos,
                                          const Vector2& los,
                                          const Stokvec& pol) {
+  ARTS_TIME_REPORT
+
   const Vector stds(frequency_grid.size(), std);
-      measurement_sensorAddVectorGaussian(
-          measurement_sensor, frequency_grid, stds, pos, los, pol);
+  measurement_sensorAddVectorGaussian(
+      measurement_sensor, frequency_grid, stds, pos, los, pol);
 }

--- a/src/m_oem.cc
+++ b/src/m_oem.cc
@@ -36,32 +36,11 @@
 #include "oem.h"
 #endif
 
-/* Workspace method: Doxygen documentation will be auto-generated */
-void vmr_fieldClip(Tensor4& vmr_field,
-                   const ArrayOfArrayOfSpeciesTag& abs_species,
-                   const String& species,
-                   const Numeric& limit_low,
-                   const Numeric& limit_high) {
-  Index iq = -1;
-  if (species == "ALL") {
-  }
-
-  else {
-    for (Size i = 0; i < abs_species.size(); i++) {
-      if (abs_species[i].Species() == SpeciesTag(species).Spec()) {
-        iq = i;
-        break;
-      }
-    }
-    ARTS_USER_ERROR_IF(iq < 0, "Could not find {} in abs_species.\n", species)
-  }
-
-  Tensor4Clip(vmr_field, iq, limit_low, limit_high);
-}
-
 void atm_fieldSetFromRetrievalValues(AtmField& atm_field,
                                      const JacobianTargets& jacobian_targets,
                                      const Vector& retrieval_values) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(const auto sz = jacobian_targets.x_size();
                      sz not_eq static_cast<Size>(retrieval_values.size()),
                      "Mismatch between size expected of jacobian_targets ("
@@ -75,10 +54,14 @@ void atm_fieldSetFromRetrievalValues(AtmField& atm_field,
 }
 
 void model_state_vector_aprioriFromState(Vector& xa, const Vector& x) {
+  ARTS_TIME_REPORT
+
   xa = x;
 }
 
 void measurement_vector_fittedFromMeasurement(Vector& yf, const Vector& y) {
+  ARTS_TIME_REPORT
+
   yf = y;
 }
 
@@ -104,6 +87,8 @@ void OEM(const Workspace& ws,
          const Vector& lm_ga_settings,
          const Index& clear_matrices,
          const Index& display_progress) {
+  ARTS_TIME_REPORT
+
   // Main sizes
   const Index n = model_state_covariance_matrix.nrows();
   const Index m = measurement_vector.size();
@@ -208,7 +193,8 @@ void OEM(const Workspace& ws,
   else {
     bool apply_norm = false;
     oem::Matrix T{};
-    if (model_state_covariance_matrix_normalization.size() == static_cast<Size>(n)) {
+    if (model_state_covariance_matrix_normalization.size() ==
+        static_cast<Size>(n)) {
       T.resize(n, n);
       T           *= 0.0;
       diagonal(T)  = model_state_covariance_matrix_normalization;
@@ -387,6 +373,8 @@ void measurement_vector_error_covariance_matrix_observation_systemCalc(
     Matrix& measurement_vector_error_covariance_matrix_observation_system,
     const Matrix& measurement_gain_matrix,
     const CovarianceMatrix& measurement_vector_error_covariance_matrix) {
+  ARTS_TIME_REPORT
+
   Index n(measurement_gain_matrix.nrows()), m(measurement_gain_matrix.ncols());
   Matrix tmp1(m, n);
 
@@ -411,6 +399,8 @@ void model_state_covariance_matrix_smoothing_errorCalc(
     Matrix& model_state_covariance_matrix_smoothing_error,
     const Matrix& measurement_averaging_kernel,
     const CovarianceMatrix& model_state_covariance_matrix) {
+  ARTS_TIME_REPORT
+
   Index n(measurement_averaging_kernel.ncols());
   Matrix tmp1(n, n), tmp2(n, n);
 
@@ -435,6 +425,8 @@ void model_state_covariance_matrix_smoothing_errorCalc(
 void measurement_averaging_kernelCalc(Matrix& measurement_averaging_kernel,
                                       const Matrix& measurement_gain_matrix,
                                       const Matrix& measurement_jacobian) {
+  ARTS_TIME_REPORT
+
   Index m(measurement_jacobian.nrows()), n(measurement_jacobian.ncols());
 
   ARTS_USER_ERROR_IF(measurement_jacobian.empty(),

--- a/src/m_operators.cc
+++ b/src/m_operators.cc
@@ -1,10 +1,10 @@
-#include <operators.h>
-
-#include "arts_constants.h"
+#include <workspace.h>
 
 void water_equivalent_pressure_operatorMK05(
     NumericUnaryOperator& water_equivalent_pressure_operator,
     const Index& only_liquid) {
+  ARTS_TIME_REPORT
+
   if (only_liquid) {
     water_equivalent_pressure_operator = NumericUnaryOperator{[](Numeric t) {
       return std::exp(

--- a/src/m_planets.cc
+++ b/src/m_planets.cc
@@ -54,6 +54,8 @@ inline constexpr Numeric DEG2RAD      = Conversion::deg2rad(1);
 
 /* Workspace method: Doxygen documentation will be auto-generated */
 void g0Earth(Numeric &g0, const Numeric &lat) {
+  ARTS_TIME_REPORT
+
   // "Small g" at altitude=0, g0:
   // Expression for g0 taken from Wikipedia page "Gravity of Earth", that
   // is stated to be: International Gravity Formula 1967, the 1967 Geodetic
@@ -73,6 +75,8 @@ void g0Earth(Numeric &g0, const Numeric &lat) {
 
 /* Workspace method: Doxygen documentation will be auto-generated */
 void g0Jupiter(Numeric &g0) {
+  ARTS_TIME_REPORT
+
   // value from MPS, ESA-planetary
   g0 = 23.12;
   // value (1bar level) from
@@ -81,18 +85,24 @@ void g0Jupiter(Numeric &g0) {
 
 /* Workspace method: Doxygen documentation will be auto-generated */
 void g0Mars(Numeric &g0) {
+  ARTS_TIME_REPORT
+
   // value from MPS, ESA-planetary
   g0 = 3.690;
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
 void g0Venus(Numeric &g0) {
+  ARTS_TIME_REPORT
+
   // value via MPS, ESA-planetary from Ahrens, 1995
   g0 = 8.870;
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
 void g0Io(Numeric &g0) {
+  ARTS_TIME_REPORT
+
   // value via Wikipedia
   g0 = 1.796;
 }
@@ -101,6 +111,8 @@ void g0Io(Numeric &g0) {
 void surface_fieldEarth(SurfaceField &surface_field,
                         const String &model,
                         const Numeric &surface_elevation) {
+  ARTS_TIME_REPORT
+
   surface_field                = {};
   surface_field[SurfaceKey::h] = surface_elevation;
 
@@ -121,6 +133,8 @@ void surface_fieldEarth(SurfaceField &surface_field,
 void surface_fieldJupiter(SurfaceField &surface_field,
                           const String &model,
                           const Numeric &surface_elevation) {
+  ARTS_TIME_REPORT
+
   surface_field                = {};
   surface_field[SurfaceKey::h] = surface_elevation;
 
@@ -140,6 +154,8 @@ void surface_fieldJupiter(SurfaceField &surface_field,
 void surface_fieldMars(SurfaceField &surface_field,
                        const String &model,
                        const Numeric &surface_elevation) {
+  ARTS_TIME_REPORT
+
   surface_field                = {};
   surface_field[SurfaceKey::h] = surface_elevation;
 
@@ -159,6 +175,8 @@ void surface_fieldMars(SurfaceField &surface_field,
 void surface_fieldMoon(SurfaceField &surface_field,
                        const String &model,
                        const Numeric &surface_elevation) {
+  ARTS_TIME_REPORT
+
   surface_field                = {};
   surface_field[SurfaceKey::h] = surface_elevation;
 
@@ -179,6 +197,8 @@ void surface_fieldMoon(SurfaceField &surface_field,
 void surface_fieldIo(SurfaceField &surface_field,
                      const String &model,
                      const Numeric &surface_elevation) {
+  ARTS_TIME_REPORT
+
   surface_field                = {};
   surface_field[SurfaceKey::h] = surface_elevation;
 
@@ -195,6 +215,8 @@ void surface_fieldIo(SurfaceField &surface_field,
 void surface_fieldEuropa(SurfaceField &surface_field,
                          const String &model,
                          const Numeric &surface_elevation) {
+  ARTS_TIME_REPORT
+
   surface_field                = {};
   surface_field[SurfaceKey::h] = surface_elevation;
 
@@ -211,6 +233,8 @@ void surface_fieldEuropa(SurfaceField &surface_field,
 void surface_fieldGanymede(SurfaceField &surface_field,
                            const String &model,
                            const Numeric &surface_elevation) {
+  ARTS_TIME_REPORT
+
   surface_field                = {};
   surface_field[SurfaceKey::h] = surface_elevation;
 
@@ -227,6 +251,8 @@ void surface_fieldGanymede(SurfaceField &surface_field,
 void surface_fieldVenus(SurfaceField &surface_field,
                         const String &model,
                         const Numeric &surface_elevation) {
+  ARTS_TIME_REPORT
+
   surface_field                = {};
   surface_field[SurfaceKey::h] = surface_elevation;
 
@@ -243,6 +269,8 @@ void surface_fieldInit(SurfaceField &surface_field,
                        const Numeric &r_equatorial,
                        const Numeric &r_polar,
                        const Numeric &surface_elevation) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(r_equatorial <= 0 || r_polar <= 0,
                      R"(Ellipsoid with a: {}, b: {} is invalid.
 
@@ -273,6 +301,8 @@ A planetary ellipsoid is defined by x^2/a^2 + y^2/a^2 + z^2/b^2 = 1 in ARTS.
 void surface_fieldPlanet(SurfaceField &surface_field,
                          const String &option,
                          const Numeric &surface_elevation) {
+  ARTS_TIME_REPORT
+
   using enum PlanetOrMoonType;
   switch (to<PlanetOrMoonType>(option)) {
     case Earth:
@@ -306,6 +336,8 @@ void surface_fieldPlanet(SurfaceField &surface_field,
 void gravity_operatorCentralMass(NumericTernaryOperator &gravity_operator,
                                  const SurfaceField &surface_field,
                                  const Numeric &mass) {
+  ARTS_TIME_REPORT
+
   struct Gravity {
     Numeric GM;
     Numeric a;
@@ -336,8 +368,8 @@ void gravity_operatorCentralMass(NumericTernaryOperator &gravity_operator,
       surface_field.ellipsoid)
 
   gravity_operator = NumericTernaryOperator{
-      Gravity{Constant::G * mass,
-              surface_field.ellipsoid[0],
-              std::sqrt(1 - Math::pow2(surface_field.ellipsoid[1] /
-                                       surface_field.ellipsoid[0]))}};
+      Gravity{.GM = Constant::G * mass,
+              .a  = surface_field.ellipsoid[0],
+              .e  = std::sqrt(1 - Math::pow2(surface_field.ellipsoid[1] /
+                                            surface_field.ellipsoid[0]))}};
 }

--- a/src/m_ppvar.cc
+++ b/src/m_ppvar.cc
@@ -21,6 +21,8 @@ void ray_path_spectral_radianceCalcTransmission(
     const ArrayOfMuelmatVector &ray_path_transmission_matrix_cumulative,
     const ArrayOfArrayOfMuelmatMatrix
         &ray_path_transmission_matrix_jacobian) try {
+  ARTS_TIME_REPORT
+
   const Size np = ray_path_transmission_matrix.size();
   const Index nq =
       ray_path_transmission_matrix_jacobian.front().front().nrows();
@@ -105,6 +107,8 @@ void ray_path_zeeman_magnetic_fieldFromPath(
     ArrayOfVector3 &ray_path_zeeman_magnetic_field,
     const ArrayOfPropagationPathPoint &ray_path,
     const ArrayOfAtmPoint &ray_path_atmospheric_point) try {
+  ARTS_TIME_REPORT
+
   const Size np = ray_path_atmospheric_point.size();
   ARTS_USER_ERROR_IF(
       np != ray_path.size(),
@@ -134,6 +138,8 @@ void ray_path_spectral_radiance_sourceFromPropmat(
     const ArrayOfAscendingGrid &ray_path_frequency_grid,
     const ArrayOfAtmPoint &ray_path_atmospheric_point,
     const JacobianTargets &jacobian_targets) try {
+  ARTS_TIME_REPORT
+
   String error{};
 
   const Index np = ray_path_atmospheric_point.size();
@@ -188,6 +194,8 @@ void ray_path_atmospheric_pointFromPath(
     ArrayOfAtmPoint &ray_path_atmospheric_point,
     const ArrayOfPropagationPathPoint &ray_path,
     const AtmField &atm_field) try {
+  ARTS_TIME_REPORT
+
   forward_atm_path(atm_path_resize(ray_path_atmospheric_point, ray_path),
                    ray_path,
                    atm_field);
@@ -200,6 +208,8 @@ void ray_path_frequency_gridFromPath(
     const AscendingGrid &frequency_grid,
     const ArrayOfPropagationPathPoint &ray_path,
     const ArrayOfAtmPoint &ray_path_atmospheric_point) try {
+  ARTS_TIME_REPORT
+
   std::string error;
 
   ray_path_frequency_grid.resize(ray_path.size());
@@ -232,6 +242,8 @@ void ray_path_spectral_radianceCalcClearsky(
     const ArrayOfMuelmatVector &ray_path_transmission_matrix_cumulative,
     const ArrayOfArrayOfMuelmatMatrix
         &ray_path_transmission_matrix_jacobian) try {
+  ARTS_TIME_REPORT
+
   const Size np = ray_path_spectral_radiance_source.size();
 
   ARTS_USER_ERROR_IF(
@@ -326,6 +338,8 @@ ARTS_METHOD_ERROR_CATCH
 void ray_path_transmission_matrix_cumulativeFromPath(
     ArrayOfMuelmatVector &ray_path_transmission_matrix_cumulative,
     const ArrayOfMuelmatVector &ray_path_transmission_matrix) try {
+  ARTS_TIME_REPORT
+
   forward_cumulative_transmission(ray_path_transmission_matrix_cumulative,
                                   ray_path_transmission_matrix);
 }

--- a/src/m_predefined_absorption_models.cc
+++ b/src/m_predefined_absorption_models.cc
@@ -26,6 +26,8 @@ void absorption_predefined_model_dataReadSpeciesSplitCatalog(
     const String& basename,
     const Index& name_missing_,
     const Index& ignore_missing_) try {
+  ARTS_TIME_REPORT
+
   const bool name_missing   = static_cast<bool>(name_missing_);
   const bool ignore_missing = static_cast<bool>(ignore_missing_);
 
@@ -62,6 +64,8 @@ ARTS_METHOD_ERROR_CATCH
 
 void absorption_predefined_model_dataInit(
     PredefinedModelData& absorption_predefined_model_data) {
+  ARTS_TIME_REPORT
+
   absorption_predefined_model_data = PredefinedModelData{};
 }
 
@@ -74,6 +78,8 @@ void absorption_predefined_model_dataAddWaterMTCKD400(
     const Vector& for_absco_ref,
     const Vector& wavenumbers,
     const Vector& self_texp) {
+  ARTS_TIME_REPORT
+
   const auto sz = self_absco_ref.size();
 
   ARTS_USER_ERROR_IF(
@@ -114,6 +120,8 @@ void propagation_matrixAddPredefined(
     const JacobianTargets& jacobian_targets,
     const AscendingGrid& f_grid,
     const AtmPoint& atm_point) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(
       propagation_matrix.size() not_eq f_grid.size(),
       "Mismatch dimensions on internal matrices of xsec and frequency");

--- a/src/m_propagation_path.cc
+++ b/src/m_propagation_path.cc
@@ -1,13 +1,6 @@
-#include <path_point.h>
+#include <workspace.h>
 
 #include <algorithm>
-#include <functional>
-
-#include "atm.h"
-#include "auto_wsa_options.h"
-#include "surf.h"
-#include "workspace_agenda_creator.h"
-#include "workspace_class.h"
 
 void apply_options(ArrayOfPropagationPathPoint& ray_path,
                    const SurfaceField& surface_field,
@@ -27,6 +20,8 @@ void ray_pathInit(ArrayOfPropagationPathPoint& ray_path,
                   const Vector3& pos,
                   const Vector2& los,
                   const Index& as_sensor) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(any_nan(pos) or any_nan(los),
                      R"(There are NAN in the pos or los vector:
 pos:      {:B,}
@@ -44,6 +39,8 @@ void ray_pathRemoveNearby(ArrayOfPropagationPathPoint& ray_path,
                           const SurfaceField& surface_field,
                           const Numeric& min_dist,
                           const Index& first) {
+  ARTS_TIME_REPORT
+
   path::erase_closeby(ray_path, surface_field, min_dist, first);
 }
 
@@ -52,6 +49,8 @@ void ray_pathSetGeometricExtremes(ArrayOfPropagationPathPoint& ray_path,
                                   const SurfaceField& surface_field,
                                   const Numeric& surface_search_accuracy,
                                   const Index& surface_safe_search) {
+  ARTS_TIME_REPORT
+
   path::set_geometric_extremes(ray_path,
                                atmospheric_field,
                                surface_field,
@@ -63,6 +62,8 @@ void ray_pathRemoveNonGeometricGridCrossings(
     ArrayOfPropagationPathPoint& ray_path,
     const AtmField& atmospheric_field,
     const AtmKey& atm_key) {
+  ARTS_TIME_REPORT
+
   const auto& data = atmospheric_field[atm_key];
   ARTS_USER_ERROR_IF(not std::holds_alternative<GriddedField3>(data.data),
                      "The data for key {} is not a GriddedField3",
@@ -83,6 +84,8 @@ void ray_pathAddGeometricGridCrossings(ArrayOfPropagationPathPoint& ray_path,
                                        const AtmField& atmospheric_field,
                                        const SurfaceField& surface_field,
                                        const AtmKey& atm_key) {
+  ARTS_TIME_REPORT
+
   const auto& data = atmospheric_field[atm_key];
   ARTS_USER_ERROR_IF(not std::holds_alternative<GriddedField3>(data.data),
                      "The data for key {} is not a GriddedField3",
@@ -98,25 +101,35 @@ void ray_pathAddGeometricGridCrossings(ArrayOfPropagationPathPoint& ray_path,
 void ray_pathFillGeometricHalfStep(ArrayOfPropagationPathPoint& ray_path,
                                    const SurfaceField& surface_field,
                                    const Numeric& max_step) {
+  ARTS_TIME_REPORT
+
   path::fill_geometric_by_half_steps(ray_path, surface_field, max_step);
 }
 
 void ray_pathFillGeometricStepwise(ArrayOfPropagationPathPoint& ray_path,
                                    const SurfaceField& surface_field,
                                    const Numeric& max_step) {
+  ARTS_TIME_REPORT
+
   path::fill_geometric_stepwise(ray_path, surface_field, max_step);
 }
 
 void ray_pathFixUpdownAzimuth(ArrayOfPropagationPathPoint& ray_path) {
+  ARTS_TIME_REPORT
+
   path::fix_updown_azimuth_to_first(ray_path);
 }
 
 void ray_pathAddLimbPoint(ArrayOfPropagationPathPoint& ray_path,
                           const SurfaceField& surface_field) {
+  ARTS_TIME_REPORT
+
   path::fill_geometric_limb(ray_path, surface_field);
 }
 
 void ray_pathRemoveNonAtm(ArrayOfPropagationPathPoint& ray_path) {
+  ARTS_TIME_REPORT
+
   path::keep_only_atm(ray_path);
 }
 
@@ -134,6 +147,8 @@ void ray_path_observer_agendaSetGeometric(
     const Index& fix_updown_azimuth,
     const Index& add_limb,
     const Index& remove_non_atm) {
+  ARTS_TIME_REPORT
+
   AgendaCreator creator("ray_path_observer_agenda");
 
   creator.add("ray_pathInit",
@@ -193,6 +208,8 @@ void ray_pathGeometric(ArrayOfPropagationPathPoint& ray_path,
                        const Index& remove_non_atm,
                        const Index& fix_updown_azimuth,
                        const Index& surface_safe_search) {
+  ARTS_TIME_REPORT
+
   ray_pathInit(ray_path, atmospheric_field, surface_field, pos, los, as_sensor);
   ray_pathSetGeometricExtremes(ray_path,
                                atmospheric_field,
@@ -207,18 +224,24 @@ void ray_pathGeometric(ArrayOfPropagationPathPoint& ray_path,
 
 void ray_path_pointBackground(PropagationPathPoint& ray_path_point,
                               const ArrayOfPropagationPathPoint& ray_path) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(ray_path.size() == 0, "Empty propagation path.")
   ray_path_point = ray_path.back();
 }
 
 void ray_path_pointForeground(PropagationPathPoint& ray_path_point,
                               const ArrayOfPropagationPathPoint& ray_path) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(ray_path.size() == 0, "Empty propagation path.")
   ray_path_point = ray_path.front();
 }
 
 void ray_path_pointLowestFromPath(PropagationPathPoint& ray_path_point,
                                   const ArrayOfPropagationPathPoint& ray_path) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(ray_path.size() == 0, "Empty propagation path.")
 
   ray_path_point = *std::ranges::min_element(
@@ -231,6 +254,8 @@ void ray_path_pointLowestFromPath(PropagationPathPoint& ray_path_point,
 void ray_path_pointHighestFromPath(
     PropagationPathPoint& ray_path_point,
     const ArrayOfPropagationPathPoint& ray_path) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(ray_path.size() == 0, "Empty propagation path.")
 
   ray_path_point = *std::ranges::max_element(
@@ -246,6 +271,8 @@ void ray_pathGeometricUplooking(ArrayOfPropagationPathPoint& ray_path,
                                 const Numeric& latitude,
                                 const Numeric& longitude,
                                 const Numeric& max_step) {
+  ARTS_TIME_REPORT
+
   ray_pathGeometric(
       ray_path,
       atmospheric_field,
@@ -269,6 +296,8 @@ void ray_pathGeometricDownlooking(ArrayOfPropagationPathPoint& ray_path,
                                   const Numeric& latitude,
                                   const Numeric& longitude,
                                   const Numeric& max_step) {
+  ARTS_TIME_REPORT
+
   ray_pathGeometric(ray_path,
                     atmospheric_field,
                     surface_field,

--- a/src/m_propagation_path_observer.cc
+++ b/src/m_propagation_path_observer.cc
@@ -1,11 +1,13 @@
-#include <workspace.h>
 #include <arts_omp.h>
+#include <workspace.h>
 
 namespace {
 Numeric surface_tangent_zenithFromAgenda(const Workspace& ws,
                                          const Vector3& pos,
                                          const Agenda& ray_path_observer_agenda,
                                          const Numeric azimuth) {
+  ARTS_TIME_REPORT
+
   ArrayOfPropagationPathPoint ray_path;
   Numeric za0 = 180.0, za1 = 90.0;
   while (std::nextafter(za0, za1) != za1) {
@@ -33,6 +35,8 @@ void ray_path_observersFieldProfilePseudo2D(
     const Index& nup,
     const Index& nlimb,
     const Index& ndown) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(nup < 2 or nlimb < 2 or ndown < 2,
                      "Must have at least 2 observers per meta-direction.")
 
@@ -83,6 +87,8 @@ void ray_path_fieldFromObserverAgenda(
     ArrayOfArrayOfPropagationPathPoint& ray_path_field,
     const ArrayOfPropagationPathPoint& ray_path_observers,
     const Agenda& ray_path_observer_agenda) {
+  ARTS_TIME_REPORT
+
   const Size N = ray_path_observers.size();
   ARTS_USER_ERROR_IF(N == 0, "Must have at least one observer.")
 

--- a/src/m_propmat.cc
+++ b/src/m_propmat.cc
@@ -13,6 +13,8 @@ void ray_path_propagation_matrixFromPath(
     const JacobianTargets &jacobian_targets,
     const ArrayOfPropagationPathPoint &ray_path,
     const ArrayOfAtmPoint &ray_path_atmospheric_point) try {
+  ARTS_TIME_REPORT
+
   const Size np = ray_path.size();
   ray_path_propagation_matrix.resize(np);
   ray_path_source_vector_nonlte.resize(np);
@@ -53,6 +55,8 @@ void select_species_listCollectAbsorption(
     const ArrayOfXsecRecord &absorption_xsec_fit_data,
     const ArrayOfCIARecord &absorption_cia_data,
     const AbsorptionBands &absorption_bands) try {
+  ARTS_TIME_REPORT
+
   std::set<SpeciesEnum> s;
 
   for (auto &[qid, _] : absorption_bands) s.insert(qid.Species());
@@ -70,9 +74,10 @@ void ray_path_propagation_matrix_species_splitFromPath(
     ArrayOfArrayOfPropmatVector &ray_path_propagation_matrix_species_split,
     ArrayOfArrayOfStokvecVector
         &ray_path_propagation_matrix_source_vector_nonlte_species_split,
-    ArrayOfArrayOfPropmatMatrix &ray_path_propagation_matrix_jacobian_species_split,
-    ArrayOfArrayOfStokvecMatrix
-        &ray_path_propagation_matrix_source_vector_nonlte_jacobian_species_split,
+    ArrayOfArrayOfPropmatMatrix
+        &ray_path_propagation_matrix_jacobian_species_split,
+    ArrayOfArrayOfStokvecMatrix &
+        ray_path_propagation_matrix_source_vector_nonlte_jacobian_species_split,
     const Agenda &propagation_matrix_agenda,
     const ArrayOfAscendingGrid &ray_path_frequency_grid,
     const ArrayOfVector3 &ray_path_frequency_grid_wind_shift_jacobian,
@@ -80,17 +85,21 @@ void ray_path_propagation_matrix_species_splitFromPath(
     const ArrayOfPropagationPathPoint &ray_path,
     const ArrayOfAtmPoint &ray_path_atmospheric_point,
     const ArrayOfSpeciesEnum &select_species_list) try {
+  ARTS_TIME_REPORT
+
   const Size ns = select_species_list.size();
   const Size np = ray_path.size();
 
   ray_path_propagation_matrix_species_split.resize(ns);
   ray_path_propagation_matrix_source_vector_nonlte_species_split.resize(ns);
   ray_path_propagation_matrix_jacobian_species_split.resize(ns);
-  ray_path_propagation_matrix_source_vector_nonlte_jacobian_species_split.resize(ns);
+  ray_path_propagation_matrix_source_vector_nonlte_jacobian_species_split
+      .resize(ns);
   for (auto &s : ray_path_propagation_matrix_species_split) s.resize(np);
   for (auto &s : ray_path_propagation_matrix_source_vector_nonlte_species_split)
     s.resize(np);
-  for (auto &s : ray_path_propagation_matrix_jacobian_species_split) s.resize(np);
+  for (auto &s : ray_path_propagation_matrix_jacobian_species_split)
+    s.resize(np);
   for (auto &s :
        ray_path_propagation_matrix_source_vector_nonlte_jacobian_species_split)
     s.resize(np);
@@ -104,10 +113,11 @@ void ray_path_propagation_matrix_species_splitFromPath(
         propagation_matrix_agendaExecute(
             ws,
             ray_path_propagation_matrix_species_split[is][ip],
-            ray_path_propagation_matrix_source_vector_nonlte_species_split[is][ip],
+            ray_path_propagation_matrix_source_vector_nonlte_species_split[is]
+                                                                          [ip],
             ray_path_propagation_matrix_jacobian_species_split[is][ip],
-            ray_path_propagation_matrix_source_vector_nonlte_jacobian_species_split[is]
-                                                                           [ip],
+            ray_path_propagation_matrix_source_vector_nonlte_jacobian_species_split
+                [is][ip],
             ray_path_frequency_grid[ip],
             ray_path_frequency_grid_wind_shift_jacobian[ip],
             jacobian_targets,

--- a/src/m_rad.cc
+++ b/src/m_rad.cc
@@ -21,6 +21,8 @@ void spectral_radiance_jacobianEmpty(
     StokvecMatrix &spectral_radiance_jacobian,
     const AscendingGrid &frequency_grid,
     const JacobianTargets &jacobian_targets) try {
+  ARTS_TIME_REPORT
+
   spectral_radiance_jacobian.resize(jacobian_targets.x_size(),
                                     frequency_grid.size());
   spectral_radiance_jacobian = Stokvec{0.0, 0.0, 0.0, 0.0};
@@ -31,6 +33,8 @@ void spectral_radiance_jacobianFromBackground(
     StokvecMatrix &spectral_radiance_jacobian,
     const StokvecMatrix &spectral_radiance_background_jacobian,
     const MuelmatVector &background_transmittance) try {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(
       static_cast<Size>(spectral_radiance_background_jacobian.ncols()) !=
           background_transmittance.size(),
@@ -58,6 +62,8 @@ void spectral_radiance_jacobianAddPathPropagation(
     const JacobianTargets &jacobian_targets,
     const AtmField &atmospheric_field,
     const ArrayOfPropagationPathPoint &ray_path) try {
+  ARTS_TIME_REPORT
+
   const auto np = ray_path_spectral_radiance_jacobian.size();
   const auto nj = spectral_radiance_jacobian.nrows();
   const auto nf = spectral_radiance_jacobian.ncols();
@@ -125,6 +131,8 @@ ARTS_METHOD_ERROR_CATCH
 void spectral_radianceFromPathPropagation(
     StokvecVector &spectral_radiance,
     const ArrayOfStokvecVector &ray_path_spectral_radiance) try {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(ray_path_spectral_radiance.empty(),
                      "Empty ray_path_spectral_radiance")
   spectral_radiance = ray_path_spectral_radiance.front();
@@ -137,11 +145,14 @@ void spectral_radiance_jacobianApplyUnit(
     const AscendingGrid &frequency_grid,
     const PropagationPathPoint &ray_path_point,
     const SpectralRadianceUnitType &spectral_radiance_unit) try {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(spectral_radiance.size() != frequency_grid.size(),
                      "spectral_radiance must have same size as frequency_grid")
   ARTS_USER_ERROR_IF(
       spectral_radiance_jacobian.size() != 0 and
-          static_cast<Size>(spectral_radiance_jacobian.ncols()) != frequency_grid.size(),
+          static_cast<Size>(spectral_radiance_jacobian.ncols()) !=
+              frequency_grid.size(),
       "spectral_radiance must have same size as frequency_grid")
 
   const auto dF =
@@ -163,6 +174,8 @@ void spectral_radianceApplyUnit(
     const AscendingGrid &frequency_grid,
     const PropagationPathPoint &ray_path_point,
     const SpectralRadianceUnitType &spectral_radiance_unit) try {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(spectral_radiance.size() != frequency_grid.size(),
                      "spectral_radiance must have same size as frequency_grid")
   const auto F =
@@ -188,6 +201,8 @@ void spectral_radiance_jacobianAddSensorJacobianPerturbations(
     const AtmField &atmospheric_field,
     const SurfaceField &surface_field,
     const Agenda &spectral_radiance_observer_agenda) try {
+  ARTS_TIME_REPORT
+
   /*
   
   This method likely calls itself "recursively" for sensor parameters
@@ -359,6 +374,8 @@ void measurement_vectorFromSensor(
     const SurfaceField &surface_field,
     const SpectralRadianceUnitType &spectral_radiance_unit,
     const Agenda &spectral_radiance_observer_agenda) try {
+  ARTS_TIME_REPORT
+
   measurement_vector.resize(measurement_sensor.size());
   measurement_vector = 0.0;
 

--- a/src/m_retrieval.cc
+++ b/src/m_retrieval.cc
@@ -11,6 +11,8 @@ void RetrievalInit(JacobianTargets& jacobian_targets,
                    CovarianceMatrix& model_state_covariance_matrix,
                    JacobianTargetsDiagonalCovarianceMatrixMap&
                        covariance_matrix_diagonal_blocks) {
+  ARTS_TIME_REPORT
+
   model_state_covariance_matrixInit(model_state_covariance_matrix);
   jacobian_targetsInit(jacobian_targets);
   covariance_matrix_diagonal_blocks.clear();
@@ -23,6 +25,8 @@ void RetrievalAddSurface(JacobianTargets& jacobian_targets,
                          const Numeric& d,
                          const BlockMatrix& matrix,
                          const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddSurface(jacobian_targets, key, d);
   covariance_matrix_diagonal_blocks[JacobianTargetType{
       jacobian_targets.surf().back().type}] = {matrix, inverse};
@@ -35,6 +39,8 @@ void RetrievalAddSurface(JacobianTargets& jacobian_targets,
                          const Numeric& d,
                          const BlockMatrix& matrix,
                          const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddSurface(jacobian_targets, key, d);
   covariance_matrix_diagonal_blocks[JacobianTargetType{
       jacobian_targets.surf().back().type}] = {matrix, inverse};
@@ -47,6 +53,8 @@ void RetrievalAddAtmosphere(JacobianTargets& jacobian_targets,
                             const Numeric& d,
                             const BlockMatrix& matrix,
                             const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddAtmosphere(jacobian_targets, key, d);
   covariance_matrix_diagonal_blocks[JacobianTargetType{
       jacobian_targets.atm().back().type}] = {matrix, inverse};
@@ -59,6 +67,8 @@ void RetrievalAddAtmosphere(JacobianTargets& jacobian_targets,
                             const Numeric& d,
                             const BlockMatrix& matrix,
                             const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddAtmosphere(jacobian_targets, key, d);
   covariance_matrix_diagonal_blocks[JacobianTargetType{
       jacobian_targets.atm().back().type}] = {matrix, inverse};
@@ -71,6 +81,8 @@ void RetrievalAddAtmosphere(JacobianTargets& jacobian_targets,
                             const Numeric& d,
                             const BlockMatrix& matrix,
                             const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddAtmosphere(jacobian_targets, key, d);
   covariance_matrix_diagonal_blocks[JacobianTargetType{
       jacobian_targets.atm().back().type}] = {matrix, inverse};
@@ -83,6 +95,8 @@ void RetrievalAddAtmosphere(JacobianTargets& jacobian_targets,
                             const Numeric& d,
                             const BlockMatrix& matrix,
                             const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddAtmosphere(jacobian_targets, key, d);
   covariance_matrix_diagonal_blocks[JacobianTargetType{
       jacobian_targets.atm().back().type}] = {matrix, inverse};
@@ -95,6 +109,8 @@ void RetrievalAddSpeciesVMR(JacobianTargets& jacobian_targets,
                             const Numeric& d,
                             const BlockMatrix& matrix,
                             const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddSpeciesVMR(jacobian_targets, species, d);
   covariance_matrix_diagonal_blocks[JacobianTargetType{
       jacobian_targets.atm().back().type}] = {matrix, inverse};
@@ -108,6 +124,8 @@ void RetrievalAddSpeciesIsotopologueRatio(
     const Numeric& d,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddSpeciesIsotopologueRatio(jacobian_targets, species, d);
   covariance_matrix_diagonal_blocks[JacobianTargetType{
       jacobian_targets.atm().back().type}] = {matrix, inverse};
@@ -120,6 +138,8 @@ void RetrievalAddMagneticField(JacobianTargets& jacobian_targets,
                                const Numeric& d,
                                const BlockMatrix& matrix,
                                const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddMagneticField(jacobian_targets, component, d);
   covariance_matrix_diagonal_blocks[JacobianTargetType{
       jacobian_targets.atm().back().type}] = {matrix, inverse};
@@ -132,6 +152,8 @@ void RetrievalAddWindField(JacobianTargets& jacobian_targets,
                            const Numeric& d,
                            const BlockMatrix& matrix,
                            const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddWindField(jacobian_targets, component, d);
   covariance_matrix_diagonal_blocks[JacobianTargetType{
       jacobian_targets.atm().back().type}] = {matrix, inverse};
@@ -143,6 +165,8 @@ void RetrievalAddTemperature(JacobianTargets& jacobian_targets,
                              const Numeric& d,
                              const BlockMatrix& matrix,
                              const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddTemperature(jacobian_targets, d);
   covariance_matrix_diagonal_blocks[JacobianTargetType{
       jacobian_targets.atm().back().type}] = {matrix, inverse};
@@ -154,6 +178,8 @@ void RetrievalAddPressure(JacobianTargets& jacobian_targets,
                           const Numeric& d,
                           const BlockMatrix& matrix,
                           const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddPressure(jacobian_targets, d);
   covariance_matrix_diagonal_blocks[JacobianTargetType{
       jacobian_targets.atm().back().type}] = {matrix, inverse};
@@ -169,26 +195,27 @@ void RetrievalAddSensorFrequencyPolyFit(
     const Index& polyorder,
     const BlockMatrix& matrix,
     const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddSensorFrequencyPolyFit(
       jacobian_targets, measurement_sensor, d, sensor_elem, polyorder);
-      auto keyk = JacobianTargetType{
-      jacobian_targets.sensor().back().type};
+  auto keyk = JacobianTargetType{jacobian_targets.sensor().back().type};
   covariance_matrix_diagonal_blocks[keyk] = {matrix, inverse};
 }
 
-void RetrievalAddErrorPolyFit(
-    JacobianTargets& jacobian_targets,
-    JacobianTargetsDiagonalCovarianceMatrixMap&
-        covariance_matrix_diagonal_blocks,
-    const ArrayOfSensorObsel& measurement_sensor,
-    const Vector& t,
-    const Index& sensor_elem,
-    const Index& polyorder,
-    const BlockMatrix& matrix,
-    const BlockMatrix& inverse) {
+void RetrievalAddErrorPolyFit(JacobianTargets& jacobian_targets,
+                              JacobianTargetsDiagonalCovarianceMatrixMap&
+                                  covariance_matrix_diagonal_blocks,
+                              const ArrayOfSensorObsel& measurement_sensor,
+                              const Vector& t,
+                              const Index& sensor_elem,
+                              const Index& polyorder,
+                              const BlockMatrix& matrix,
+                              const BlockMatrix& inverse) {
+  ARTS_TIME_REPORT
+
   jacobian_targetsAddErrorPolyFit(
       jacobian_targets, measurement_sensor, t, sensor_elem, polyorder);
-      auto keyk = JacobianTargetType{
-      jacobian_targets.error().back().type};
+  auto keyk = JacobianTargetType{jacobian_targets.error().back().type};
   covariance_matrix_diagonal_blocks[keyk] = {matrix, inverse};
 }

--- a/src/m_spectral_radiance.cc
+++ b/src/m_spectral_radiance.cc
@@ -16,6 +16,8 @@ void ray_path_transmission_matrixFromPath(
     const SurfaceField& surface_field,
     const JacobianTargets& jacobian_targets,
     const Index& hse_derivative) try {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(ray_path.size() == 0, "Empty path.");
 
   ARTS_USER_ERROR_IF(not arr::same_size(ray_path,
@@ -84,6 +86,8 @@ void spectral_radianceStepByStepEmission(
     const ArrayOfStokvecVector& ray_path_spectral_radiance_source,
     const ArrayOfStokvecMatrix& ray_path_spectral_radiance_source_jacobian,
     const StokvecVector& spectral_radiance_background) try {
+  ARTS_TIME_REPORT
+
   rtepack::two_level_linear_emission_step_by_step_full(
       spectral_radiance,
       ray_path_spectral_radiance_jacobian,
@@ -103,6 +107,8 @@ void spectral_radianceCumulativeTransmission(
     const ArrayOfMuelmatVector& ray_path_transmission_matrix_cumulative,
     const ArrayOfMuelmatTensor3& ray_path_transmission_matrix_jacobian,
     const StokvecVector& spectral_radiance_background) try {
+  ARTS_TIME_REPORT
+
   rtepack::two_level_linear_transmission_step(
       spectral_radiance,
       ray_path_spectral_radiance_jacobian,

--- a/src/m_sun.cc
+++ b/src/m_sun.cc
@@ -48,6 +48,8 @@ void sunFromGrid(Sun& sun,
                  const Numeric& latitude,
                  const Numeric& longitude,
                  const String& description) {
+  ARTS_TIME_REPORT
+
   // some sanity checks
   ARTS_USER_ERROR_IF(distance < radius,
                      "The distance to the center of the sun (",
@@ -76,6 +78,8 @@ void sunBlackbody(Sun& sun,
                   const Numeric& temperature,
                   const Numeric& latitude,
                   const Numeric& longitude) {
+  ARTS_TIME_REPORT
+
   // some sanity checks
   ARTS_USER_ERROR_IF(distance < radius,
                      "The distance to the center of the sun ({} m) \n"
@@ -96,7 +100,10 @@ void sunBlackbody(Sun& sun,
   sun.longitude   = longitude;
 }
 
-void sunsAddSun(ArrayOfSun& suns, const Sun& sun) { suns.push_back(sun); }
+void sunsAddSun(ArrayOfSun& suns, const Sun& sun) {
+  ARTS_TIME_REPORT
+  suns.push_back(sun);
+}
 
 void sun_pathFromObserverAgenda(const Workspace& ws,
                                 ArrayOfPropagationPathPoint& sun_path,
@@ -107,6 +114,8 @@ void sun_pathFromObserverAgenda(const Workspace& ws,
                                 const Numeric& angle_cut,
                                 const Index& refinements,
                                 const Index& just_hit) {
+  ARTS_TIME_REPORT
+
   find_sun_path(ws,
                 sun_path,
                 sun,
@@ -128,6 +137,8 @@ void ray_path_sun_pathFromPathObserver(
     const Numeric& angle_cut,
     const Index& refinements,
     const Index& just_hit) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(angle_cut < 0.0, "angle_cut must be positive")
 
   const Size np = ray_path.size();
@@ -181,6 +192,8 @@ void ray_path_suns_pathFromPathObserver(
     const Numeric& angle_cut,
     const Index& refinements,
     const Index& just_hit) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(angle_cut < 0.0, "angle_cut must be positive")
 
   const Size np    = ray_path.size();
@@ -234,6 +247,8 @@ void ray_path_suns_pathFromPathObserver(
 void propagation_matrix_scatteringInit(
     PropmatVector& propagation_matrix_scattering,
     const AscendingGrid& frequency_grid) {
+  ARTS_TIME_REPORT
+
   propagation_matrix_scattering.resize(frequency_grid.size());
   propagation_matrix_scattering = 0.0;
 }
@@ -271,6 +286,8 @@ void ray_path_propagation_matrix_scatteringFromPath(
     const Agenda& propagation_matrix_scattering_agenda,
     const ArrayOfAscendingGrid& ray_path_frequency_grid,
     const ArrayOfAtmPoint& ray_path_atmospheric_point) {
+  ARTS_TIME_REPORT
+
   const Size np = ray_path_frequency_grid.size();
   ARTS_USER_ERROR_IF(
       np != ray_path_atmospheric_point.size(),
@@ -311,6 +328,8 @@ void ray_path_spectral_radiance_sourceAddScattering(
     ArrayOfStokvecVector& ray_path_spectral_radiance_source,
     const ArrayOfStokvecVector& ray_path_spectral_radiance_scattering,
     const ArrayOfPropmatVector& ray_path_propagation_matrix) {
+  ARTS_TIME_REPORT
+
   const Size np = ray_path_propagation_matrix.size();
   ARTS_USER_ERROR_IF(
       np != ray_path_spectral_radiance_source.size(),
@@ -322,13 +341,14 @@ void ray_path_spectral_radiance_sourceAddScattering(
   if (np == 0) return;
   const Size nf = ray_path_propagation_matrix.front().size();
   ARTS_USER_ERROR_IF(
-      std::ranges::any_of(
-          ray_path_spectral_radiance_source, Cmp::ne(nf), [](auto& v){return v.size();}),
+      std::ranges::any_of(ray_path_spectral_radiance_source,
+                          Cmp::ne(nf),
+                          [](auto& v) { return v.size(); }),
       "Mismatch frequency size of ray_path_propagation_matrix and ray_path_spectral_radiance_source")
   ARTS_USER_ERROR_IF(
       std::ranges::any_of(ray_path_spectral_radiance_scattering,
                           Cmp::ne(nf),
-                          [](auto& v){return v.size();}),
+                          [](auto& v) { return v.size(); }),
       "Mismatch frequency size of ray_path_propagation_matrix and ray_path_spectral_radiance_scattering")
 
   if (arts_omp_in_parallel()) {
@@ -372,6 +392,8 @@ void ray_path_spectral_radiance_scatteringSunsFirstOrderRayleigh(
     const Agenda& propagation_matrix_agenda,
     const Numeric& depolarization_factor,
     const Index& hse_derivative) try {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(jacobian_targets.x_size(),
                      "Cannot have any Jacobian targets")
 
@@ -393,7 +415,7 @@ void ray_path_spectral_radiance_scatteringSunsFirstOrderRayleigh(
   ARTS_USER_ERROR_IF(
       std::ranges::any_of(ray_path_spectral_radiance_scattering,
                           Cmp::ne(nf),
-                          [](auto& v){return v.size();}),
+                          [](auto& v) { return v.size(); }),
       "Bad ray_path_spectral_radiance_source: incorrect number of frequencies")
 
   StokvecVector spectral_radiance{};

--- a/src/m_surf.cc
+++ b/src/m_surf.cc
@@ -1,21 +1,29 @@
-#include "surf.h"
+#include <workspace.h>
 
 void surface_fieldSet(SurfaceField &surface_field, const Numeric &value,
                       const String &key) {
+  ARTS_TIME_REPORT
+
   surface_field[to<SurfaceKey>(key)] = value;
 }
 
 void surface_fieldSet(SurfaceField &surface_field, const GriddedField2 &value,
                       const String &key) {
+  ARTS_TIME_REPORT
+
   surface_field[to<SurfaceKey>(key)] = value;
 }
 
 void surface_fieldSetProp(SurfaceField &surface_field, const Numeric &value,
                           const String &key) {
+  ARTS_TIME_REPORT
+
   surface_field[SurfacePropertyTag{key}] = value;
 }
 
 void surface_fieldSetProp(SurfaceField &surface_field,
                           const GriddedField2 &value, const String &key) {
+  ARTS_TIME_REPORT
+
   surface_field[SurfacePropertyTag{key}] = value;
 }

--- a/src/m_wigner.cc
+++ b/src/m_wigner.cc
@@ -1,18 +1,12 @@
-/**
- * @file m_wigner.cc
- * @author Richard Larsson
- * @date 2018-04-03
- * 
- * @brief Wigner symbol interactions
- */
-
-#include "debug.h"
+#include <workspace.h>
 #include "wigner_functions.h"
 
 /* Workspace method: Doxygen documentation will be auto-generated */
 void WignerInit(const Index& fast_wigner_stored_symbols,
                 const Index& largest_wigner_symbol_parameter,
                 const Index& symbol_type) {
+  ARTS_TIME_REPORT
+
   ARTS_USER_ERROR_IF(symbol_type != 3 and symbol_type != 6,
                      "Invalid symbol type: {} (must be 3 or 6)",
                      symbol_type);
@@ -24,4 +18,7 @@ void WignerInit(const Index& fast_wigner_stored_symbols,
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
-void WignerUnload() { WignerInformation{}.unload(); }
+void WignerUnload() {
+  ARTS_TIME_REPORT
+  WignerInformation{}.unload();
+}

--- a/src/m_xml.cc
+++ b/src/m_xml.cc
@@ -12,17 +12,23 @@
 /* Workspace method: Doxygen documentation will be auto-generated */
 void output_file_formatSetAscii(  // WS Output:
     String& file_format) {
+  ARTS_TIME_REPORT
+
   file_format = "ascii";
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
 void output_file_formatSetZippedAscii(  // WS Output:
     String& file_format) {
+  ARTS_TIME_REPORT
+
   file_format = "zascii";
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
 void output_file_formatSetBinary(  // WS Output:
     String& file_format) {
+  ARTS_TIME_REPORT
+
   file_format = "binary";
 }

--- a/src/m_xml.h
+++ b/src/m_xml.h
@@ -15,6 +15,7 @@
 #endif
 
 #include <workspace.h>
+
 #include "xml_io.h"
 
 /* Workspace method: Doxygen documentation will be auto-generated */
@@ -23,6 +24,8 @@ void ReadXML(  // WS Generic Output:
     T& v,
     // WS Generic Input:
     const String& f) {
+  ARTS_TIME_REPORT
+
   String filename = f;
 
   // Create default filename if empty
@@ -40,6 +43,8 @@ void ReadXMLIndexed(  // WS Generic Output:
     // WS Generic Input:
     const String& f,
     const Index& digits) {
+  ARTS_TIME_REPORT
+
   String filename = f;
 
   // Create default filename if empty
@@ -58,6 +63,8 @@ void WriteXML(  //WS Input:
     const Index& no_clobber)
 
 {
+  ARTS_TIME_REPORT
+
   // If MPI is enabled make sure only master process performs the write.
 #ifdef ENABLE_MPI
   int initialized;
@@ -90,7 +97,7 @@ void WriteXML(  //WS Input:
     }
   }
 
-  ARTS_USER_ERROR_IF (errmsg.length(), "{}", errmsg);
+  ARTS_USER_ERROR_IF(errmsg.length(), "{}", errmsg);
 }
 
 /* Workspace method: Doxygen documentation will be auto-generated */
@@ -102,6 +109,8 @@ void WriteXMLIndexed(  //WS Input:
     const T& v,
     const String& f,
     const Index& digits) {
+  ARTS_TIME_REPORT
+
   String filename = f;
 
   // Create default filename if empty

--- a/src/m_xsec_fit.cc
+++ b/src/m_xsec_fit.cc
@@ -21,6 +21,8 @@ void absorption_xsec_fit_dataReadSpeciesSplitCatalog(
     const ArrayOfArrayOfSpeciesTag& abs_species,
     const String& basename,
     const Index& ignore_missing_) try {
+  ARTS_TIME_REPORT
+
   const bool ignore_missing = static_cast<bool>(ignore_missing_);
 
   // Build a set of species indices. Duplicates are ignored.
@@ -68,6 +70,8 @@ void propagation_matrixAddXsecFit(  // WS Output:
     const ArrayOfXsecRecord& absorption_xsec_fit_data,
     const Numeric& force_p,
     const Numeric& force_t) {
+  ARTS_TIME_REPORT
+
   // Forward simulations and their error handling
   ARTS_USER_ERROR_IF(
       propagation_matrix.size() not_eq f_grid.size(),

--- a/src/python_interface/py_global.cpp
+++ b/src/python_interface/py_global.cpp
@@ -18,11 +18,19 @@ struct global_data {
 #else
       false;
 #endif
+
   static constexpr bool has_sht = not is_lgpl and
 #ifdef _MSC_VER
                                   false;
 #else
                                   true;
+#endif
+
+  static constexpr bool has_profiling = 
+#if ARTS_PROFILING
+  true;
+#else
+  false;
 #endif
 };
 
@@ -179,12 +187,17 @@ Parameters
 
   py::class_<global_data>(global, "data")
       .def(py::init<>())
-      .def_ro_static("is_lgpl",
-                     &global_data::is_lgpl,
-                     "Whether the ARTS library is compiled licensed under the LGPL")
-      .def_ro_static("has_sht",
-                     &global_data::has_sht,
-                     "Whether the ARTS library is compiled to be able to use the SHT library")
+      .def_ro_static(
+          "is_lgpl",
+          &global_data::is_lgpl,
+          "Whether the ARTS library is compiled licensed under the LGPL")
+      .def_ro_static(
+          "has_sht",
+          &global_data::has_sht,
+          "Whether the ARTS library is compiled to be able to use the SHT library")
+      .def_ro_static("has_profiling",
+                     &global_data::has_profiling,
+                     "Whether the ARTS library is compiled with time profiling")
       .def("__repr__",
            [](const global_data&) {
              return std::format(R"(Global state of ARTS:
@@ -198,7 +211,10 @@ has_sht: {}
       .doc() =
       "A set of global data that we might need from ARTS inside pyarts";
 
-      global.def("time_report", &arts::get_report, "clear"_a=true, "Get the time report");
+  global.def("time_report",
+             &arts::get_report,
+             "clear"_a = true,
+             "Get the time report");
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format("DEV ERROR:\nCannot initialize global\n{}", e.what()));

--- a/src/python_interface/py_global.cpp
+++ b/src/python_interface/py_global.cpp
@@ -197,6 +197,8 @@ has_sht: {}
            })
       .doc() =
       "A set of global data that we might need from ARTS inside pyarts";
+
+      global.def("time_report", &arts::get_report, "clear"_a=true, "Get the time report");
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format("DEV ERROR:\nCannot initialize global\n{}", e.what()));

--- a/src/tests/test_band_matrix_solver.cc
+++ b/src/tests/test_band_matrix_solver.cc
@@ -4,7 +4,6 @@
 #include <limits>
 
 #include "debug.h"
-#include <matpack.h>
 
 int main() {
   const Matrix ex = []() {
@@ -32,11 +31,12 @@ int main() {
 
   //! Ensure that the difference is within the machine epsilon
   for (auto& x : dense_y) {
-    ARTS_USER_ERROR_IF(std::abs(x) > 10*std::numeric_limits<Numeric>::epsilon(),
-                       "Error in band matrix solver!\nOutput supposed to be: {}"
-                       "\nBut diff between dense and banded matrix solutions are: {}",
-                       sparse_b,
-                       dense_y)
+    ARTS_USER_ERROR_IF(
+        std::abs(x) > 1000 * std::numeric_limits<Numeric>::epsilon(),
+        "Error in band matrix solver!\nOutput supposed to be: {}"
+        "\nBut diff between dense and banded matrix solutions are: {}",
+        sparse_b,
+        dense_y)
   }
 
   return 0;

--- a/src/workspace.h
+++ b/src/workspace.h
@@ -18,3 +18,7 @@
 #include <auto_wsg.h>
 #include <auto_wsm.h>
 #include <auto_wsv.h>
+
+// For help
+#include <time_report.h>
+


### PR DESCRIPTION
This adds profiling support to methods in ARTS.

It requires manual addition of the macro `ARTS_TIME_REPORT` to the method you wish to profile.  I have added this to a large number of functions in the `m_*`-files.  If CMake has been run with `-DENABLE_ARTS_PROFILING=1`, there will be a defined value `ARTS_PROFILING` available  while compiling ARTS.

If it is true, a local instance of a `arts::profiler` struct is created.  Upon destruction of this instance, a static data structure will have the delta time from creation to destruction stored in it.  The time step here depends on your system but is generally in microseconds on mac, it might be as slow as milliseconds on some machines.

Anyways, to get a report out of this profiling, the `pyarts.arts.globals.time_report()` call will return a string of this report.  This string contains the average, maximum, and minimum, and total times.  As well as how many times the method was called.  The C++ data is cleared if wanted after this

To allow this to work with multithreading, a mutex is locked in the time report and in the profiler destructor.  This will mean that there's a large overhead and it is recommended to not use the functionality unless while developing.  The times are limited in accuracy, and might be slowed down by the mutex, but it should give a hint at the speed and call time.  The output is sorted by the total amount of time it takes to execute the method.  Note also that methods often call other methods, so the total time will not be the time it took to execute the script.  I am not considering this depth of timings at all for simplicity.

The report running the simple `1.zeeman.py` script looks like:

| Function | Average time | Times called | Min time | Max time | Total time |
| -------- | ------------ | ------------ | -------- | -------- | ---------- |
| void propagation_matrixAddLines(PropmatVector &, StokvecVector &, PropmatMatrix &, StokvecMatrix &, const AscendingGrid &, const JacobianTargets &, const SpeciesEnum &, const AbsorptionBands &, const LinemixingEcsData &, const AtmPoint &, const PropagationPathPoint &, const Index &) | 773µs | 101 | 498µs | 2911µs | 78089µs |
 | void ReadCatalogData(PredefinedModelData &, ArrayOfXsecRecord &, ArrayOfCIARecord &, AbsorptionBands &, const ArrayOfArrayOfSpeciesTag &, const String &, const Index &) | 44297µs | 1 | 44297µs | 44297µs | 44297µs |
 | void absorption_bandsReadSpeciesSplitCatalog(AbsorptionBands &, const ArrayOfArrayOfSpeciesTag &, const String &, const Index &) | 44246µs | 1 | 44246µs | 44246µs | 44246µs |
 | void ray_path_propagation_matrixFromPath(const Workspace &, ArrayOfPropmatVector &, ArrayOfStokvecVector &, ArrayOfPropmatMatrix &, ArrayOfStokvecMatrix &, const Agenda &, const ArrayOfAscendingGrid &, const ArrayOfVector3 &, const JacobianTargets &, const ArrayOfPropagationPathPoint &, const ArrayOfAtmPoint &) | 13437µs | 1 | 13437µs | 13437µs | 13437µs |
 | void ray_path_atmospheric_pointFromPath(ArrayOfAtmPoint &, const ArrayOfPropagationPathPoint &, const AtmField &) | 10417µs | 1 | 10417µs | 10417µs | 10417µs |
 | void ray_path_transmission_matrixFromPath(ArrayOfMuelmatVector &, ArrayOfMuelmatTensor3 &, const ArrayOfPropmatVector &, const ArrayOfPropmatMatrix &, const ArrayOfPropagationPathPoint &, const ArrayOfAtmPoint &, const SurfaceField &, const JacobianTargets &, const Index &) | 6736µs | 1 | 6736µs | 6736µs | 6736µs |
 | void absorption_bandsSelectFrequencyByLine(AbsorptionBands &, const Numeric &, const Numeric &) | 2714µs | 1 | 2714µs | 2714µs | 2714µs |
 | void ray_path_transmission_matrix_cumulativeFromPath(ArrayOfMuelmatVector &, const ArrayOfMuelmatVector &) | 2217µs | 1 | 2217µs | 2217µs | 2217µs |
 | void atmospheric_fieldAppendBaseData(AtmField &, const String &, const String &, const String &, const Index &, const Index &, const Index &) | 1736µs | 1 | 1736µs | 1736µs | 1736µs |
 | void propagation_matrixInit(PropmatVector &, StokvecVector &, PropmatMatrix &, StokvecMatrix &, const JacobianTargets &, const AscendingGrid &) | 9µs | 101 | 2µs | 91µs | 971µs |
 | void ray_path_spectral_radiance_sourceFromPropmat(ArrayOfStokvecVector &, ArrayOfStokvecMatrix &, const ArrayOfPropmatVector &, const ArrayOfStokvecVector &, const ArrayOfPropmatMatrix &, const ArrayOfStokvecMatrix &, const ArrayOfAscendingGrid &, const ArrayOfAtmPoint &, const JacobianTargets &) | 853µs | 1 | 853µs | 853µs | 853µs |
 | void spectral_radianceStepByStepEmission(StokvecVector &, ArrayOfStokvecMatrix &, const ArrayOfMuelmatVector &, const ArrayOfMuelmatVector &, const ArrayOfMuelmatTensor3 &, const ArrayOfStokvecVector &, const ArrayOfStokvecMatrix &, const StokvecVector &) | 654µs | 1 | 654µs | 654µs | 654µs |
 | void atmospheric_fieldAppendAbsorptionData(const Workspace &, AtmField &, const String &, const String &, const Index &, const Index &, const Index &, const Index &) | 611µs | 1 | 611µs | 611µs | 611µs |
 | void WignerInit(const Index &, const Index &, const Index &) | 260µs | 1 | 260µs | 260µs | 260µs |
 | void ray_path_frequency_gridFromPath(ArrayOfAscendingGrid &, ArrayOfVector3 &, const AscendingGrid &, const ArrayOfPropagationPathPoint &, const ArrayOfAtmPoint &) | 155µs | 1 | 155µs | 155µs | 155µs |
 | void atmospheric_fieldInit(AtmField &, const Numeric &, const String &) | 83µs | 1 | 83µs | 83µs | 83µs |
 | void frequency_gridWindShift(AscendingGrid &, Vector3 &, const AtmPoint &, const PropagationPathPoint &) | 0µs | 101 | 0µs | 2µs | 65µs |
 | void propagation_matrix_agendaAuto(Agenda &, const ArrayOfArrayOfSpeciesTag &, const AbsorptionBands &, const Index &, const Numeric &, const Index &, const Index &, const Numeric &, const Numeric &, const Index &, const Index &, const Index &, const Index &, const Numeric &) | 55µs | 1 | 55µs | 55µs | 55µs |
 | void spectral_radianceApplyUnit(StokvecVector &, const AscendingGrid &, const PropagationPathPoint &, const SpectralRadianceUnitType &) | 53µs | 1 | 53µs | 53µs | 53µs |
 | void ray_pathGeometric(ArrayOfPropagationPathPoint &, const AtmField &, const SurfaceField &, const Vector3 &, const Vector2 &, const Numeric &, const Numeric &, const Index &, const Index &, const Index &, const Index &, const Index &) | 52µs | 1 | 52µs | 52µs | 52µs |
 | void spectral_radiance_backgroundAgendasAtEndOfPath(const Workspace &, StokvecVector &, StokvecMatrix &, const AscendingGrid &, const JacobianTargets &, const PropagationPathPoint &, const SurfaceField &, const Agenda &, const Agenda &) | 41µs | 1 | 41µs | 41µs | 41µs |
 | void spectral_radianceSurfaceBlackbody(StokvecVector &, StokvecMatrix &, const AscendingGrid &, const SurfaceField &, const JacobianTargets &, const PropagationPathPoint &) | 29µs | 1 | 29µs | 29µs | 29µs |
 | void ray_pathSetGeometricExtremes(ArrayOfPropagationPathPoint &, const AtmField &, const SurfaceField &, const Numeric &, const Index &) | 27µs | 1 | 27µs | 27µs | 27µs |
 | void absorption_speciesSet(ArrayOfArrayOfSpeciesTag &, const ArrayOfString &) | 27µs | 1 | 27µs | 27µs | 27µs |
 | void spectral_radiance_jacobianEmpty(StokvecMatrix &, const AscendingGrid &, const JacobianTargets &) | 21µs | 1 | 21µs | 21µs | 21µs |
 | void transmission_matrix_backgroundFromPathPropagationBack(MuelmatVector &, const ArrayOfMuelmatVector &) | 20µs | 1 | 20µs | 20µs | 20µs |
 | void surface_fieldPlanet(SurfaceField &, const String &, const Numeric &) | 18µs | 1 | 18µs | 18µs | 18µs |
 | void surface_fieldEarth(SurfaceField &, const String &, const Numeric &) | 16µs | 1 | 16µs | 16µs | 16µs |
 | void atmospheric_fieldIGRF(AtmField &, const Time &) | 15µs | 1 | 15µs | 15µs | 15µs |
 | void ray_pathFixUpdownAzimuth(ArrayOfPropagationPathPoint &) | 12µs | 1 | 12µs | 12µs | 12µs |
 | void propagation_matrix_jacobianWindFix(PropmatMatrix &, StokvecMatrix &, const AscendingGrid &, const JacobianTargets &, const Vector3 &) | 0µs | 101 | 0µs | 1µs | 10µs |
 | void ray_pathFillGeometricStepwise(ArrayOfPropagationPathPoint &, const SurfaceField &, const Numeric &) | 10µs | 1 | 10µs | 10µs | 10µs |
 | void spectral_radiance_jacobianApplyUnit(StokvecMatrix &, const StokvecVector &, const AscendingGrid &, const PropagationPathPoint &, const SpectralRadianceUnitType &) | 5µs | 1 | 5µs | 5µs | 5µs |
 | void ray_pathInit(ArrayOfPropagationPathPoint &, const AtmField &, const SurfaceField &, const Vector3 &, const Vector2 &, const Index &) | 2µs | 1 | 2µs | 2µs | 2µs |
 | void absorption_bandsSetZeeman(AbsorptionBands &, const SpeciesIsotope &, const Numeric &, const Numeric &, const Index &) | 1µs | 1 | 1µs | 1µs | 1µs |
 | void absorption_xsec_fit_dataReadSpeciesSplitCatalog(ArrayOfXsecRecord &, const ArrayOfArrayOfSpeciesTag &, const String &, const Index &) | 1µs | 1 | 1µs | 1µs | 1µs |
 | void spectral_radiance_jacobianFromBackground(StokvecMatrix &, const StokvecMatrix &, const MuelmatVector &) | 1µs | 1 | 1µs | 1µs | 1µs |
 | void ray_path_pointForeground(PropagationPathPoint &, const ArrayOfPropagationPathPoint &) | 0µs | 1 | 0µs | 0µs | 0µs |
 | void absorption_predefined_model_dataReadSpeciesSplitCatalog(PredefinedModelData &, const ArrayOfArrayOfSpeciesTag &, const String &, const Index &, const Index &) | 0µs | 1 | 0µs | 0µs | 0µs |
 | void absorption_cia_dataReadSpeciesSplitCatalog(ArrayOfCIARecord &, const ArrayOfArrayOfSpeciesTag &, const String &, const Index &) | 0µs | 1 | 0µs | 0µs | 0µs |
 | void ray_pathRemoveNonAtm(ArrayOfPropagationPathPoint &) | 0µs | 1 | 0µs | 0µs | 0µs |
 | void spectral_radiance_jacobianAddPathPropagation(StokvecMatrix &, const ArrayOfStokvecMatrix &, const JacobianTargets &, const AtmField &, const ArrayOfPropagationPathPoint &) | 0µs | 1 | 0µs | 0µs | 0µs |
 | void ray_path_pointBackground(PropagationPathPoint &, const ArrayOfPropagationPathPoint &) | 0µs | 1 | 0µs | 0µs | 0µs |