### PR TITLE
Make UBSAN happy

### DIFF
--- a/3rdparty/wigner/wigxjpf/src/prime_factor.c
+++ b/3rdparty/wigner/wigxjpf/src/prime_factor.c
@@ -21,8 +21,9 @@
 #include "prime_factor.h"
 #include "wigxjpf_error.h"
 
-#include <string.h>
+#include <limits.h>
 #include <stddef.h>
+#include <string.h>
 
 uint32_t *wigxjpf_prime_list = NULL;
 
@@ -280,7 +281,7 @@ size_t wigxjpf_fill_factors(int max_factorial)
    * And we cannot use last bit,
    */
 
-  uint32_t max_allowed = (uint32_t) (1 << (sizeof (prime_exp_t) * 8 - 1));
+  uint32_t max_allowed = (uint32_t)INT_MAX + 1;
 
   /* We can never pick up more than @max_factorial factors of [2] during the
    * factorials.  I.e. FACTORIAL_PRIME_FACTOR(i)->expo[0] is always < i.

--- a/3rdparty/wigner/wigxjpf/src/trivial_zero.c
+++ b/3rdparty/wigner/wigxjpf/src/trivial_zero.c
@@ -19,6 +19,7 @@
  */
 
 #include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #include "wigxjpf.h"

--- a/3rdparty/wigner/wigxjpf/src/trivial_zero.c
+++ b/3rdparty/wigner/wigxjpf/src/trivial_zero.c
@@ -18,6 +18,7 @@
  *  <http://www.gnu.org/licenses/>.
  */
 
+#include <limits.h>
 #include <stdio.h>
 
 #include "wigxjpf.h"
@@ -58,7 +59,7 @@ int trivial_zero_3j(int two_j1, int two_j2, int two_j3,
   COLLECT_ABS_M_WITHIN_J(two_m3, two_j3);
 
   return ((two_m1 + two_m2 + two_m3) |
-	  (collect_sign & (1 << (sizeof (int) * 8 - 1))) |
+	  (collect_sign & ((uint32_t)INT_MAX + 1)) |
 	  (collect_odd & 1));
 }
 
