### PR TITLE
Port scalar surface reflectance

### DIFF
--- a/doc/arts/dev.matpack.sorted_grid.rst
+++ b/doc/arts/dev.matpack.sorted_grid.rst
@@ -33,7 +33,7 @@ For cases where you know this will not work well, you can use the ``extend_grid_
 It takes a reference to the grid and exposes the :class:`~pyarts.arts.Vector` interface
 directly.  Upon destroying the ``extend_grid_t`` object, the grid is checked to ensure the sorting is correct.
 
-.. warn::
+.. warning::
 
   Do not have a living instance of a ``extend_grid_t``-object in the same context you intend to consume ``grid_t``.
   The sorting is never guaranteed to be correct until the ``extend_grid_t`` object is destroyed.

--- a/doc/arts/dev.workspace.agendas.rst
+++ b/doc/arts/dev.workspace.agendas.rst
@@ -17,7 +17,7 @@ The agenda object itself is a struct with the following fields:
 - ``inputs`` - the workspace variables that are consumed by the agenda as a list of strings.
 - ``enum_options`` - (optional) a list of strings that are the options for the agenda.  Defaults to empty.
 - ``enum_defaults`` - (optional) the default enum option for the agenda.  Defaults to no-default by being empty.
-- ``output_constraints`` - (optional) a vector of structs tht define constraints on the output after the agenda has been executed.  Defaults to unconstrainged.
+- ``output_constraints`` - (optional) a vector of structs that define constraints on the output after the agenda has been executed.  Defaults to unconstrained.
 
 The two enum-variables, if set, will generate workspace methods that allow setting the agenda to a specific named option.
 This is useful for agendas that have known "modes".  However, it puts some constraints on the implementation of the agenda.

--- a/doc/arts/dev.workspace.agendas.rst
+++ b/doc/arts/dev.workspace.agendas.rst
@@ -15,14 +15,23 @@ The agenda object itself is a struct with the following fields:
 - ``desc`` - a description of the agenda as a string.
 - ``outputs`` - the workspace variables that are produced/output by the agenda as a list of strings.
 - ``inputs`` - the workspace variables that are consumed by the agenda as a list of strings.
-- ``enum_options`` - a list of strings that are the options for the agenda.  Defaults to empty.
-- ``enum_defaults`` - the default enum option for the agenda.  Defaults to no-default by being empty.
+- ``enum_options`` - (optional) a list of strings that are the options for the agenda.  Defaults to empty.
+- ``enum_defaults`` - (optional) the default enum option for the agenda.  Defaults to no-default by being empty.
+- ``output_constraints`` - (optional) a vector of structs tht define constraints on the output after the agenda has been executed.  Defaults to unconstrainged.
 
 The two enum-variables, if set, will generate workspace methods that allow setting the agenda to a specific named option.
 This is useful for agendas that have known "modes".  However, it puts some constraints on the implementation of the agenda.
 The implementor must implement a method ``get_agendax(const std::string&)`` in the
 ``workspace_agenda_creator.h`` and ``workspace_agenda_creator.cpp`` files.
 Please see existing options in those files for examples.
