### PR TITLE
[ARTS-2.6] Fix bug in certain XFIT on the fly calculations

### DIFF
--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -5,8 +5,8 @@ dependencies:
         - clangxx
         - cmake
         - docutils
-        - gcc
-        - gfortran
+        - gcc<15
+        - gfortran<15
         - glew
         - glfw
         - gmp

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -9,7 +9,7 @@ dependencies:
         - glfw
         - lark-parser
         - libclang
-        - libcxx
+        - libcxx!=20.1.5
         - libmicrohttpd
         - llvm-openmp
         - matplotlib

--- a/src/m_xsec_fit.cc
+++ b/src/m_xsec_fit.cc
@@ -135,11 +135,15 @@ void propmat_clearskyAddXsecFit(  // WS Output:
     if (select_abs_species.nelem() and abs_species[i] not_eq select_abs_species)
       continue;
 
+    bool skip_species = false;
     for (Index s = 0; s < abs_species[i].nelem(); s++) {
       const SpeciesTag& this_species = abs_species[i][s];
 
       // Check if this is a HITRAN cross section tag
-      if (this_species.Type() != Species::TagType::XsecFit) continue;
+      if (this_species.Type() != Species::TagType::XsecFit) {
+        skip_species = true;
+        continue;
+      }
 
       Index this_xdata_index =
           hitran_xsec_get_index(xsec_fit_data, this_species.Spec());
@@ -165,6 +169,7 @@ void propmat_clearskyAddXsecFit(  // WS Output:
             dxsec_temp_dT, f_grid, current_p, current_t + dt, verbosity);
       }
     }
+    if (skip_species) continue;
 
     // Add to result variable:
     Numeric nd = number_density(rtp_pressure, rtp_temperature);

--- a/src/species_tags.cc
+++ b/src/species_tags.cc
@@ -317,7 +317,7 @@ void check_abs_species(const ArrayOfArrayOfSpeciesTag& abs_species) {
   for (Index i = 0; i < abs_species.nelem(); ++i) {
     bool has_free_electrons = false;
     bool has_particles = false;
-    bool has_hitran_xsec = false;
+    bool has_xfit = false;
     for (Index s = 0; s < abs_species[i].nelem(); ++s) {
       if (abs_species[i][s].Type() == Species::TagType::FreeElectrons) {
         num_free_electrons++;
@@ -329,7 +329,7 @@ void check_abs_species(const ArrayOfArrayOfSpeciesTag& abs_species) {
       }
 
       if (abs_species[i][s].Type() == Species::TagType::XsecFit) {
-        has_hitran_xsec = true;
+        has_xfit = true;
       }
     }
 
@@ -344,8 +344,8 @@ void check_abs_species(const ArrayOfArrayOfSpeciesTag& abs_species) {
                        "'particles' must not be combined "
                        "with other tags in the same group.");
 
-    ARTS_USER_ERROR_IF(abs_species[i].nelem() > 1 && has_hitran_xsec,
-                       "'hitran_xsec' must not be combined "
+    ARTS_USER_ERROR_IF(abs_species[i].nelem() > 1 && has_xfit,
+                       "'*-XFIT' must not be combined "
                        "with other tags in the same group.");
   }
 }


### PR DESCRIPTION
If an XFIT species was not defined last in abs_species, non-sensical
values for the following non-XFIT species were wrongly written to
propmat_clearsky.

Exclude libcxx 20.1.5 and gcc 15 in linux environment for now until issues are resolved.