### PR TITLE
Stick with clang 19 on macOS for now

### DIFF
--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -1,8 +1,8 @@
 dependencies:
         - boost
         - ccache
-        - clang>=19
-        - clangxx>=19
+        - clang=19
+        - clangxx=19
         - cmake
         - docutils
         - doxygen


### PR DESCRIPTION
clang 20 currently causes failures in wigner lib in Release mode.