### PR TITLE
[ARTS-2.6] Fix reading of negative Index from binary files

### DIFF
--- a/src/binio.h
+++ b/src/binio.h
@@ -77,7 +77,7 @@ class binio {
   virtual std::streampos pos() = 0;
 
  protected:
-  using Int = std::int64_t;
+  using Int = std::int32_t;
   using Float = double;
   using Byte = unsigned char;  // has to be unsigned!
 


### PR DESCRIPTION
Signedness was lost when reading negative Index values from binary xml files.