+
+If you want to ensure that the outputs have the right size or correct values (e.g., positive values),
+after executing the agenda, you can use the ``output_constraints`` field.  This is a complicated field
+that is a vector of constraints.  Each constraint has a test and a message.  The test should be 
+a compilable expression that returns a boolean true when the constraint is satisfied.  The message
+is the string that is printed in the exception when 1) the test fails, and 2) on the documentation page.
+Additionally, any number of expressions can be added to the message.  These expressions added to the message
+and evaluated at runtime when a failure occurs (e.g., ``{x.size()}``).
 
 How to add a workspace agenda?
 ==============================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -151,6 +151,7 @@ add_library(artsworkspace STATIC
   m_spectral_radiance_field.cc
   m_sun.cc
   m_surf.cc
+  m_surface_spectral_radiance.cc
   m_wigner.cc
   m_xml.cc
   sun_methods.cc

--- a/src/core/rtepack/CMakeLists.txt
+++ b/src/core/rtepack/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(rtepack STATIC
   rtepack_scattering.cc
   rtepack_source.cc
   rtepack_stokes_vector.cc
+  rtepack_surface.cc
   rtepack_transmission.cc
 )
 target_include_directories(rtepack PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/core/rtepack/rtepack.h
+++ b/src/core/rtepack/rtepack.h
@@ -5,6 +5,7 @@
 #include "rtepack_scattering.h"
 #include "rtepack_source.h"
 #include "rtepack_spectral_matrix.h"
+#include "rtepack_surface.h"
 #include "rtepack_transmission.h"
 
 using Propmat                     = rtepack::propmat;

--- a/src/core/rtepack/rtepack_surface.cc
+++ b/src/core/rtepack/rtepack_surface.cc
@@ -1,0 +1,35 @@
+#include "rtepack_mueller_matrix.h"
+#include "rtepack_multitype.h"
+#include "rtepack_stokes_vector.h"
+
+namespace rtepack {
+stokvec flat_scalar_reflection(stokvec I, const Numeric R, const Numeric B) {
+  assert(R >= 0.0 and R <= 1.0);
+
+  I      = I * R;
+  I.V() *= -1.0;  //! NOTE: The elementwise multiplication is [R, R, R, -R]
+  I.I() += B * (1.0 - R);
+  return I;
+}
+
+stokvec flat_scalar_reflection_pure_reflect(stokvec I, const Numeric R) {
+  assert(R >= 0.0 and R <= 1.0);
+
+  I      = I * R;
+  I.V() *= -1.0;  //! NOTE: The elementwise multiplication is [R, R, R, -R]
+  return I;
+}
+
+stokvec dflat_scalar_reflection_dr(stokvec I, const Numeric dRdx, const Numeric B) {
+  I      = I * dRdx;
+  I.V() *= -1.0;  //! NOTE: The elementwise multiplication is [R, R, R, -R]
+  I.I() -= B * dRdx;
+  return I;
+}
+
+stokvec dflat_scalar_reflection_db(const Numeric R, const Numeric dBdx) {
+  assert(R >= 0.0 and R <= 1.0);
+
+  return {dBdx * (1.0 - R), 0.0, 0.0, 0.0};
+}
+}  // namespace rtepack

--- a/src/core/rtepack/rtepack_surface.h
+++ b/src/core/rtepack/rtepack_surface.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "rtepack_mueller_matrix.h"
+#include "rtepack_multitype.h"
+#include "rtepack_stokes_vector.h"
+
+namespace rtepack {
+/** Reflect and emit a Stokes vector
+ * 
+ * The reflection is scalar, i.e. the same for all Stokes components.
+ * To maintain R + E = 1, (1 - R) * B is added to the I() component.
+ * 
+ * Circular polarization is mirrored.
+ * 
+ * @param I Incoming radiation
+ * @param R Scalar reflection
+ * @param T Surface temperature
+ * @param f Frequency of incoming radiation
+ * @return  Outgoing radiation
+ */
+stokvec flat_scalar_reflection(stokvec I, const Numeric R, const Numeric B);
+
+/** See flat_scalar_reflection, this is just the reflection part. */
+stokvec flat_scalar_reflection_pure_reflect(stokvec I, const Numeric R);
+
+/** See flat_scalar_reflection, this is the dRdx part. */
+stokvec dflat_scalar_reflection_dr(stokvec I, const Numeric dRdx, const Numeric B);
+
+/** See flat_scalar_reflection, this is the dBdx part. */
+stokvec dflat_scalar_reflection_db(const Numeric R, const Numeric dBdx);
+}  // namespace rtepack

--- a/src/core/surface/surf.cpp
+++ b/src/core/surface/surf.cpp
@@ -300,8 +300,7 @@ Vector2 Field::normal(Numeric lat, Numeric lon, Numeric alt) const try {
 
   constexpr Numeric offset = 1e-3;
   const Numeric lat1 = (lat + offset > 90) ? (lat - offset) : (lat + offset),
-                lon1 = lon,
-                alt1 = interpolation_function(lat1, lon1)(z);
+                lon1 = lon, alt1 = interpolation_function(lat1, lon1)(z);
   const Numeric lat2 = lat, lon2 = lon + offset,
                 alt2 = interpolation_function(lat2, lon2)(z);
 
@@ -549,4 +548,22 @@ std::string std::formatter<SurfaceKeyVal>::to_string(
         return std::vformat(fmt.c_str(), std::make_format_args(val));
       },
       v);
+}
+
+bool operator==(const SurfaceKeyVal &lhs, SurfaceKey rhs) {
+  auto *val = std::get_if<SurfaceKey>(&lhs);
+
+  return val ? (*val == rhs) : false;
+}
+
+bool operator==(SurfaceKey lhs, const SurfaceKeyVal &rhs) { return rhs == lhs; }
+
+bool operator==(const SurfaceKeyVal &lhs, const SurfacePropertyTag &rhs) {
+  auto *val = std::get_if<SurfacePropertyTag>(&lhs);
+
+  return val ? (*val == rhs) : false;
+}
+
+bool operator==(const SurfacePropertyTag &lhs, const SurfaceKeyVal &rhs) {
+  return rhs == lhs;
 }

--- a/src/core/surface/surf.h
+++ b/src/core/surface/surf.h
@@ -194,6 +194,10 @@ using SurfacePoint        = Surf::Point;
 using SurfaceField        = Surf::Field;
 using ArrayOfSurfacePoint = Array<SurfacePoint>;
 
+bool operator==(const SurfaceKeyVal &, SurfaceKey);
+bool operator==(SurfaceKey, const SurfaceKeyVal &);
+bool operator==(const SurfaceKeyVal &, const SurfacePropertyTag &);
+bool operator==(const SurfacePropertyTag &, const SurfaceKeyVal &);
 template <>
 struct std::formatter<SurfacePropertyTag> {
   format_tags tags;

--- a/src/core/util/array.h
+++ b/src/core/util/array.h
@@ -4,6 +4,8 @@
 #include <debug.h>
 
 #include <algorithm>
+#include <limits>
+#include <type_traits>
 #include <vector>
 
 /** An array. */
@@ -24,10 +26,26 @@ constexpr base max(const Array<base>& x) {
   return *std::ranges::max_element(x);
 }
 
+template <class base, class ConvFunc>
+constexpr auto max(const Array<base>& x, ConvFunc&& f) {
+  using RetType = std::remove_cvref_t<decltype(f(base{}))>;
+  RetType maxv  = std::numeric_limits<RetType>::lowest();
+  for (auto& elem : x) maxv = std::max<RetType>(f(elem), maxv);
+  return maxv;
+}
+
 /** Min function. */
 template <class base>
 constexpr base min(const Array<base>& x) {
   return *std::ranges::min_element(x);
+}
+
+template <class base, class ConvFunc>
+constexpr auto min(const Array<base>& x, ConvFunc&& f) {
+  using RetType = std::remove_cvref_t<decltype(f(base{}))>;
+  RetType maxv  = std::numeric_limits<RetType>::max();
+  for (auto& elem : x) maxv = std::min<RetType>(f(elem), maxv);
+  return maxv;
 }
 
 //! Find first occurance.

--- a/src/m_rad.cc
+++ b/src/m_rad.cc
@@ -412,30 +412,6 @@ void measurement_vectorFromSensor(
             surface_field,
             spectral_radiance_observer_agenda);
 
-        ARTS_USER_ERROR_IF(
-            spectral_radiance.size() != f_grid_ptr->size(),
-            R"(spectral_radiance must have same size as element frequency grid
-
-spectral_radiance.size() = {},
-f_grid_ptr->size()       = {}
-)",
-            spectral_radiance.size(),
-            f_grid_ptr->size())
-
-        ARTS_USER_ERROR_IF(
-            not same_shape<2>({measurement_jacobian.ncols(),
-                               static_cast<Index>(f_grid_ptr->size())},
-                              spectral_radiance_jacobian),
-            R"(spectral_radiance_jacobian must be targets x frequency grid size
-
-spectral_radiance_jacobian.shape()  = {:B,},
-f_grid_ptr->size()                  = {},
-measurement_jacobian.ncols()        = {}
-)",
-            spectral_radiance_jacobian.shape(),
-            f_grid_ptr->size(),
-            measurement_jacobian.ncols())
-
         spectral_radianceApplyUnitFromSpectralRadiance(
             spectral_radiance,
             spectral_radiance_jacobian,

--- a/src/m_surface_spectral_radiance.cc
+++ b/src/m_surface_spectral_radiance.cc
@@ -1,0 +1,128 @@
+#include <arts_omp.h>
+#include <workspace.h>
+
+Vector2 specular_losNormal(const Vector2& normal,
+                           const Vector2& los,
+                           const Vector3& pos,
+                           const Vector2& ell) {
+  const auto [ecef_pos, ecef_los] = path::geodetic_poslos2ecef(pos, los, ell);
+  const auto [_, ecef_normal] = path::geodetic_poslos2ecef(pos, normal, ell);
+
+  // Specular direction is 2(dn*di)dn-di, where dn is the normal vector
+  const Numeric fac       = 2 * dot(ecef_normal, ecef_los);
+  const Vector3 ecef_spec = {fac * ecef_normal[0] - ecef_los[0],
+                             fac * ecef_normal[1] - ecef_los[1],
+                             fac * ecef_normal[2] - ecef_los[2]};
+
+  return path::ecef2geodetic_poslos(ecef_pos, normalized(ecef_spec), ell)
+      .second;
+}
+
+void spectral_radianceFlatScalarReflectance(
+    const Workspace& ws,
+    StokvecVector& spectral_radiance,
+    StokvecMatrix& spectral_radiance_jacobian,
+    const AscendingGrid& frequency_grid,
+    const AtmField& atmospheric_field,
+    const SurfaceField& surface_field,
+    const JacobianTargets& jacobian_targets,
+    const PropagationPathPoint& ray_path_point,
+    const Agenda& spectral_radiance_observer_agenda) try {
+  ARTS_TIME_REPORT
+
+  //! NOTE: Feel free to change the name and style of this key, it is unique to this method
+  const SurfacePropertyTag reflectance_target{"flat scalar reflectance"};
+
+  ARTS_USER_ERROR_IF(not surface_field.has(reflectance_target, SurfaceKey::t),
+                     R"--(Missing key property tag for method.
+
+Tag "flat scalar reflectance" not in the surface field.
+
+surface_field:
+{}
+)--",
+                     surface_field);
+
+  const SurfacePoint surface_point =
+      surface_field.at(ray_path_point.pos[1], ray_path_point.pos[2]);
+
+  // Get the direction of the incoming radiation
+  const Vector2 los = specular_losNormal(surface_point.normal,
+                                         ray_path_point.los,
+                                         ray_path_point.pos,
+                                         surface_field.ellipsoid);
+
+  const Size NF = frequency_grid.size();
+  const Size NX = jacobian_targets.x_size();
+
+  ArrayOfPropagationPathPoint ray_path;
+  spectral_radiance_observer_agendaExecute(ws,
+                                           spectral_radiance,
+                                           spectral_radiance_jacobian,
+                                           ray_path,
+                                           frequency_grid,
+                                           jacobian_targets,
+                                           ray_path_point.pos,
+                                           los,
+                                           atmospheric_field,
+                                           surface_field,
+                                           spectral_radiance_observer_agenda);
+
+  const Numeric R = surface_point[reflectance_target];
+  const Numeric T = surface_point[SurfaceKey::t];
+
+  ARTS_USER_ERROR_IF(
+      R < 0.0 or R > 1.0,
+      "Flat scalar reflectance must be between 0 and 1, but is {}.",
+      R)
+
+#pragma omp parallel for collapse(2) if (not arts_omp_in_parallel())
+  for (Size j = 0; j < NX; j++) {
+    for (Size i = 0; i < NF; i++) {
+      spectral_radiance_jacobian[j, i] =
+          rtepack::flat_scalar_reflection_pure_reflect(
+              spectral_radiance_jacobian[j, i], R);
+    }
+  }
+
+  for (auto& target : jacobian_targets.surf()) {
+    if (target.type == SurfaceKey::t) {
+      const auto& data = surface_field[target.type];
+
+      const auto ws =
+          data.flat_weights(ray_path_point.pos[1], ray_path_point.pos[2]);
+
+#pragma omp parallel for if (not arts_omp_in_parallel())
+      for (Size i = 0; i < NF; i++) {
+        const Numeric dBdt = dplanck_dt(frequency_grid[i], T);
+        for (const auto& w : ws) {
+          spectral_radiance_jacobian[w.first + target.x_start, i] +=
+              w.second * rtepack::dflat_scalar_reflection_db(R, dBdt);
+        }
+      }
+    } else if (target.type == reflectance_target) {
+      const auto& data = surface_field[target.type];
+
+      const auto ws =
+          data.flat_weights(ray_path_point.pos[1], ray_path_point.pos[2]);
+
+#pragma omp parallel for if (not arts_omp_in_parallel())
+      for (Size i = 0; i < NF; i++) {
+        const Numeric B = planck(frequency_grid[i], T);
+        for (const auto& w : ws) {
+          spectral_radiance_jacobian[w.first + target.x_start, i] +=
+              w.second *
+              rtepack::dflat_scalar_reflection_dr(spectral_radiance[i], 1.0, B);
+        }
+      }
+    }
+  }
+
+#pragma omp parallel for if (not arts_omp_in_parallel())
+  for (Size i = 0; i < NF; i++) {
+    const Numeric B = planck(frequency_grid[i], T);
+    spectral_radiance[i] =
+        rtepack::flat_scalar_reflection(spectral_radiance[i], R, B);
+  }
+}
+ARTS_METHOD_ERROR_CATCH

