### PR TITLE
Python absorption

### DIFF
--- a/src/m_cia.cc
+++ b/src/m_cia.cc
@@ -370,6 +370,8 @@ void absorption_cia_dataReadSpeciesSplitCatalog(
     const Index& ignore_missing_) try {
   ARTS_TIME_REPORT
 
+  absorption_cia_data.clear();
+  
   const bool ignore_missing = static_cast<bool>(ignore_missing_);
 
   ArrayOfString names{};

--- a/src/m_lbl.cc
+++ b/src/m_lbl.cc
@@ -202,8 +202,9 @@ void absorption_bandsReadSpeciesSplitCatalog(
     const Index& ignore_missing_) try {
   ARTS_TIME_REPORT
 
-  const bool ignore_missing = static_cast<bool>(ignore_missing_);
   absorption_bands.clear();
+  
+  const bool ignore_missing = static_cast<bool>(ignore_missing_);
 
   const String my_base = complete_basename(basename);
 

--- a/src/m_predefined_absorption_models.cc
+++ b/src/m_predefined_absorption_models.cc
@@ -28,6 +28,8 @@ void absorption_predefined_model_dataReadSpeciesSplitCatalog(
     const Index& ignore_missing_) try {
   ARTS_TIME_REPORT
 
+  absorption_predefined_model_data.data.clear();
+
   const bool name_missing   = static_cast<bool>(name_missing_);
   const bool ignore_missing = static_cast<bool>(ignore_missing_);
 

--- a/src/m_xsec_fit.cc
+++ b/src/m_xsec_fit.cc
@@ -23,6 +23,8 @@ void absorption_xsec_fit_dataReadSpeciesSplitCatalog(
     const Index& ignore_missing_) try {
   ARTS_TIME_REPORT
 
+  absorption_xsec_fit_data.clear();
+
   const bool ignore_missing = static_cast<bool>(ignore_missing_);
 
   // Build a set of species indices. Duplicates are ignored.

--- a/src/python_interface/py_cia.cpp
+++ b/src/python_interface/py_cia.cpp
@@ -157,7 +157,7 @@ Returns
          const Index ignore_errors,
          const py::kwargs&) {
         PropmatVector propagation_matrix(f.size());
-        PropmatMatrix propagation_matrix_jacobian{};
+        PropmatMatrix propagation_matrix_jacobian(0, f.size());
         JacobianTargets jacobian_targets{};
 
         propagation_matrixAddCIA(propagation_matrix,

--- a/src/python_interface/py_lbl.cpp
+++ b/src/python_interface/py_lbl.cpp
@@ -534,8 +534,8 @@ T0 : float
          const py::kwargs&) {
         PropmatVector propagation_matrix(f.size());
         StokvecVector nlte_vector(f.size());
-        PropmatMatrix propagation_matrix_jacobian{};
-        StokvecMatrix nlte_matrix{};
+        PropmatMatrix propagation_matrix_jacobian(0, f.size());
+        StokvecMatrix nlte_matrix(0, f.size());
         JacobianTargets jacobian_targets{};
 
         propagation_matrixAddLines(propagation_matrix,

--- a/src/python_interface/py_lbl.cpp
+++ b/src/python_interface/py_lbl.cpp
@@ -521,6 +521,71 @@ T0 : float
       "ecs_data"_a,
       "atm"_a,
       "T"_a);
+
+  aoab.def(
+      "propagation_matrix",
+      [](const AbsorptionBands& self,
+         const AscendingGrid& f,
+         const AtmPoint& atm,
+         const SpeciesEnum& spec,
+         const PropagationPathPoint& path_point,
+         const LinemixingEcsData& ecs_data,
+         const Index& no_negative_absorption,
+         const py::kwargs&) {
+        PropmatVector propagation_matrix(f.size());
+        StokvecVector nlte_vector(f.size());
+        PropmatMatrix propagation_matrix_jacobian{};
+        StokvecMatrix nlte_matrix{};
+        JacobianTargets jacobian_targets{};
+
+        propagation_matrixAddLines(propagation_matrix,
+                                   nlte_vector,
+                                   propagation_matrix_jacobian,
+                                   nlte_matrix,
+                                   f,
+                                   jacobian_targets,
+                                   spec,
+                                   self,
+                                   ecs_data,
+                                   atm,
+                                   path_point,
+                                   no_negative_absorption);
+
+        return propagation_matrix;
+      },
+      "f"_a,
+      "atm"_a,
+      "spec"_a                   = SpeciesEnum::Bath,
+      "path_point"_a             = PropagationPathPoint{},
+      "ecs_data"_a               = LinemixingEcsData{},
+      "no_negative_absorption"_a = Index{1},
+      "kwargs"_a                 = py::kwargs{},
+      R"--(Computes the line-by-line model absorption in 1/m
+
+The method accepts any number of kwargs to be compatible
+with similar methods for computing the propagation matrix.
+
+Parameters
+----------
+f : AscendingGrid
+    Frequency grid [Hz]
+atm : AtmPoint
+    Atmospheric point
+spec : SpeciesEnum, optional
+    Species to use.  Defaults to all species.
+path_point : PropagationPathPoint, optional
+    The path point.  Default is POS [0, 0, 0], LOS [0, 0].
+ecs_data : LinemixingEcsData, optional
+    The ECS data.  Default is empty.
+no_negative_absorption : Index, optional
+    If 1, the absorption is set to zero if it is negative. The default is 1.
+
+Returns
+-------
+propagation_matrix : PropmatVector
+    Propagation matrix by frequency [1/m]
+
+)--");
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format("DEV ERROR:\nCannot initialize lbl\n{}", e.what()));

--- a/src/python_interface/py_lookup.cpp
+++ b/src/python_interface/py_lookup.cpp
@@ -49,7 +49,7 @@ void py_lookup(py::module_& m) try {
          const Numeric& extpolfac,
          const py::kwargs&) {
         PropmatVector propagation_matrix(f.size());
-        PropmatMatrix propagation_matrix_jacobian{};
+        PropmatMatrix propagation_matrix_jacobian(0, f.size());
         JacobianTargets jacobian_targets{};
 
         propagation_matrixAddLookup(propagation_matrix,

--- a/src/python_interface/py_lookup.cpp
+++ b/src/python_interface/py_lookup.cpp
@@ -34,6 +34,79 @@ void py_lookup(py::module_& m) try {
 
   auto alts = py::bind_map<AbsorptionLookupTables>(m, "AbsorptionLookupTables");
   workspace_group_interface(alts);
+
+  alts.def(
+      "propagation_matrix",
+      [](const AbsorptionLookupTables& self,
+         const AscendingGrid& f,
+         const AtmPoint& atm,
+         const SpeciesEnum& spec,
+         const Index& no_negative_absorption,
+         const Index& p_interp_order,
+         const Index& t_interp_order,
+         const Index& water_interp_order,
+         const Index& f_interp_order,
+         const Numeric& extpolfac,
+         const py::kwargs&) {
+        PropmatVector propagation_matrix(f.size());
+        PropmatMatrix propagation_matrix_jacobian{};
+        JacobianTargets jacobian_targets{};
+
+        propagation_matrixAddLookup(propagation_matrix,
+                                    propagation_matrix_jacobian,
+                                    f,
+                                    jacobian_targets,
+                                    spec,
+                                    self,
+                                    atm,
+                                    no_negative_absorption,
+                                    p_interp_order,
+                                    t_interp_order,
+                                    water_interp_order,
+                                    f_interp_order,
+                                    extpolfac);
+
+        return propagation_matrix;
+      },
+      "f"_a,
+      "atm"_a,
+      "spec"_a                   = SpeciesEnum::Bath,
+      "no_negative_absorption"_a = Index{1},
+      "p_interp_order"_a         = Index{7},
+      "t_interp_order"_a         = Index{7},
+      "water_interp_order"_a     = Index{7},
+      "f_interp_order"_a         = Index{7},
+      "extpolfac"_a              = Numeric{0.5},
+      "kwargs"_a                 = py::kwargs{},
+      R"--(Computes the line-by-line model absorption in 1/m
+
+Parameters
+----------
+f : AscendingGrid
+    Frequency grid [Hz]
+atm : AtmPoint
+    Atmospheric point
+spec : SpeciesEnum, optional
+    Species to use.  Defaults to all.
+no_negative_absorption : Index, optional
+    If 1, the absorption is set to zero if it is negative. The default is 1.
+p_interp_order : Index, optional
+    Order of interpolation in pressure.  The default is 7.
+t_interp_order : Index, optional
+    Order of interpolation in temperature.  The default is 7.
+water_interp_order : Index, optional
+    Order of interpolation in water VMR.  The default is 7.
+f_interp_order : Index, optional
+    Order of interpolation in frequency.  The default is 7.
+extpolfac : Numeric, optional
+    How far the grids are allowed to be extended in relative distance of the outer two most grid points.  Default is 0.5.
+
+Returns
+-------
+propagation_matrix : PropmatVector
+    Propagation matrix by frequency [1/m]
+
+)--");
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format("DEV ERROR:\nCannot initialize lookup\n{}", e.what()));

--- a/src/python_interface/py_predefined.cpp
+++ b/src/python_interface/py_predefined.cpp
@@ -973,7 +973,7 @@ void py_predefined(py::module_& m) try {
              const SpeciesEnum& spec,
              const py::kwargs&) {
             PropmatVector propagation_matrix(f.size());
-            PropmatMatrix propagation_matrix_jacobian{};
+            PropmatMatrix propagation_matrix_jacobian(0, f.size());
             JacobianTargets jacobian_targets{};
 
             propagation_matrixAddPredefined(propagation_matrix,

--- a/src/python_interface/py_predefined.cpp
+++ b/src/python_interface/py_predefined.cpp
@@ -998,8 +998,8 @@ f : AscendingGrid
     Frequency grid [Hz]
 atm : AtmPoint
     Atmospheric point
-spec : SpeciesIsotope, optional
-    Isotopologue to use
+    spec : SpeciesEnum, optional
+    Species to use
 
 Returns
 -------

--- a/src/python_interface/py_predefined.cpp
+++ b/src/python_interface/py_predefined.cpp
@@ -630,8 +630,7 @@ abs_coef : ~pyarts.arts.Vector
       "get_n2_fun_ckdmt252",
       [](const Vector& f, const AtmPoint& atm) -> Vector {
         PropmatVector pm(f.size());
-        Absorption::PredefinedModel::MT_CKD252::nitrogen_fun(
-            pm, f, atm);
+        Absorption::PredefinedModel::MT_CKD252::nitrogen_fun(pm, f, atm);
         Vector out(pm.size());
         std::transform(pm.begin(), pm.end(), out.begin(), [](auto& prop) {
           return prop.A();
@@ -659,8 +658,7 @@ abs_coef : ~pyarts.arts.Vector
       "get_n2_rot_ckdmt252",
       [](const Vector& f, const AtmPoint& atm) -> Vector {
         PropmatVector pm(f.size());
-        Absorption::PredefinedModel::MT_CKD252::nitrogen_rot(
-            pm, f, atm);
+        Absorption::PredefinedModel::MT_CKD252::nitrogen_rot(pm, f, atm);
         Vector out(pm.size());
         std::transform(pm.begin(), pm.end(), out.begin(), [](auto& prop) {
           return prop.A();
@@ -967,6 +965,48 @@ void py_predefined(py::module_& m) try {
           "basename"_a,
           "specs"_a,
           "Reads predefined models from catalog")
+      .def(
+          "propagation_matrix",
+          [](const PredefinedModelData& self,
+             const AscendingGrid& f,
+             const AtmPoint& atm,
+             const SpeciesEnum& spec,
+             const py::kwargs&) {
+            PropmatVector propagation_matrix(f.size());
+            PropmatMatrix propagation_matrix_jacobian{};
+            JacobianTargets jacobian_targets{};
+
+            propagation_matrixAddPredefined(propagation_matrix,
+                                            propagation_matrix_jacobian,
+                                            self,
+                                            spec,
+                                            jacobian_targets,
+                                            f,
+                                            atm);
+
+            return propagation_matrix;
+          },
+          "f"_a,
+          "atm"_a,
+          "spec"_a   = SpeciesEnum::Bath,
+          "kwargs"_a = py::kwargs{},
+          R"--(Computes the predefined model absorption in 1/m
+
+Parameters
+----------
+f : AscendingGrid
+    Frequency grid [Hz]
+atm : AtmPoint
+    Atmospheric point
+spec : SpeciesIsotope, optional
+    Isotopologue to use
+
+Returns
+-------
+propagation_matrix : PropmatVector
+    Propagation matrix by frequency [1/m]
+
+)--")
       .def("__getstate__",
            [](const PredefinedModelData& t) {
              const std::unordered_map<SpeciesIsotope,

--- a/src/python_interface/py_xsec_fit.cpp
+++ b/src/python_interface/py_xsec_fit.cpp
@@ -33,6 +33,42 @@ void py_xsec(py::module_& m) try {
               &XsecRecord::mfitmaxtemperatures,
               ":class:`~pyarts.arts.ArrayOfGriddedField2` Fit coefficients")
       .def(
+          "propagation_matrix",
+          [](const XsecRecord& self,
+             const AscendingGrid& f,
+             const AtmPoint& atm) {
+            PropmatVector out(f.size());
+
+            const Numeric nd = atm.number_density(self.Species());
+
+            Vector result(f.size(), 0);
+            self.Extract(result, f, atm.pressure, atm.temperature);
+
+            std::transform(
+                result.begin(), result.end(), out.begin(), [nd](auto& x) {
+                  return Propmat{x * nd};
+                });
+
+            return out;
+          },
+          "f"_a,
+          "atm"_a,
+          R"--(Computes the Hitran cross-section absorption in 1/m
+
+Parameters
+----------
+f : AscendingGrid
+    Frequency grid [Hz]
+atm : AtmPoint
+    Atmospheric point
+
+Returns
+-------
+abs : PropmatVector
+    Absorption profile [1/m]
+
+)--")
+      .def(
           "compute_abs",
           [](XsecRecord& self,
              Numeric T,
@@ -299,6 +335,50 @@ abs : Vector
           m, "ArrayOfXsecRecord");
   workspace_group_interface(a1);
   vector_interface(a1);
+  a1.def(
+      "propagation_matrix",
+      [](const ArrayOfXsecRecord& self,
+         const AscendingGrid& f,
+         const AtmPoint& atm,
+         const SpeciesEnum& spec,
+         const py::kwargs&) {
+        PropmatVector propagation_matrix(f.size());
+        PropmatMatrix propagation_matrix_jacobian{};
+        JacobianTargets jacobian_targets{};
+
+        propagation_matrixAddXsecFit(propagation_matrix,
+                                     propagation_matrix_jacobian,
+                                     spec,
+                                     jacobian_targets,
+                                     f,
+                                     atm,
+                                     self,
+                                     -1.0,
+                                     -1.0);
+
+        return propagation_matrix;
+      },
+      "f"_a,
+      "atm"_a,
+      "spec"_a          = SpeciesEnum::Bath,
+      "kwargs"_a        = py::kwargs{},
+      R"--(Computes the Hitran cross-section absorption in 1/m
+
+Parameters
+----------
+f : AscendingGrid
+    Frequency grid [Hz]
+atm : AtmPoint
+    Atmospheric point
+spec : SpeciesEnum, optional
+    Species to use.  Defaults to all.
+
+Returns
+-------
+propagation_matrix : PropmatVector
+    Propagation matrix by frequency [1/m]
+
+)--");
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format("DEV ERROR:\nCannot initialize xsec fit\n{}", e.what()));

--- a/src/python_interface/py_xsec_fit.cpp
+++ b/src/python_interface/py_xsec_fit.cpp
@@ -343,7 +343,7 @@ abs : Vector
          const SpeciesEnum& spec,
          const py::kwargs&) {
         PropmatVector propagation_matrix(f.size());
-        PropmatMatrix propagation_matrix_jacobian{};
+        PropmatMatrix propagation_matrix_jacobian(0, f.size());
         JacobianTargets jacobian_targets{};
 
         propagation_matrixAddXsecFit(propagation_matrix,

--- a/testdata/CMakeLists.txt
+++ b/testdata/CMakeLists.txt
@@ -3,6 +3,7 @@ if(NOT ARTS_CAT_DATA_DIR MATCHES "^${ARTS_BINARY_DIR}")
 else()
     list(APPEND DOWNLOAD_CATDATA
         cia/O2-CIA-O2.xml
+        cia/O2-CIA-N2.xml
         lines/O2-66.xml
         lines/N2-44.xml
         lines/CO2-626.xml

--- a/tests/python/xsec/cia.py
+++ b/tests/python/xsec/cia.py
@@ -1,0 +1,66 @@
+import pyarts
+import numpy as np
+
+ws = pyarts.Workspace()
+
+atm = pyarts.arts.AtmPoint()
+atm.pressure = 101325.0
+atm.temperature = 273.15
+atm["O2"] = 0.21
+atm["N2"] = 0.79
+nd = atm.number_density("O2-66")
+
+ws.absorption_speciesSet(species=["O2-CIA-O2"])
+ws.absorption_cia_data = []
+ws.ReadCatalogData()
+f = ws.absorption_cia_data[0].data[0].grids[0]
+x = ws.absorption_cia_data.propagation_matrix(f=f, atm=atm) / nd
+
+assert np.allclose(
+    x[::300, 0],
+    [
+        0.00000000e00,
+        0.00000000e00,
+        8.28862173e-33,
+        3.95506323e-32,
+        8.94099309e-32,
+        7.30562463e-31,
+        2.05122205e-30,
+        3.47065863e-30,
+        2.61488493e-30,
+        8.57954839e-31,
+        1.08628874e-31,
+        5.20303987e-32,
+        5.68696897e-32,
+        0.00000000e00,
+    ],
+    atol=1e-36,
+)
+
+ws.absorption_speciesSet(species=["O2-CIA-N2"])
+ws.absorption_cia_data = []
+ws.ReadCatalogData()
+f = ws.absorption_cia_data[0].data[1].grids[0]
+x = ws.absorption_cia_data.propagation_matrix(f=f, atm=atm) / nd
+
+assert np.allclose(
+    x[::300, 0],
+    [
+        0.00000000e00,
+        0.00000000e00,
+        0.00000000e00,
+        0.00000000e00,
+        8.35363249e-32,
+        4.48072042e-31,
+        1.73662572e-30,
+        5.76244958e-31,
+        7.52829275e-32,
+        6.40651315e-33,
+        0.00000000e00,
+        0.00000000e00,
+        0.00000000e00,
+        0.00000000e00,
+        0.00000000e00,
+    ],
+    atol=1e-36,
+)

--- a/tests/python/xsec/cia.py
+++ b/tests/python/xsec/cia.py
@@ -11,7 +11,6 @@ atm["N2"] = 0.79
 nd = atm.number_density("O2-66")
 
 ws.absorption_speciesSet(species=["O2-CIA-O2"])
-ws.absorption_cia_data = []
 ws.ReadCatalogData()
 f = ws.absorption_cia_data[0].data[0].grids[0]
 x = ws.absorption_cia_data.propagation_matrix(f=f, atm=atm) / nd
@@ -38,7 +37,6 @@ assert np.allclose(
 )
 
 ws.absorption_speciesSet(species=["O2-CIA-N2"])
-ws.absorption_cia_data = []
 ws.ReadCatalogData()
 f = ws.absorption_cia_data[0].data[1].grids[0]
 x = ws.absorption_cia_data.propagation_matrix(f=f, atm=atm) / nd

--- a/tests/python/xsec/lbl.py
+++ b/tests/python/xsec/lbl.py
@@ -1,0 +1,32 @@
+import pyarts
+import numpy as np
+
+ws = pyarts.Workspace()
+
+atm = pyarts.arts.AtmPoint()
+atm.pressure = 101325.0
+atm.temperature = 273.15
+atm["O2"] = 0.21
+nd = atm.number_density("O2-66")
+
+ws.absorption_speciesSet(species=["O2-66"])
+ws.ReadCatalogData()
+f = np.linspace(50e9, 70e9, 10)
+x = ws.absorption_bands.propagation_matrix(f=f, atm=atm) / nd
+
+assert np.allclose(
+    x[::300, 0],
+    [
+        1.09249629e-29,
+        2.79155620e-29,
+        1.24134579e-28,
+        4.10225824e-28,
+        6.40578024e-28,
+        6.96936469e-28,
+        4.31517120e-28,
+        1.19008426e-28,
+        3.51438019e-29,
+        1.81454497e-29,
+    ],
+    atol=1e-36,
+)

--- a/tests/python/xsec/lbl.py
+++ b/tests/python/xsec/lbl.py
@@ -15,7 +15,7 @@ f = np.linspace(50e9, 70e9, 10)
 x = ws.absorption_bands.propagation_matrix(f=f, atm=atm) / nd
 
 assert np.allclose(
-    x[::300, 0],
+    x[:, 0],
     [
         1.09249629e-29,
         2.79155620e-29,

--- a/tests/python/xsec/predef.py
+++ b/tests/python/xsec/predef.py
@@ -1,0 +1,33 @@
+import pyarts
+import numpy as np
+
+ws = pyarts.Workspace()
+
+atm = pyarts.arts.AtmPoint()
+atm.pressure = 101325.0
+atm.temperature = 273.15
+atm["O2"] = 0.21
+atm["H2O"] = 0.0
+nd = atm.number_density("O2-66")
+
+ws.absorption_speciesSet(species=["O2-PWR98"])
+ws.ReadCatalogData()
+f = np.linspace(50e9, 70e9, 10)
+x = ws.absorption_predefined_model_data.propagation_matrix(f=f, atm=atm) / nd
+
+assert np.allclose(
+    x[:, 0],
+    [
+        1.31538279e-29,
+        3.13886678e-29,
+        1.28291163e-28,
+        4.16609430e-28,
+        6.43587999e-28,
+        7.09865626e-28,
+        4.24233633e-28,
+        1.13296982e-28,
+        3.04226249e-29,
+        1.43713835e-29,
+    ],
+    atol=1e-36,
+)

--- a/tests/python/xsec/xfit.py
+++ b/tests/python/xsec/xfit.py
@@ -1,0 +1,30 @@
+import pyarts
+import numpy as np
+
+ws = pyarts.Workspace()
+
+atm = pyarts.arts.AtmPoint()
+atm.pressure = 101325.0
+atm.temperature = 273.15
+atm["O3"] = 1e-8
+nd = atm.number_density("O3-666")
+
+ws.absorption_speciesSet(species=["O3-XFIT"])
+ws.ReadCatalogData()
+f = ws.absorption_xsec_fit_data[0].fitcoeffs[0].grids[0]
+x = ws.absorption_xsec_fit_data.propagation_matrix(f=f, atm=atm) / nd
+
+assert np.allclose(
+    x[::60000, 0],
+    [
+        5.48830541e-29,
+        7.01126943e-26,
+        2.25566466e-25,
+        3.67157516e-27,
+        5.42679027e-26,
+        7.56822053e-23,
+        1.11608430e-21,
+        3.90151892e-22,
+    ],
+    atol=1e-36,
+)


### PR DESCRIPTION
Make it easier to just get absorption directly from the relevant python structures.

This adds a method `propagation_matrix` to all 5 of the data structures responsible for absorption data.  The interface to each is the same: first is a frequency grid, second is an atmospheric point.  Since each data type has a few special inputs, these are defaulted to the current defaults in the workspace method call that is wrapped.  Each new member method takes an unused `kwargs`, so in essence you don't need to change anything between calling the methods of different data structures if you need make use of this.

The methods take a `spec` species to mimic species selection in the workspace approach, but if you want individual isotopologue absorption, you are going to have to achieve that by manual manipulation of the data structures.