### PR TITLE
Force openmp openblas in linux dev environment

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -92,6 +92,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
+          conda-remove-defaults: "true"
           activate-environment: arts
           environment-file: ${{ matrix.devenv }}
       - shell: bash -l {0}

--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -18,6 +18,7 @@ dependencies:
         - lark-parser
         - libclang
         - libcxx
+        - libopenblas=*=*openmp*
         - llvm-openmp
         - nanobind < 2.5.0
         - nbsphinx


### PR DESCRIPTION
The environment-dev-linux.yml didn't explicitly depend on the openmp version of libopenblas. The pthread version, which is installed by default, causes significant performance degredation.

Add conda-remove-defaults flag in CI to completely disable the Anaconda channels. There is still a warning about the defaults channel in the build logs, but that's due to the order the setup-miniconda action does things. It first adds the conda-forge channel (which generates the warning about defaults being present), then removes the defaults channel.