### PR TITLE
Output test numbers

### DIFF
--- a/tests/core/jac/transmission_matrix_polarized.py
+++ b/tests/core/jac/transmission_matrix_polarized.py
@@ -11,6 +11,7 @@ from pyarts.arts.rtepack import two_level_exp
 
 
 a, b, c, d, u, v, w = np.random.random((7))
+print(f"a, b, c, d, u, v, w = {a, b, c, d, u, v, w}")
 a += 1
 
 


### PR DESCRIPTION
This transmission_matrix_polarized test fails in rare circumstances. Outputting the random input numbers hopefully helps to debug this if it occurs again.