--- a/src/make_auto_wsa.cpp
+++ b/src/make_auto_wsa.cpp
@@ -17,6 +17,7 @@ struct auto_ag {
   std::string desc;
   std::vector<std::pair<std::string, std::string>> o;
   std::vector<std::pair<std::string, std::string>> i;
+  std::vector<StringVectorAgendaHelper> output_constraints;
 };
 
 void helper_auto_ag(std::ostream& os,
@@ -51,6 +52,8 @@ std::map<std::string, auto_ag> auto_ags(std::ostream& os) {
     for (const auto& in : record.input) {
       helper_auto_ag(os, ag.i, name, in);
     }
+
+    ag.output_constraints = record.output_constraints;
   }
 
   return map;
@@ -179,6 +182,27 @@ void agenda_checker(std::ostream& os, const std::string& name) {
         "    throw std::runtime_error(std::format(\"Mismatch with name: {}\", n));\n  }\n";
 }
 
+std::string double_curly(std::string s) { 
+  Size n = 0;
+
+  for (Size i=0; i<s.size()-1; i++) {
+    n += (s[i] == '{' and s[i+1] == '{');
+  }
+
+  for (Size i=0; i<n; i++) {
+    s.push_back('{');
+    s.push_back('}');
+  }
+
+  for (Size i=1; i<s.size(); i++) {
+    if (s[i-1] == '{' and s[i] == '}') {
+      stdr::rotate(s.begin()+i, s.end()-2, s.end());
+    }
+  }
+
+  return s;
+ }
+
 void workspace_setup_and_exec(std::ostream& os,
                               const std::string& name,
                               const auto_ag& ag) {
@@ -205,6 +229,31 @@ void workspace_setup_and_exec(std::ostream& os,
 
   os << "\n  // Run all the methods\n  " << name;
   os << ".execute(_lws);\n";
+
+  for (auto& constraint : ag.output_constraints) {
+    std::print(os,
+               R"--(
+  if(not ({}))
+    throw std::runtime_error(std::format(R"ERR({}
+)--",
+               constraint.test,
+               double_curly(constraint.constraint));
+
+    const Size N = max(constraint.printables,
+                       [](const std::string& x) -> Size { return x.size(); });
+    for (auto& p : constraint.printables) {
+      std::print(os,
+                 R"--(
+{}:{} {{}})--",
+                 double_curly(p),
+                 std::string(N - p.size(), ' '));
+    }
+    if (not constraint.printables.empty()) {
+      std::print(os, R"--(
+)ERR", {:,}));
+)--", constraint.printables);
+    }
+  }
 }
 
 void implementation(std::ostream& os) {

--- a/src/make_auto_wsa.cpp
+++ b/src/make_auto_wsa.cpp
@@ -182,26 +182,26 @@ void agenda_checker(std::ostream& os, const std::string& name) {
         "    throw std::runtime_error(std::format(\"Mismatch with name: {}\", n));\n  }\n";
 }
 
-std::string double_curly(std::string s) { 
+std::string double_curly(std::string s) {
   Size n = 0;
 
-  for (Size i=0; i<s.size()-1; i++) {
-    n += (s[i] == '{' and s[i+1] == '{');
+  for (Size i = 0; i < s.size() - 1; i++) {
+    n += (s[i] == '{' and s[i + 1] == '{');
   }
 
-  for (Size i=0; i<n; i++) {
+  for (Size i = 0; i < n; i++) {
     s.push_back('{');
     s.push_back('}');
   }
 
-  for (Size i=1; i<s.size(); i++) {
-    if (s[i-1] == '{' and s[i] == '}') {
-      stdr::rotate(s.begin()+i, s.end()-2, s.end());
+  for (Size i = 1; i < s.size(); i++) {
+    if (s[i - 1] == '{' and s[i] == '}') {
+      stdr::rotate(s.begin() + i, s.end() - 2, s.end());
     }
   }
 
   return s;
- }
+}
 
 void workspace_setup_and_exec(std::ostream& os,
                               const std::string& name,
@@ -249,9 +249,11 @@ void workspace_setup_and_exec(std::ostream& os,
                  std::string(N - p.size(), ' '));
     }
     if (not constraint.printables.empty()) {
-      std::print(os, R"--(
+      std::print(os,
+                 R"--(
 )ERR", {:,}));
-)--", constraint.printables);
+)--",
+                 constraint.printables);
     }
   }
 }

--- a/src/python_interface/gen_auto_py_groups.cpp
+++ b/src/python_interface/gen_auto_py_groups.cpp
@@ -293,13 +293,49 @@ Returns
     workspace_group_interface({0}_operator);
     py::implicitly_convertible<{0}Operator::func_t,
                                {0}Operator>();
+    {0}_operator.doc() = R"-x-(This is the operator for free customization of the agenda: :attr:`~pyarts.workspace.Workspace.{0}`.
+
+The python meta-code to make use of this operator class instead of the standard agenda in a workspace reads like this:
+
+.. code-block:: python
+
+    import pyarts
+
+    ws = pyarts.Workspace()
+
+    def my_{0}_operator({2:,}):
+        ...
+        # custom code that creates or modifies {6:,}
+        ...
+        return {6:,}
+    
+    ws.{0}SetOperator(f=my_{0}_operator)
+
+You are free to put whatever custom code you want in the operator.
+The types returned must be convertible to the types of the workspace variables being returned.
+The input to the operator from the workspace will be the types of the workspace variables
+that are passed to the agenda.
+Failure to follow these rules will result in a runtime error.
+
+.. note::
+
+      There might be constraints on the input and output passed to the operator.
+      Check the documentation of the agenda for more details.
+
+.. warning::
+
+      Accessing global variables in the operator is not thread safe.
+      It is very likely ARTS will access your operator in parallel.
+      You need to make sure that the operator is thread safe.
+)-x-";
 )",
                name,
                input,
                ag.input,
                vars,
                params,
-               retval);
+               retval,
+               ag.output);
   }
 
   cpp << "}}\n";