@@ -75,7 +76,7 @@ int trivial_zero_6j(int two_j1, int two_j2, int two_j3,
   COLLECT_TRIANGLE_TRIVIAL_ZERO(two_j4, two_j2, two_j6);
   COLLECT_TRIANGLE_TRIVIAL_ZERO(two_j4, two_j5, two_j3);
 
-  return ((collect_sign & (1 << (sizeof (int) * 8 - 1))) |
+  return ((collect_sign & ((uint32_t)INT_MAX + 1)) |
 	  (collect_odd & 1));
 }
 

--- a/src/core/lbl/lbl_data.cpp
+++ b/src/core/lbl/lbl_data.cpp
@@ -81,15 +81,18 @@ std::pair<Size, std::span<const line>> band_data::active_lines(
 }
 
 Rational band_data::max(QuantumNumberType x) const try {
-  Rational out{std::numeric_limits<Index>::lowest()};
-  for (auto& line : *this) {
-    auto qn = line.qn.at(x);
+  ARTS_USER_ERROR_IF(lines.empty(), "Must have lines")
+
+  Rational out{maxr(lines.front().qn.at(x).upper.get<Rational>(),
+                    lines.front().qn.at(x).lower.get<Rational>())};
+  for (auto& line : lines | stdv::drop(1)) {
+    auto& qn = line.qn.at(x);
     out = maxr(out, maxr(qn.upper.get<Rational>(), qn.lower.get<Rational>()));
   }
   return out;
 } catch (std::out_of_range&) {
-  throw std::runtime_error(
-      std::format("Cannot find QuantumNumberType \"{}\" for at least on line", x));
+  throw std::runtime_error(std::format(
+      "Cannot find QuantumNumberType \"{}\" for at least on line", x));
 } catch (std::exception&) {
   throw;
 }

--- a/src/core/lbl/lbl_lineshape_voigt_ecs_hartmann.cpp
+++ b/src/core/lbl/lbl_lineshape_voigt_ecs_hartmann.cpp
@@ -73,7 +73,7 @@ void relaxation_matrix_offdiagonal(MatrixView& W,
   if (not n) return;
 
   // These are constant for a band
-  auto l2     = bnd_qid.state.at(QuantumNumberType::l2);
+  auto& l2     = bnd_qid.state.at(QuantumNumberType::l2);
   Rational li = l2.upper.get<Rational>();
   Rational lf = l2.lower.get<Rational>();
 

--- a/src/core/lbl/lbl_lineshape_voigt_ecs_makarov.cpp
+++ b/src/core/lbl/lbl_lineshape_voigt_ecs_makarov.cpp
@@ -115,7 +115,7 @@ void relaxation_matrix_offdiagonal(MatrixView& W,
 
   const auto n = bnd.size();
 
-  auto S            = bnd_qid.state.at(QuantumNumberType::S);
+  auto& S            = bnd_qid.state.at(QuantumNumberType::S);
   const Rational Si = S.upper.get<Rational>();
   const Rational Sf = S.lower.get<Rational>();
 

--- a/src/core/matpack/rational.cc
+++ b/src/core/matpack/rational.cc
@@ -75,6 +75,31 @@ void Rational::simplify_in_place() noexcept {
   fixSign();
 }
 
+Numeric sqrt(const Rational r) { return std::sqrt(r.toNumeric()); }
+
+Numeric pow(const Rational base, Numeric exp) {
+  return std::pow(base.toNumeric(), exp);
+}
+
+Numeric pow(Numeric base, const Rational exp) {
+  return std::pow(base, exp.toNumeric());
+}
+
+Numeric pow(const Rational base, const Rational exp) {
+  return pow(base, exp.toNumeric());
+}
+
+bifstream& Rational::read(bifstream& bif) {
+  bif >> numer >> denom;
+  return bif;
+}
+
+/** Binary write for Rational */
+bofstream& Rational::write(bofstream& bof) const {
+  bof << numer << denom;
+  return bof;
+}
+
 void xml_io_stream<Rational>::write(std::ostream& os_xml,
                                     const Rational& rational,
                                     bofstream* pbofs,

--- a/src/core/matpack/rational.h
+++ b/src/core/matpack/rational.h
@@ -86,8 +86,6 @@ struct Rational {
 
   /** Converts the value to index by n-scaled division
    * 
-   * Throws a logic error if *this is not an Index
-   * 
    * @param[in]  n Scale to *this
    * @return constexpr Index Of *this
    */
@@ -276,16 +274,10 @@ struct Rational {
   explicit constexpr operator int() const noexcept { return toInt(); }
 
   /** Binary read for Rational */
-  bifstream& read(bifstream& bif) {
-    bif >> numer >> denom;
-    return bif;
-  }
+  bifstream& read(bifstream& bif);
 
   /** Binary write for Rational */
-  bofstream& write(bofstream& bof) const {
-    bof << numer << denom;
-    return bof;
-  }
+  bofstream& write(bofstream& bof) const;
 
   /** Makes the sign of denom positive */
   constexpr Rational& fixSign() noexcept {
@@ -703,7 +695,7 @@ constexpr bool operator!(const Rational a) noexcept {
  * @param[in] r Any Rational
  * @return Numeric Square root of the Rational
  */
-inline Numeric sqrt(const Rational r) { return std::sqrt(r.toNumeric()); }
+Numeric sqrt(const Rational r);
 
 /** Power of
  * 
@@ -711,9 +703,7 @@ inline Numeric sqrt(const Rational r) { return std::sqrt(r.toNumeric()); }
  * @param[in] exp Any Numeric
  * @return Numeric base to the power of exp
  */
-inline Numeric pow(const Rational base, Numeric exp) {
-  return std::pow(base.toNumeric(), exp);
-}
+Numeric pow(const Rational base, Numeric exp);
 
 /** Power of
  * 
@@ -721,9 +711,7 @@ inline Numeric pow(const Rational base, Numeric exp) {
  * @param[in] exp Any Rational
  * @return Numeric base to the power of exp
  */
-inline Numeric pow(Numeric base, const Rational exp) {
-  return std::pow(base, exp.toNumeric());
-}
+Numeric pow(Numeric base, const Rational exp);
 
 /** Power of
  * 
@@ -731,9 +719,7 @@ inline Numeric pow(Numeric base, const Rational exp) {
  * @param[in] exp Any Rational
  * @return Numeric base to the power of exp
  */
-inline Numeric pow(const Rational base, const Rational exp) {
-  return pow(base, exp.toNumeric());
-}
+Numeric pow(const Rational base, const Rational exp);
 
 /** less
  * 
@@ -868,7 +854,7 @@ constexpr Rational abs(const Rational a) noexcept { return a < 0 ? -a : a; }
  * @param[in] b Any Rational
  * @return constexpr Rational Largest of a and b
  */
-constexpr Rational maxr(const Rational a, const Rational b) noexcept {
+constexpr const Rational& maxr(const Rational& a, const Rational& b) noexcept {
   return a < b ? b : a;
 }  // Let other operators find out if this is allowed instead
 
@@ -878,7 +864,7 @@ constexpr Rational maxr(const Rational a, const Rational b) noexcept {
  * @param[in] b Any Rational
  * @return constexpr Rational Smallest of a and b
  */
-constexpr Rational minr(const Rational a, const Rational b) noexcept {
+constexpr const Rational& minr(const Rational& a, const Rational& b) noexcept {
   return a < b ? a : b;
 }  // Let other operators find out if this is allowed instead
 

--- a/src/core/util/array.h
+++ b/src/core/util/array.h
@@ -29,8 +29,12 @@ constexpr base max(const Array<base>& x) {
 template <class base, class ConvFunc>
 constexpr auto max(const Array<base>& x, ConvFunc&& f) {
   using RetType = std::remove_cvref_t<decltype(f(base{}))>;
-  RetType maxv  = std::numeric_limits<RetType>::lowest();
-  for (auto& elem : x) maxv = std::max<RetType>(f(elem), maxv);
+
+  if (x.empty()) return std::numeric_limits<RetType>::lowest();
+
+  RetType maxv = f(x.front());
+  for (auto& elem : x | std::views::drop(1))
+    maxv = std::max<RetType>(f(elem), maxv);
   return maxv;
 }
 
@@ -43,9 +47,13 @@ constexpr base min(const Array<base>& x) {
 template <class base, class ConvFunc>
 constexpr auto min(const Array<base>& x, ConvFunc&& f) {
   using RetType = std::remove_cvref_t<decltype(f(base{}))>;
-  RetType maxv  = std::numeric_limits<RetType>::max();
-  for (auto& elem : x) maxv = std::min<RetType>(f(elem), maxv);
-  return maxv;
+
+  if (x.empty()) return std::numeric_limits<RetType>::max();
+
+  RetType minv = f(x.front());
+  for (auto& elem : x | std::views::drop(1))
+    minv = std::min<RetType>(f(elem), minv);
+  return minv;
 }
 
 //! Find first occurance.


### PR DESCRIPTION
This PR probably fixes the clang-20 issue.

I found a big problem in the code anyways.  Well, in how clang-20 looks at the code - the code is valid in clang-19.

After messing around with the part that has caused the headache, I managed to make the bug appear again.  Running UBSAN the error is still there (luckily! print makes it go away still).  Somewhere, clang-20 is negating the numerator of my Rational while doing the comparison.  I want to find the maximum value, so I opted to put the largest negative Rational as the starting point, so that I am guaranteed to get a value from the list.  Since clang-20 decides to negate it, which I think is a change from clang-19, it generates an invalid object.  There is one more negative Index than there are positive Index because of how Index signs work.

So I now initialize the Rational from the first absorption line instead.  This way, only reasonable numbers are involved in the comparisons and clang-20 can do its negation freely without introducing UB in our code.

Anyways, I also spotted three places in wigxjpf that was also doing undefined stuff, so I changed those as well.