### PR TITLE
[ARTS-2.6] Force openmp openblas in linux dev environment

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           miniforge-version: latest
           channels: conda-forge
+          conda-remove-defaults: "true"
           channel-priority: true
           activate-environment: arts
           environment-file: ${{ matrix.devenv }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,6 +403,8 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARTS_CXX_FLAGS} ${ARTS_FLAGS}")
 if (APPLE)
   set (OS_NAME "Mac OS")
   set (OSX 1)
+  # Set as recommended in https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk
+  add_definitions(-D_LIBCPP_DISABLE_AVAILABILITY)
 elseif ("${CMAKE_SYSTEM_NAME}" STREQUAL "CYGWIN")
   set (OS_NAME "Cygwin")
   set (CYGWIN 1)

--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -15,6 +15,7 @@ dependencies:
         - libclang
         - libcxx
         - libmicrohttpd
+        - libopenblas=*=*openmp*
         - llvm-openmp
         - matplotlib
         - netcdf4


### PR DESCRIPTION
The `environment-dev-linux.yml` didn't explicitly depended on the openmp version of libopenblas. The pthread version, which is installed by default, causes significant performance degredation.

Other fixes:

Added `LIBCPP_DISABLE_AVAILABILITY` to fix compilation error on macOS with newer libc++.

Add `conda-remove-defaults` flag in CI to completely disable the Anaconda channels. There is still a warning about the `defaults` channel in the build logs, but that's due to the order the `setup-miniconda` action does things. It first adds the `conda-forge` channel (which generates the warning about defaults being present), then removes the `defaults` channel.