--- a/src/python_interface/py_jac.cpp
+++ b/src/python_interface/py_jac.cpp
@@ -19,16 +19,22 @@ namespace Python {
 void py_jac(py::module_& m) try {
   py::class_<ErrorKey> errkey(m, "ErrorKey");
   errkey.doc() = "Error key";
-  errkey.def_rw("y_start", &ErrorKey::y_start, "Start index of target in measurement vector");
-  errkey.def_rw("y_size", &ErrorKey::y_size, "Size of target in measurement vector");
+  errkey.def_rw("y_start",
+                &ErrorKey::y_start,
+                "Start index of target in measurement vector");
+  errkey.def_rw(
+      "y_size", &ErrorKey::y_size, "Size of target in measurement vector");
 
   py::class_<Jacobian::AtmTarget> atm(m, "AtmTarget");
   atm.doc() = "Atmospheric target";
   atm.def_ro("type", &Jacobian::AtmTarget::type, "Type of target");
   atm.def_ro("d", &Jacobian::AtmTarget::d, "Perturbation magnitude");
   atm.def_ro("target_pos", &Jacobian::AtmTarget::target_pos, "Target position");
-  atm.def_ro("x_start", &Jacobian::AtmTarget::x_start, "Start index of target in state vector");
-  atm.def_ro("x_size", &Jacobian::AtmTarget::x_size, "Size of target in state vector");
+  atm.def_ro("x_start",
+             &Jacobian::AtmTarget::x_start,
+             "Start index of target in state vector");
+  atm.def_ro(
+      "x_size", &Jacobian::AtmTarget::x_size, "Size of target in state vector");
   str_interface(atm);
   atm.def(
       "model_state",
@@ -61,9 +67,14 @@ x : Vector
   surf.doc() = "Surface target";
   surf.def_ro("type", &Jacobian::SurfaceTarget::type, "Type of target");
   surf.def_ro("d", &Jacobian::SurfaceTarget::d, "Perturbation magnitude");
-  surf.def_ro("target_pos", &Jacobian::SurfaceTarget::target_pos, "Target position");
-  surf.def_ro("x_start", &Jacobian::SurfaceTarget::x_start, "Start index of target in state vector");
-  surf.def_ro("x_size", &Jacobian::SurfaceTarget::x_size, "Size of target in state vector");
+  surf.def_ro(
+      "target_pos", &Jacobian::SurfaceTarget::target_pos, "Target position");
+  surf.def_ro("x_start",
+              &Jacobian::SurfaceTarget::x_start,
+              "Start index of target in state vector");
+  surf.def_ro("x_size",
+              &Jacobian::SurfaceTarget::x_size,
+              "Size of target in state vector");
   str_interface(surf);
   surf.def(
       "model_state",
@@ -96,9 +107,14 @@ x : Vector
   line.doc() = "Line target";
   line.def_ro("type", &Jacobian::LineTarget::type, "Type of target");
   line.def_ro("d", &Jacobian::LineTarget::d, "Perturbation magnitude");
-  line.def_ro("target_pos", &Jacobian::LineTarget::target_pos, "Target position");
-  line.def_ro("x_start", &Jacobian::LineTarget::x_start, "Start index of target in state vector");
-  line.def_ro("x_size", &Jacobian::LineTarget::x_size, "Size of target in state vector");
+  line.def_ro(
+      "target_pos", &Jacobian::LineTarget::target_pos, "Target position");
+  line.def_ro("x_start",
+              &Jacobian::LineTarget::x_start,
+              "Start index of target in state vector");
+  line.def_ro("x_size",
+              &Jacobian::LineTarget::x_size,
+              "Size of target in state vector");
   str_interface(line);
   line.def(
       "model_state",
@@ -131,9 +147,14 @@ x : Vector
   sensor.doc() = "Sensor target";
   sensor.def_ro("type", &Jacobian::SensorTarget::type, "Type of target");
   sensor.def_ro("d", &Jacobian::SensorTarget::d, "Perturbation magnitude");
-  sensor.def_ro("target_pos", &Jacobian::SensorTarget::target_pos, "Target position");
-  sensor.def_ro("x_start", &Jacobian::SensorTarget::x_start, "Start index of target in state vector");
-  sensor.def_ro("x_size", &Jacobian::SensorTarget::x_size, "Size of target in state vector");
+  sensor.def_ro(
+      "target_pos", &Jacobian::SensorTarget::target_pos, "Target position");
+  sensor.def_ro("x_start",
+                &Jacobian::SensorTarget::x_start,
+                "Start index of target in state vector");
+  sensor.def_ro("x_size",
+                &Jacobian::SensorTarget::x_size,
+                "Size of target in state vector");
   str_interface(sensor);
   sensor.def(
       "model_state",
@@ -165,9 +186,14 @@ x : Vector
   py::class_<Jacobian::ErrorTarget> error(m, "SensorTarget");
   error.doc() = "Error target";
   error.def_ro("type", &Jacobian::ErrorTarget::type, "Type of target");
-  error.def_ro("target_pos", &Jacobian::ErrorTarget::target_pos, "Target position");
-  error.def_ro("x_start", &Jacobian::ErrorTarget::x_start, "Start index of target in state vector");
-  error.def_ro("x_size", &Jacobian::ErrorTarget::x_size, "Size of target in state vector");
+  error.def_ro(
+      "target_pos", &Jacobian::ErrorTarget::target_pos, "Target position");
+  error.def_ro("x_start",
+               &Jacobian::ErrorTarget::x_start,
+               "Start index of target in state vector");
+  error.def_ro("x_size",
+               &Jacobian::ErrorTarget::x_size,
+               "Size of target in state vector");
   str_interface(error);
 
   py::bind_vector<std::vector<Jacobian::AtmTarget>>(m, "ArrayOfAtmTargets")
@@ -219,6 +245,14 @@ x : Vector
         j.error() = std::move(t);
       },
       "List of error targets");
+  jacs.def(
+      "x_size",
+      [](const JacobianTargets& j){return j.x_size();},
+      "The number of elements required in the *model_state_vector* to represent the Jacobian.");
+  jacs.def(
+      "target_count",
+      [](const JacobianTargets& j){return j.target_count();},
+      "The number of targets added to the Jacobian.");
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format("DEV ERROR:\nCannot initialize jac\n{}", e.what()));

--- a/src/python_interface/py_surf.cpp
+++ b/src/python_interface/py_surf.cpp
@@ -131,7 +131,8 @@ void py_surf(py::module_ &m) try {
           "__getitem__",
           [](SurfacePoint &surf, const SurfacePropertyTag& x) {
             if (not surf.has(x))
-              throw py::key_error(std::format("{}", x).c_str());
+              const auto error_message = std::format("{}", x);
+              throw py::key_error(error_message.c_str());
             return surf[x];
           },
           py::rv_policy::reference_internal)

--- a/src/python_interface/py_surf.cpp
+++ b/src/python_interface/py_surf.cpp
@@ -128,6 +128,18 @@ void py_surf(py::module_ &m) try {
              surf[x] = data;
            })
       .def(
+          "__getitem__",
+          [](SurfacePoint &surf, const SurfacePropertyTag& x) {
+            if (not surf.has(x))
+              throw py::key_error(std::format("{}", x).c_str());
+            return surf[x];
+          },
+          py::rv_policy::reference_internal)
+      .def("__setitem__",
+           [](SurfacePoint &surf, const SurfacePropertyTag& x, Numeric data) {
+             surf[x] = data;
+           })
+      .def(
           "__getstate__",
           [](const SurfacePoint &t) {
             auto k = t.keys();
@@ -166,6 +178,17 @@ void py_surf(py::module_ &m) try {
          py::rv_policy::reference_internal)
       .def("__setitem__",
            [](SurfaceField &surf, SurfaceKey x, const Surf::Data &data) {
+             surf[x] = data;
+           }).def(
+         "__getitem__",
+         [](SurfaceField &surf, const SurfacePropertyTag& x) -> Surf::Data & {
+           if (not surf.has(x))
+             throw py::key_error(std::format("{}", x).c_str());
+           return surf[x];
+         },
+         py::rv_policy::reference_internal)
+      .def("__setitem__",
+           [](SurfaceField &surf, const SurfacePropertyTag& x, const Surf::Data &data) {
              surf[x] = data;
            })
       .def(

--- a/src/python_interface/py_surf.cpp
+++ b/src/python_interface/py_surf.cpp
@@ -118,8 +118,10 @@ void py_surf(py::module_ &m) try {
       .def(
           "__getitem__",
           [](SurfacePoint &surf, SurfaceKey x) {
-            if (not surf.has(x))
-              throw py::key_error(std::format("{}", x).c_str());
+            if (not surf.has(x)) {
+              const auto error_message = std::format("{}", x);
+              throw py::key_error(error_message.c_str());
+            }
             return surf[x];
           },
           py::rv_policy::reference_internal)
@@ -129,15 +131,16 @@ void py_surf(py::module_ &m) try {
            })
       .def(
           "__getitem__",
-          [](SurfacePoint &surf, const SurfacePropertyTag& x) {
-            if (not surf.has(x))
+          [](SurfacePoint &surf, const SurfacePropertyTag &x) {
+            if (not surf.has(x)) {
               const auto error_message = std::format("{}", x);
               throw py::key_error(error_message.c_str());
+            }
             return surf[x];
           },
           py::rv_policy::reference_internal)
       .def("__setitem__",
-           [](SurfacePoint &surf, const SurfacePropertyTag& x, Numeric data) {
+           [](SurfacePoint &surf, const SurfacePropertyTag &x, Numeric data) {
              surf[x] = data;
            })
       .def(
@@ -172,26 +175,31 @@ void py_surf(py::module_ &m) try {
   fld.def(
          "__getitem__",
          [](SurfaceField &surf, SurfaceKey x) -> Surf::Data & {
-           if (not surf.has(x))
-             throw py::key_error(std::format("{}", x).c_str());
+           if (not surf.has(x)) {
+             const auto error_message = std::format("{}", x);
+             throw py::key_error(error_message.c_str());
+           }
            return surf[x];
          },
          py::rv_policy::reference_internal)
       .def("__setitem__",
            [](SurfaceField &surf, SurfaceKey x, const Surf::Data &data) {
              surf[x] = data;
-           }).def(
-         "__getitem__",
-         [](SurfaceField &surf, const SurfacePropertyTag& x) -> Surf::Data & {
-           if (not surf.has(x))
-             throw py::key_error(std::format("{}", x).c_str());
-           return surf[x];
-         },
-         py::rv_policy::reference_internal)
-      .def("__setitem__",
-           [](SurfaceField &surf, const SurfacePropertyTag& x, const Surf::Data &data) {
-             surf[x] = data;
            })
+      .def(
+          "__getitem__",
+          [](SurfaceField &surf, const SurfacePropertyTag &x) -> Surf::Data & {
+            if (not surf.has(x)) {
+              const auto error_message = std::format("{}", x);
+              throw py::key_error(error_message.c_str());
+            }
+            return surf[x];
+          },
+          py::rv_policy::reference_internal)
+      .def("__setitem__",
+           [](SurfaceField &surf,
+              const SurfacePropertyTag &x,
+              const Surf::Data &data) { surf[x] = data; })
       .def(
           "__call__",
           [](const SurfaceField &surf, Numeric lat, Numeric lon) {

--- a/src/workspace_agenda_creator.cpp
+++ b/src/workspace_agenda_creator.cpp
@@ -128,6 +128,9 @@ Agenda get_spectral_radiance_surface_agenda(const std::string& option) {
     case Transmission:
       agenda.add("spectral_radianceDefaultTransmission");
       break;
+    case FlatScalarReflectance:
+      agenda.add("spectral_radianceFlatScalarReflectance");
+      break;
   }
 
   return std::move(agenda).finalize(true);

--- a/src/workspace_agendas.cpp
+++ b/src/workspace_agendas.cpp
@@ -19,6 +19,26 @@ internal_workspace_agendas_creator() {
                        "ray_path_point",
                        "atmospheric_point"},
       .enum_options = {"Empty"},
+      .output_constraints = {
+            {"propagation_matrix.size() == frequency_grid.size()",
+             "Propagation matrix has the same size as frequency grid after executing the agenda.",
+             "propagation_matrix.size()",
+             "frequency_grid.size()"},
+            {"propagation_matrix_source_vector_nonlte.size() == frequency_grid.size()",
+             "Non-LTE source vector has the same size as frequency grid after executing the agenda.",
+             "propagation_matrix_source_vector_nonlte.size()",
+             "frequency_grid.size()"},
+            {"matpack::same_shape<2>({jacobian_targets.target_count(), frequency_grid.size()}, propagation_matrix_jacobian)",
+             "Propagation matrix Jacobian has the shape [jacobian_targets.target_count() x frequency_grid.size()] after executing the agenda.",
+             "propagation_matrix_jacobian.shape()",
+             "frequency_grid.size()",
+             "jacobian_targets.target_count()"},
+            {"matpack::same_shape<2>({jacobian_targets.target_count(), frequency_grid.size()}, propagation_matrix_source_vector_nonlte_jacobian)",
+             "Non-LTE source vector Jacobian has the shape [jacobian_targets.target_count() x frequency_grid.size()] after executing the agenda.",
+             "propagation_matrix_source_vector_nonlte_jacobian.shape()",
+             "frequency_grid.size()",
+             "jacobian_targets.target_count()"},
+      },
   };
 
   wsa_data["propagation_matrix_scattering_spectral_agenda"] = {
@@ -31,6 +51,22 @@ internal_workspace_agendas_creator() {
       .input  = {"frequency_grid", "atmospheric_point", "legendre_degree"},
       .enum_options = {"FromSpeciesTRO"},
       .enum_default = "FromSpeciesTRO",
+      .output_constraints =
+          {
+              {"propagation_matrix_scattering.size() == frequency_grid.size()",
+               "Propagation matrix has the same size as frequency grid after executing the agenda.",
+               "propagation_matrix_scattering.size()",
+               "frequency_grid.size()"},
+              {"absorption_vector_scattering.size() == frequency_grid.size()",
+               "Absorption vector has the same size as frequency grid after executing the agenda.",
+               "absorption_vector_scattering.size()",
+               "frequency_grid.size()"},
+              {"matpack::same_shape<2>({frequency_grid.size(), legendre_degree + 1}, phase_matrix_scattering_spectral)",
+               "Phase matrix has the shape [frequency_grid.size() x legendre_degree + 1] after executing the agenda.",
+               "phase_matrix_scattering_spectral.shape()",
+               "frequency_grid.size()",
+            "legendre_degree"},
+          },
   };
 
   wsa_data["propagation_matrix_scattering_agenda"] = {
@@ -41,17 +77,24 @@ internal_workspace_agendas_creator() {
       .input        = {"frequency_grid", "atmospheric_point"},
       .enum_options = {"AirSimple"},
       .enum_default = "AirSimple",
+      .output_constraints =
+          {
+              {"propagation_matrix_scattering.size() == frequency_grid.size()",
+               "Propagation matrix scattering has the same size as frequency grid after executing the agenda.",
+               "propagation_matrix_scattering.size()",
+               "frequency_grid.size()"},
+          },
   };
 
   wsa_data["ray_path_observer_agenda"] = {
-      .desc         = R"--(Get the propagation path as it is obeserved.
+      .desc   = R"--(Get the propagation path as it is obeserved.
 
 The intent of this agenda is to provide a propagation path as seen from the observer
 position and line of sight.
 )--",
-      .output       = {"ray_path"},
-      .input        = {"spectral_radiance_observer_position",
-                       "spectral_radiance_observer_line_of_sight"},
+      .output = {"ray_path"},
+      .input  = {"spectral_radiance_observer_position",
+                 "spectral_radiance_observer_line_of_sight"},
   };
 
   wsa_data["spectral_radiance_observer_agenda"] = {
@@ -64,12 +107,6 @@ position and line of sight.
 It also outputs the *ray_path* as seen from the observer position and line of sight.
 This is useful in-case a call to the destructive *spectral_radianceApplyUnitFromSpectralRadiance*
 is warranted
-
-The output must be sized as:
-
-- *spectral_radiance* : (*frequency_grid*)
-- *spectral_radiance_jacobian* : (*jacobian_targets*, *frequency_grid*)
-- *ray_path* : (Unknown)
 )--",
       .output = {"spectral_radiance", "spectral_radiance_jacobian", "ray_path"},
       .input  = {"frequency_grid",
@@ -80,6 +117,18 @@ The output must be sized as:
                  "surface_field"},
       .enum_options = {"Emission"},
       .enum_default = "Emission",
+      .output_constraints =
+          {
+              {"spectral_radiance.size() == frequency_grid.size()",
+               "Spectral radiance has the same size as frequency grid after executing the agenda.",
+               "spectral_radiance.size()",
+               "frequency_grid.size()"},
+              {"matpack::same_shape<2>({jacobian_targets.x_size(), frequency_grid.size()}, spectral_radiance_jacobian)",
+               "Spectral radiance Jacobian has the shape [jacobian_targets.x_size() x frequency_grid.size()] after executing the agenda.",
+               "spectral_radiance_jacobian.shape()",
+               "frequency_grid.size()",
+               "jacobian_targets.x_size()"},
+          },
   };
 
   wsa_data["spectral_radiance_space_agenda"] = {
@@ -89,11 +138,6 @@ This agenda calculates the spectral radiance as seen of space.
 One common use-case us to provide a background spectral radiance.
 
 The input path point should be as if it is looking at space.
-
-The output must be sized as:
-
-- *spectral_radiance* : (*frequency_grid*)
-- *spectral_radiance_jacobian* : (*jacobian_targets*, *frequency_grid*)
 )--",
       .output       = {"spectral_radiance", "spectral_radiance_jacobian"},
       .input        = {"frequency_grid", "jacobian_targets", "ray_path_point"},
@@ -101,29 +145,44 @@ The output must be sized as:
                        "SunOrCosmicBackground",
                        "Transmission"},
       .enum_default = "UniformCosmicBackground",
-  };
+      .output_constraints = {
+          {"spectral_radiance.size() == frequency_grid.size()",
+           "Spectral radiance has the same size as frequency grid after executing the agenda.",
+           "spectral_radiance.size()",
+           "frequency_grid.size()"},
+          {"matpack::same_shape<2>({jacobian_targets.x_size(), frequency_grid.size()}, spectral_radiance_jacobian)",
+           "Spectral radiance Jacobian has the shape [jacobian_targets.x_size() x frequency_grid.size()] after executing the agenda.",
+           "spectral_radiance_jacobian.shape()",
+           "frequency_grid.size()",
+           "jacobian_targets.x_size()"},
+      }};
 
   wsa_data["spectral_radiance_surface_agenda"] = {
-      .desc         = R"--(Spectral radiance as seen of the surface.
+      .desc               = R"--(Spectral radiance as seen of the surface.
 
 This agenda calculates the spectral radiance as seen of the surface.
 One common use-case us to provide a background spectral radiance.
 
 The input path point should be as if it is looking at the surface.
-
-The output must be sized as:
-
-- *spectral_radiance* : (*frequency_grid*)
-- *spectral_radiance_jacobian* : (*jacobian_targets*, *frequency_grid*)
 )--",
-      .output       = {"spectral_radiance", "spectral_radiance_jacobian"},
-      .input        = {"frequency_grid",
-                       "jacobian_targets",
-                       "ray_path_point",
-                       "surface_field"},
-      .enum_options = {"Blackbody", "Transmission"},
-      .enum_default = "Blackbody",
-  };
+      .output             = {"spectral_radiance", "spectral_radiance_jacobian"},
+      .input              = {"frequency_grid",
+                             "jacobian_targets",
+                             "ray_path_point",
+                             "surface_field"},
+      .enum_options       = {"Blackbody", "Transmission", "FlatScalarReflectance"},
+      .enum_default       = "Blackbody",
+      .output_constraints = {
+          {"spectral_radiance.size() == frequency_grid.size()",
+           "Spectral radiance has the same size as frequency grid after executing the agenda.",
+           "spectral_radiance.size()",
+           "frequency_grid.size()"},
+          {"matpack::same_shape<2>({jacobian_targets.x_size(), frequency_grid.size()}, spectral_radiance_jacobian)",
+           "Spectral radiance Jacobian has the shape [jacobian_targets.x_size() x frequency_grid.size()] after executing the agenda.",
+           "spectral_radiance_jacobian.shape()",
+           "frequency_grid.size()",
+           "jacobian_targets.x_size()"},
+      }};
 
   wsa_data["inversion_iterate_agenda"] = {
       .desc   = R"--(Work in progress ...
@@ -140,17 +199,17 @@ is not yet any calculated Jacobian.
   };
 
   wsa_data["disort_settings_agenda"] = {
-      .desc         = R"--(An agenda for setting up Disort.
+      .desc   = R"--(An agenda for setting up Disort.
 
 The only intent of this Agenda is to simplify the setup of Disort for different
 scenarios.  The output of this Agenda is just that setting.
 )--",
-      .output       = {"disort_settings"},
-      .input        = {"frequency_grid",
-                       "ray_path",
-                       "disort_quadrature_dimension",
-                       "disort_fourier_mode_dimension",
-                       "disort_legendre_polynomial_dimension"},
+      .output = {"disort_settings"},
+      .input  = {"frequency_grid",
+                 "ray_path",
+                 "disort_quadrature_dimension",
+                 "disort_fourier_mode_dimension",
+                 "disort_legendre_polynomial_dimension"},
   };
 
   return wsa_data;

--- a/src/workspace_agendas.cpp
+++ b/src/workspace_agendas.cpp
@@ -1,5 +1,7 @@
 #include "workspace_agendas.h"
 
+#include <format>
+
 std::unordered_map<std::string, WorkspaceAgendaInternalRecord>
 internal_workspace_agendas_creator() {
   std::unordered_map<std::string, WorkspaceAgendaInternalRecord> wsa_data;
@@ -19,26 +21,27 @@ internal_workspace_agendas_creator() {
                        "ray_path_point",
                        "atmospheric_point"},
       .enum_options = {"Empty"},
-      .output_constraints = {
-            {"propagation_matrix.size() == frequency_grid.size()",
-             "Propagation matrix has the same size as frequency grid after executing the agenda.",
-             "propagation_matrix.size()",
-             "frequency_grid.size()"},
-            {"propagation_matrix_source_vector_nonlte.size() == frequency_grid.size()",
-             "Non-LTE source vector has the same size as frequency grid after executing the agenda.",
-             "propagation_matrix_source_vector_nonlte.size()",
-             "frequency_grid.size()"},
-            {"matpack::same_shape<2>({jacobian_targets.target_count(), frequency_grid.size()}, propagation_matrix_jacobian)",
-             "Propagation matrix Jacobian has the shape [jacobian_targets.target_count() x frequency_grid.size()] after executing the agenda.",
-             "propagation_matrix_jacobian.shape()",
-             "frequency_grid.size()",
-             "jacobian_targets.target_count()"},
-            {"matpack::same_shape<2>({jacobian_targets.target_count(), frequency_grid.size()}, propagation_matrix_source_vector_nonlte_jacobian)",
-             "Non-LTE source vector Jacobian has the shape [jacobian_targets.target_count() x frequency_grid.size()] after executing the agenda.",
-             "propagation_matrix_source_vector_nonlte_jacobian.shape()",
-             "frequency_grid.size()",
-             "jacobian_targets.target_count()"},
-      },
+      .output_constraints =
+          {
+              {"propagation_matrix.size() == frequency_grid.size()",
+               "On output, *propagation_matrix* has the size of *frequency_grid*.",
+               "propagation_matrix.size()",
+               "frequency_grid.size()"},
+              {"propagation_matrix_source_vector_nonlte.size() == frequency_grid.size()",
+               "On output, *propagation_matrix_source_vector_nonlte* has the size of *frequency_grid*.",
+               "propagation_matrix_source_vector_nonlte.size()",
+               "frequency_grid.size()"},
+              {"matpack::same_shape<2>({jacobian_targets.target_count(), frequency_grid.size()}, propagation_matrix_jacobian)",
+               "On output, *propagation_matrix_jacobian* has the shape of the target-count of *jacobian_targets* times the size of *frequency_grid*.",
+               "propagation_matrix_jacobian.shape()",
+               "frequency_grid.size()",
+               "jacobian_targets.target_count()"},
+              {"matpack::same_shape<2>({jacobian_targets.target_count(), frequency_grid.size()}, propagation_matrix_source_vector_nonlte_jacobian)",
+               "On output, *propagation_matrix_source_vector_nonlte_jacobian* has the shape of the target-count of *jacobian_targets* times the size of *frequency_grid*.",
+               "propagation_matrix_source_vector_nonlte_jacobian.shape()",
+               "frequency_grid.size()",
+               "jacobian_targets.target_count()"},
+          },
   };
 
   wsa_data["propagation_matrix_scattering_spectral_agenda"] = {
@@ -54,24 +57,24 @@ internal_workspace_agendas_creator() {
       .output_constraints =
           {
               {"propagation_matrix_scattering.size() == frequency_grid.size()",
-               "Propagation matrix has the same size as frequency grid after executing the agenda.",
+               "On output, *propagation_matrix_scattering* has the size of *frequency_grid*.",
                "propagation_matrix_scattering.size()",
                "frequency_grid.size()"},
               {"absorption_vector_scattering.size() == frequency_grid.size()",
-               "Absorption vector has the same size as frequency grid after executing the agenda.",
+               "On output, *absorption_vector_scattering* has the size of *frequency_grid*.",
                "absorption_vector_scattering.size()",
                "frequency_grid.size()"},
               {"matpack::same_shape<2>({frequency_grid.size(), legendre_degree + 1}, phase_matrix_scattering_spectral)",
-               "Phase matrix has the shape [frequency_grid.size() x legendre_degree + 1] after executing the agenda.",
+               "On output, *phase_matrix_scattering_spectral* has the shape of <*legendre_degree* + 1> times the size of *frequency_grid*.",
                "phase_matrix_scattering_spectral.shape()",
                "frequency_grid.size()",
-            "legendre_degree"},
+               "legendre_degree"},
           },
   };
 
   wsa_data["propagation_matrix_scattering_agenda"] = {
       .desc =
-          R"--(Compute the propagation matrix, the non-LTE source vector, and their derivatives
+          R"--(Compute the part of the propagation matrix that relates to scattering.
 )--",
       .output       = {"propagation_matrix_scattering"},
       .input        = {"frequency_grid", "atmospheric_point"},
@@ -80,7 +83,7 @@ internal_workspace_agendas_creator() {
       .output_constraints =
           {
               {"propagation_matrix_scattering.size() == frequency_grid.size()",
-               "Propagation matrix scattering has the same size as frequency grid after executing the agenda.",
+               "On output, *propagation_matrix_scattering* has the size of *frequency_grid*.",
                "propagation_matrix_scattering.size()",
                "frequency_grid.size()"},
           },
@@ -120,11 +123,11 @@ is warranted
       .output_constraints =
           {
               {"spectral_radiance.size() == frequency_grid.size()",
-               "Spectral radiance has the same size as frequency grid after executing the agenda.",
+               "On output, *spectral_radiance* has the size of *frequency_grid*.",
                "spectral_radiance.size()",
                "frequency_grid.size()"},
               {"matpack::same_shape<2>({jacobian_targets.x_size(), frequency_grid.size()}, spectral_radiance_jacobian)",
-               "Spectral radiance Jacobian has the shape [jacobian_targets.x_size() x frequency_grid.size()] after executing the agenda.",
+               "On output, *spectral_radiance_jacobian* has the shape of the expected *model_state_vector* (i.e., the x-size of *jacobian_targets*) times the size of *frequency_grid*.",
                "spectral_radiance_jacobian.shape()",
                "frequency_grid.size()",
                "jacobian_targets.x_size()"},
@@ -147,38 +150,38 @@ The input path point should be as if it is looking at space.
       .enum_default = "UniformCosmicBackground",
       .output_constraints = {
           {"spectral_radiance.size() == frequency_grid.size()",
-           "Spectral radiance has the same size as frequency grid after executing the agenda.",
+           "On output, *spectral_radiance* has the size of *frequency_grid*.",
            "spectral_radiance.size()",
            "frequency_grid.size()"},
           {"matpack::same_shape<2>({jacobian_targets.x_size(), frequency_grid.size()}, spectral_radiance_jacobian)",
-           "Spectral radiance Jacobian has the shape [jacobian_targets.x_size() x frequency_grid.size()] after executing the agenda.",
+           "On output, *spectral_radiance_jacobian* has the shape of the expected *model_state_vector* (i.e., the x-size of *jacobian_targets*) times the size of *frequency_grid*.",
            "spectral_radiance_jacobian.shape()",
            "frequency_grid.size()",
            "jacobian_targets.x_size()"},
       }};
 
   wsa_data["spectral_radiance_surface_agenda"] = {
-      .desc               = R"--(Spectral radiance as seen of the surface.
+      .desc         = R"--(Spectral radiance as seen of the surface.
 
 This agenda calculates the spectral radiance as seen of the surface.
 One common use-case us to provide a background spectral radiance.
 
 The input path point should be as if it is looking at the surface.
 )--",
-      .output             = {"spectral_radiance", "spectral_radiance_jacobian"},
-      .input              = {"frequency_grid",
-                             "jacobian_targets",
-                             "ray_path_point",
-                             "surface_field"},
-      .enum_options       = {"Blackbody", "Transmission", "FlatScalarReflectance"},
-      .enum_default       = "Blackbody",
+      .output       = {"spectral_radiance", "spectral_radiance_jacobian"},
+      .input        = {"frequency_grid",
+                       "jacobian_targets",
+                       "ray_path_point",
+                       "surface_field"},
+      .enum_options = {"Blackbody", "Transmission", "FlatScalarReflectance"},
+      .enum_default = "Blackbody",
       .output_constraints = {
           {"spectral_radiance.size() == frequency_grid.size()",
-           "Spectral radiance has the same size as frequency grid after executing the agenda.",
+           "On output, *spectral_radiance* has the size of *frequency_grid*.",
            "spectral_radiance.size()",
            "frequency_grid.size()"},
           {"matpack::same_shape<2>({jacobian_targets.x_size(), frequency_grid.size()}, spectral_radiance_jacobian)",
-           "Spectral radiance Jacobian has the shape [jacobian_targets.x_size() x frequency_grid.size()] after executing the agenda.",
+           "On output, *spectral_radiance_jacobian* has the shape of the expected *model_state_vector* (i.e., the x-size of *jacobian_targets*) times the size of *frequency_grid*.",
            "spectral_radiance_jacobian.shape()",
            "frequency_grid.size()",
            "jacobian_targets.x_size()"},
@@ -211,6 +214,31 @@ scenarios.  The output of this Agenda is just that setting.
                  "disort_fourier_mode_dimension",
                  "disort_legendre_polynomial_dimension"},
   };
+
+  // Add information about all automatically generated code
+  for (auto& [name, record] : wsa_data) {
+    record.desc += std::format(R"(
+It is possible to execute *{0}* directly from the workspace by calling *{0}Execute*.
+
+As all agendas in ARTS, *{0}* is also customizable via its operator helper class: *{0}Operator*.
+See it, *{0}SetOperator*, and *{0}ExecuteOperator* for more details.
+)",
+                               name);
+    if (not record.output_constraints.empty()) {
+      record.desc += std::format(R"(
+The following constraints are put on the output generated by executing *{0}*:
+
+.. hlist::
+    :columns: 1
+
+)",
+                                 name);
+      for (auto& c : record.output_constraints) {
+        record.desc += std::format("    * {}\n", c.constraint);
+      }
+    }
+    record.desc += "\n";
+  }
 
   return wsa_data;
 }

--- a/src/workspace_agendas.h
+++ b/src/workspace_agendas.h
@@ -4,12 +4,30 @@
 #include <unordered_map>
 #include <vector>
 
+struct StringVectorAgendaHelper {
+  std::string test{};
+  std::string constraint{};
+  std::vector<std::string> printables{};
+
+  constexpr StringVectorAgendaHelper() = default;
+
+  template <typename... Args>
+  constexpr StringVectorAgendaHelper(std::string&& Test,
+                                     std::string&& Constraint,
+                                     Args&&... Printables)
+      : test(std::move(Test)),
+        constraint(std::move(Constraint)),
+        printables(
+            std::vector<std::string>{std::forward<Args>(Printables)...}) {}
+};
+
 struct WorkspaceAgendaInternalRecord {
   std::string desc{};
   std::vector<std::string> output{};
   std::vector<std::string> input{};
   std::vector<std::string> enum_options{};
   std::string enum_default{};
+  std::vector<StringVectorAgendaHelper> output_constraints{};
 };
 
 const std::unordered_map<std::string, WorkspaceAgendaInternalRecord>&

--- a/src/workspace_groups.cpp
+++ b/src/workspace_groups.cpp
@@ -11,7 +11,7 @@ void agenda_operators(
   for (auto& [name, ag] : internal_workspace_agendas()) {
     wsg_data[name + "Operator"] = {
         .file = "auto_agenda_operators.h",
-        .desc = ag.desc,
+        .desc = ag.desc + "\n\nThis is the free-form customization point of the agenda *" + name + "*\n\n.. note::\n    Output constraints must be followed\n\n",
     };
   }
 }

--- a/src/workspace_methods.cpp
+++ b/src/workspace_methods.cpp
@@ -2063,6 +2063,9 @@ The Jacobian variable is all 0s, the background is [1 0 0 0] everywhere
 
 Gets incoming radiation by placing an observer at the surface looking at the
 specular reflection of the outgoing radiation (as described by *ray_path_point*)
+
+The surface field must contain the surface temperature and the reflectance.
+The reflectance lives under the *SurfacePropertyTag* key "flat scalar reflectance".
 )--",
       .author         = {"Richard Larsson"},
       .out            = {"spectral_radiance", "spectral_radiance_jacobian"},

--- a/src/workspace_methods.cpp
+++ b/src/workspace_methods.cpp
@@ -3,9 +3,10 @@
 #include <mystring.h>
 
 #include <exception>
-#include <iomanip>
+#include <format>
 #include <limits>
 #include <optional>
+#include <ranges>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -37,37 +38,35 @@ bool WorkspaceMethodInternalRecord::has_overloads() const {
 }
 
 std::string WorkspaceMethodInternalRecord::docstring() const try {
-  std::stringstream os;
-
-  os << "/** " << desc << "\n";
-  if (pass_workspace) os << "  @param[in] ws Workspace reference\n";
+  std::string doc = std::format("/** {}\n", desc);
+  if (pass_workspace) doc += "  @param[in] ws Workspace reference\n";
 
   for (auto& str : out) {
     if (std::any_of(
             in.begin(), in.end(), [&str](auto& var) { return str == var; }))
-      os << "  @param[inout] " << str << " As WSV" << '\n';
+      doc += std::format("  @param[inout] {} As WSV\n", str);
     else
-      os << "  @param[out] " << str << " As WSV" << '\n';
+      doc += std::format("  @param[out] {} As WSV\n", str);
   }
 
   for (std::size_t i = 0; i < gout.size(); i++) {
-    os << "  @param[out] " << gout[i] << " " << gout_desc[i] << '\n';
+    doc += std::format("  @param[out] {} {}\n", gout[i], gout_desc[i]);
   }
 
   for (auto& str : in) {
     if (std::any_of(
             out.begin(), out.end(), [&str](auto& var) { return str == var; }))
       continue;
-    os << "  @param[in] " << str << " As WSV" << '\n';
+    doc += std::format("  @param[in] {} As WSV\n", str);
   }
 
   for (std::size_t i = 0; i < gin.size(); i++) {
-    os << "  @param[in] " << gin[i] << " " << gin_desc[i] << '\n';
+    doc += std::format("  @param[in] {} {}\n", gin[i], gin_desc[i]);
   }
 
-  os << " */";
+  doc += " */";
 
-  return os.str();
+  return doc;
 } catch (std::exception& e) {
   throw std::runtime_error("Error in meta-function docstring():\n\n" +
                            std::string(e.what()));
@@ -112,31 +111,31 @@ std::string WorkspaceMethodInternalRecord::header(const std::string& name,
   const auto overloads = generic_overloads();
   int GVAR             = 0;
 
-  std::stringstream os;
+  std::string doc{};
 
   if (has_any()) {
-    os << "template <WorkspaceGroup T>\n";
+    doc += "template <WorkspaceGroup T>\n";
   }
 
-  os << "void " << name << '(';
+  doc += std::format("void {}(", name);
 
   bool first = true;
   if (pass_workspace) {
-    os << "const Workspace& ws";
-    first = false;
+    doc   += "const Workspace& ws";
+    first  = false;
   }
 
   for (auto& str : out) {
     auto wsv_ptr = wsv.find(str);
     if (wsv_ptr != wsv.end()) {
-      os << comma(first, spaces) << wsv_ptr->second.type << "& " << str;
+      doc += std::format(
+          "{}{}& {}", comma(first, spaces), wsv_ptr->second.type, str);
       continue;
     }
 
     auto wsa_ptr = wsa.find(str);
     if (wsa_ptr != wsa.end()) {
-      os << comma(first, spaces) << "Agenda"
-         << "& " << str;
+      doc += std::format("{}Agenda& {}", comma(first, spaces), str);
       continue;
     }
 
@@ -144,10 +143,12 @@ std::string WorkspaceMethodInternalRecord::header(const std::string& name,
   }
 
   for (const auto& i : gout) {
-    os << comma(first, spaces)
-       << any(overloads[GVAR][std::min<int>(
-              overload, static_cast<int>(overloads[GVAR].size() - 1))])
-       << "& " << i;
+    doc += std::format(
+        "{}{}& {}",
+        comma(first, spaces),
+        any(overloads[GVAR][std::min<int>(
+            overload, static_cast<int>(overloads[GVAR].size() - 1))]),
+        i);
     GVAR++;
   }
 
@@ -158,15 +159,14 @@ std::string WorkspaceMethodInternalRecord::header(const std::string& name,
 
     auto wsv_ptr = wsv.find(str);
     if (wsv_ptr != wsv.end()) {
-      os << comma(first, spaces) << "const " << wsv_ptr->second.type << "& "
-         << str;
+      doc += std::format(
+          "{}const {}& {}", comma(first, spaces), wsv_ptr->second.type, str);
       continue;
     }
 
     auto wsa_ptr = wsa.find(str);
     if (wsa_ptr != wsa.end()) {
-      os << comma(first, spaces) << "const Agenda"
-         << "& " << str;
+      doc += std::format("{}const Agenda& {}", comma(first, spaces), str);
       continue;
     }
 
@@ -174,16 +174,18 @@ std::string WorkspaceMethodInternalRecord::header(const std::string& name,
   }
 
   for (const auto& i : gin) {
-    os << comma(first, spaces) << "const "
-       << any(overloads[GVAR][std::min<int>(
-              overload, static_cast<int>(overloads[GVAR].size() - 1))])
-       << "& " << i;
+    doc += std::format(
+        "{}const {}& {}",
+        comma(first, spaces),
+        any(overloads[GVAR][std::min<int>(
+            overload, static_cast<int>(overloads[GVAR].size() - 1))]),
+        i);
     GVAR++;
   }
 
-  os << ")";
+  doc += ")";
 
-  return os.str();
+  return doc;
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format(R"(Error in meta-function header("{}", {}):
@@ -215,22 +217,20 @@ std::string WorkspaceMethodInternalRecord::call(const std::string& name) const
     try {
   const std::string spaces(6, ' ');
 
-  std::stringstream os;
-
-  os << name << "(\n      ";
+  std::string doc = std::format("  {}(\n      ", name);
 
   bool first = true;
   if (pass_workspace) {
-    os << "ws";
-    first = false;
+    doc   += "ws";
+    first  = false;
   }
 
   for (auto& str : out) {
-    os << comma(first, spaces) << str;
+    doc += std::format("{}{}", comma(first, spaces), str);
   }
 
   for (const auto& i : gout) {
-    os << comma(first, spaces) << i;
+    doc += std::format("{}{}", comma(first, spaces), i);
   }
 
   for (auto& str : in) {
@@ -238,16 +238,16 @@ std::string WorkspaceMethodInternalRecord::call(const std::string& name) const
             out.begin(), out.end(), [&str](auto& var) { return str == var; }))
       continue;
 
-    os << comma(first, spaces) << str;
+    doc += std::format("{}{}", comma(first, spaces), str);
   }
 
   for (const auto& i : gin) {
-    os << comma(first, spaces) << i;
+    doc += std::format("{}{}", comma(first, spaces), i);
   }
 
-  os << ");";
+  doc += ");";
 
-  return os.str();
+  return doc;
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format("Cannot create call of method \"{}\":\n\n{}",
@@ -290,7 +290,8 @@ Remove the manual definition of these methods from workspace_methods.cpp.
 
     wsm_data[agname + "ExecuteOperator"] = {
         .desc = "Executes an operator emulating *" + agname +
-                "*, see it for more details\n",
+                "*, see it, and also *" + agname +
+                "Operator*, for more details\n",
         .author    = {"``Automatically Generated``"},
         .out       = ag.output,
         .in        = ag.input,
@@ -302,7 +303,8 @@ Remove the manual definition of these methods from workspace_methods.cpp.
 
     wsm_data[agname + "SetOperator"] = {
         .desc = "Set *" + agname +
-                "* to exclusively use provided external operator\n",
+                "* to exclusively use provided external operator.  See *" +
+                agname + "Operator* for more details.\n",
         .author    = {"``Automatically Generated``"},
         .out       = {agname},
         .gin       = {"f"},

--- a/src/workspace_methods.cpp
+++ b/src/workspace_methods.cpp
@@ -2055,6 +2055,24 @@ The Jacobian variable is all 0s, the background is [1 0 0 0] everywhere
                  "ray_path_point"},
   };
 
+  wsm_data["spectral_radianceFlatScalarReflectance"] = {
+      .desc =
+          R"--(Set surface spectral radiance from Planck function of the surface temperature and the reflectance of incoming radiation
+
+Gets incoming radiation by placing an observer at the surface looking at the
+specular reflection of the outgoing radiation (as described by *ray_path_point*)
+)--",
+      .author         = {"Richard Larsson"},
+      .out            = {"spectral_radiance", "spectral_radiance_jacobian"},
+      .in             = {"frequency_grid",
+                         "atmospheric_field",
+                         "surface_field",
+                         "jacobian_targets",
+                         "ray_path_point",
+                         "spectral_radiance_observer_agenda"},
+      .pass_workspace = true,
+  };
+
   wsm_data["spectral_radiance_jacobianAddSensorJacobianPerturbations"] = {
       .desc = R"--(Adds sensor properties to the *spectral_radiance_jacobian*.
 

--- a/tests/core/surf/spectral_radiance_jacobian_blackbody.py
+++ b/tests/core/surf/spectral_radiance_jacobian_blackbody.py
@@ -1,0 +1,102 @@
+import pyarts
+import numpy as np
+import matplotlib.pyplot as plt
+
+PLOT = False  # Plot for debug
+LIMIT = 50  # Rerun limit for finding a fit
+ATOL = 5
+NF = 11
+noise = 0.5
+
+ws = pyarts.workspace.Workspace()
+
+# %% Sampled frequency range
+
+line_f0 = 118750348044.712
+ws.frequency_grid = np.linspace(-500e6, 500e6, NF) + line_f0
+
+# %% Species and line absorption
+
+ws.absorption_speciesSet(species=["O2-66"])
+ws.ReadCatalogData()
+ws.absorption_bandsSelectFrequencyByLine(fmin=118e9, fmax=119e9)
+ws.absorption_bandsSetZeeman(species="O2-66", fmin=118e9, fmax=119e9)
+ws.WignerInit()
+
+bandkey = "O2-66 ElecStateLabel X X Lambda 0 0 S 1 1 v 0 0"
+ws.absorption_bands = {bandkey: ws.absorption_bands[bandkey]}
+
+# %% Use the automatic agenda setter for propagation matrix calculations
+ws.propagation_matrix_agendaAuto()
+
+# %% Grids and planet
+
+ws.surface_fieldPlanet(option="Earth")
+ws.surface_field[pyarts.arts.SurfaceKey("t")] = 295.0
+ws.atmospheric_fieldRead(
+    toa=120e3, basename="planets/Earth/afgl/tropical/", missing_is_zero=1
+)
+ws.atmospheric_fieldIGRF(time="2000-03-11 14:39:37")
+
+# %% Checks and settings
+
+ws.spectral_radiance_unit = "Tb"
+ws.spectral_radiance_observer_agendaSet(option="Emission")
+ws.spectral_radiance_space_agendaSet(option="UniformCosmicBackground")
+ws.spectral_radiance_surface_agendaSet(option="Blackbody")
+ws.ray_path_observer_agendaSetGeometric()
+
+# %% Artificial Surface
+
+ts = 295.0
+ws.surface_field["t"] = ts
+
+# %% Retrieval agenda
+
+@pyarts.workspace.arts_agenda(ws=ws, fix=True)
+def inversion_iterate_agenda(ws):
+    ws.UpdateModelStates()
+    ws.measurement_vectorFromSensor()
+    ws.measurement_vector_fittedFromMeasurement()
+
+pos = [110e3, 0, 0]
+los = [160.0, 0.0]
+ws.measurement_sensorSimple(pos=pos, los=los)
+
+ws.RetrievalInit()
+ws.RetrievalAddSurface(
+    target = pyarts.arts.SurfaceKey.t, matrix=np.diag(np.ones((1)) * 1000)
+)
+ws.RetrievalFinalizeDiagonal()
+
+fail = True
+
+for i in range(LIMIT):
+    ws.surface_field["t"] = ts
+    ws.measurement_vectorFromSensor()
+
+    ws.measurement_vector_fitted = []
+    ws.model_state_vector = []
+    ws.measurement_jacobian = [[]]
+
+    ws.surface_field["t"] = ts + 30
+    ws.model_state_vector_aprioriFromData()
+
+    ws.measurement_vector_error_covariance_matrixConstant(value=noise**2)
+    ws.measurement_vector += np.random.normal(0, noise, NF)
+
+    ws.OEM(method="gn")
+
+    absdiff = round(abs(ts - ws.model_state_vector[0]), 2)
+
+    print(
+        f"t-component: Input {ts} K, Output {round(ws.model_state_vector[0], 2)} K, AbsDiff {absdiff} K"
+    )
+    if absdiff >= ATOL:
+        print(f"AbsDiff not less than {ATOL} K, rerunning with new random noise")
+        continue
+    else:
+        fail = False
+        break
+
+assert not fail

--- a/tests/core/surf/spectral_radiance_jacobian_flat_scalar_reflectance.py
+++ b/tests/core/surf/spectral_radiance_jacobian_flat_scalar_reflectance.py
@@ -1,0 +1,213 @@
+import pyarts
+import numpy as np
+import matplotlib.pyplot as plt
+
+PLOT = False  # Plot for debug
+LIMIT = 50  # Rerun limit for finding a fit
+ATOL = 5
+NF = 11
+noise = 0.5
+
+ws = pyarts.workspace.Workspace()
+
+# %% Sampled frequency range
+
+line_f0 = 118750348044.712
+ws.frequency_grid = np.linspace(-5000e6, 5000e6, NF) + line_f0
+
+# %% Species and line absorption
+
+ws.absorption_speciesSet(species=["O2-66"])
+ws.ReadCatalogData()
+ws.absorption_bandsSelectFrequencyByLine(fmin=118e9, fmax=119e9)
+ws.absorption_bandsSetZeeman(species="O2-66", fmin=118e9, fmax=119e9)
+ws.WignerInit()
+
+bandkey = "O2-66 ElecStateLabel X X Lambda 0 0 S 1 1 v 0 0"
+ws.absorption_bands = {bandkey: ws.absorption_bands[bandkey]}
+
+# %% Use the automatic agenda setter for propagation matrix calculations
+ws.propagation_matrix_agendaAuto()
+
+# %% Grids and planet
+
+ws.surface_fieldPlanet(option="Earth")
+ws.surface_field[pyarts.arts.SurfaceKey("t")] = 295.0
+ws.atmospheric_fieldRead(
+    toa=120e3, basename="planets/Earth/afgl/tropical/", missing_is_zero=1
+)
+ws.atmospheric_fieldIGRF(time="2000-03-11 14:39:37")
+
+# %% Checks and settings
+
+ws.spectral_radiance_unit = "Tb"
+ws.spectral_radiance_observer_agendaSet(option="Emission")
+ws.spectral_radiance_space_agendaSet(option="UniformCosmicBackground")
+ws.spectral_radiance_surface_agendaSet(option="FlatScalarReflectance")
+ws.ray_path_observer_agendaSetGeometric()
+
+# %% Artificial Surface
+
+ts = 295.0
+rs = 0.5
+ws.surface_field["t"] = ts
+ws.surface_field["flat scalar reflectance"] = rs
+
+# %% Retrieval agenda
+
+@pyarts.workspace.arts_agenda(ws=ws, fix=True)
+def inversion_iterate_agenda(ws):
+    ws.UpdateModelStates()
+    ws.measurement_vectorFromSensor()
+    ws.measurement_vector_fittedFromMeasurement()
+
+pos = [110e3, 0, 0]
+los = [160.0, 30.0]
+ws.measurement_sensorSimple(pos=pos, los=los)
+
+ws.RetrievalInit()
+ws.RetrievalAddSurface(
+    target = pyarts.arts.SurfaceKey.t, matrix=np.diag(np.ones((1)) * 100)
+)
+ws.RetrievalFinalizeDiagonal()
+
+fail = True
+
+print("Retrieving temperature")
+for i in range(LIMIT):
+    ws.surface_field["t"] = ts
+    ws.measurement_vectorFromSensor()
+
+    ws.measurement_vector_fitted = []
+    ws.model_state_vector = []
+    ws.measurement_jacobian = [[]]
+
+    ws.surface_field["t"] = ts + 30
+    ws.model_state_vector_aprioriFromData()
+
+    ws.measurement_vector_error_covariance_matrixConstant(value=noise**2)
+    ws.measurement_vector += np.random.normal(0, noise, NF)
+
+    ws.OEM(method="gn")
+
+    absdiff = round(abs(ts - ws.model_state_vector[0]), 2)
+
+    print(
+        f"t-component: Input {ts} K, Output {round(ws.model_state_vector[0], 2)} K, AbsDiff {absdiff} K"
+    )
+    if absdiff >= ATOL:
+        print(f"AbsDiff not less than {ATOL} K, rerunning with new random noise")
+        continue
+    else:
+        fail = False
+        break
+
+assert not fail
+
+print("Temperature retrieval successful\n")
+
+# %% Artificial Surface Reset
+
+ws.surface_field["t"] = ts
+ws.surface_field["flat scalar reflectance"] = rs
+
+# %% Retrieval agenda
+
+ws.RetrievalInit()
+ws.RetrievalAddSurface(
+    target = "flat scalar reflectance", matrix=np.diag(np.ones((1)) * 1)
+)
+ws.RetrievalFinalizeDiagonal()
+
+fail = True
+
+print("Retrieving flat scalar reflectance")
+for i in range(LIMIT):
+    ws.surface_field["flat scalar reflectance"] = rs
+    ws.measurement_vectorFromSensor()
+
+    ws.measurement_vector_fitted = []
+    ws.model_state_vector = []
+    ws.measurement_jacobian = [[]]
+
+    ws.surface_field["flat scalar reflectance"] = rs + 0.3
+    ws.model_state_vector_aprioriFromData()
+
+    ws.measurement_vector_error_covariance_matrixConstant(value=noise**2)
+    ws.measurement_vector += np.random.normal(0, noise, NF)
+
+    ws.OEM(method="gn")
+
+    absdiff = round(100*abs(rs - ws.model_state_vector[0]), 2)
+
+    print(
+        f"'flat scalar reflectance'-component: Input {100*rs} %, Output {round(100*ws.model_state_vector[0], 2)} %, AbsDiff {absdiff} %"
+    )
+    if absdiff >= ATOL:
+        print(f"AbsDiff not less than {ATOL} %, rerunning with new random noise")
+        continue
+    else:
+        fail = False
+        break
+
+assert not fail
+
+print("Flat scalar reflectance retrieval successful\n")
+
+# %% Artificial Surface Reset
+
+ws.surface_field["t"] = ts
+ws.surface_field["flat scalar reflectance"] = rs
+
+# %% Retrieval agenda
+
+ws.RetrievalInit()
+ws.RetrievalAddSurface(
+    target = "flat scalar reflectance", matrix=np.diag(np.ones((1)) * 1)
+)
+ws.RetrievalAddSurface(
+    target = "t", matrix=np.diag(np.ones((1)) * 1000)
+)
+ws.RetrievalFinalizeDiagonal()
+
+fail = True
+
+print("Retrieving flat scalar reflectance and temperature")
+ATOL = 10
+for i in range(LIMIT):
+    ws.surface_field["t"] = ts
+    ws.surface_field["flat scalar reflectance"] = rs
+    ws.measurement_vectorFromSensor()
+
+    ws.measurement_vector_fitted = []
+    ws.model_state_vector = []
+    ws.measurement_jacobian = [[]]
+
+    ws.surface_field["t"] = ts + 35
+    ws.surface_field["flat scalar reflectance"] = rs + 0.3
+    ws.model_state_vector_aprioriFromData()
+
+    ws.measurement_vector_error_covariance_matrixConstant(value=noise**2)
+    ws.measurement_vector += np.random.normal(0, noise, NF)
+
+    ws.OEM(method="gn")
+
+    absdiff_rs = round(100*abs(rs - ws.model_state_vector[0]), 2)
+    absdiff_ts = round(abs(ts - ws.model_state_vector[1]), 2)
+
+    print(
+        f"'flat scalar reflectance'-component: Input {100*rs} %, Output {round(100*ws.model_state_vector[0], 2)} %, AbsDiff {absdiff_rs} %"
+    )
+    print(
+        f"t-component: Input {ts} K, Output {round(ws.model_state_vector[1], 2)} K, AbsDiff {absdiff_ts} K"
+    )
+    if absdiff_rs >= ATOL or absdiff_ts >= ATOL:
+        print(f"AbsDiff Reflectance not less than {ATOL} %, or AbsDiff Temperature not less than {ATOL} K, rerunning with new random noise")
+        continue
+    else:
+        fail = False
+        break
+
+assert not fail
+
+print("Flat scalar reflectance and temperature retrieval successful\n")


### PR DESCRIPTION
Port simple surface reflection.  I need others to port tests of the physics implemented.  I added tests that the surface reflectance and the surface temperature can be retrieved.

Also added some ways to define output constraints on Agendas because it was bothering me how many tests I had to perform manually after an Agenda was run.