### PR TITLE
Separate friends from groups

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,6 +159,7 @@ add_library(artsworkspace STATIC
   workspace_method_class.cpp
   workspace_method_extra_doc.cpp
   workspace_class.cpp
+  workspace_group_friends.cpp
   m_abs.cc
   m_atm.cc
   m_atm_profile.cc

--- a/src/python_interface/gen_auto_py_groups.cpp
+++ b/src/python_interface/gen_auto_py_groups.cpp
@@ -1,6 +1,8 @@
 #include <workspace.h>
+#include <workspace_group_friends.h>
 
 #include <iostream>
+#include <ranges>
 #include <string>
 
 #include "pydocs.h"
@@ -225,7 +227,8 @@ void groups(const std::string& fname) {
 
 )--";
 
-  for (auto& [group, wsg] : wsgs) {
+  for (auto& [group, wsg] :
+       std::array{wsgs, workspace_group_friends()} | stdv::join) {
     hos << "NB_MAKE_OPAQUE(Array<" << group << ">);\n";
     if (wsg.map_type) {
       hos << "NB_MAKE_OPAQUE(" << group << ");\n";
@@ -313,7 +316,8 @@ struct PythonWorkspaceGroupInfo {{static std::string_view desc() = delete;}};
   std::println(osc, R"(#include "py_auto_wsgdocs.h"
 )");
 
-  for (auto& [group, wsg] : wsgs) {
+  for (auto& [group, wsg] :
+       std::array{wsgs, workspace_group_friends()} | stdv::join) {
     const auto info =
         unwrap_stars(std::format("{}\n{}{}",
                                  wsg.desc,

--- a/src/python_interface/gen_auto_py_helpers.cpp
+++ b/src/python_interface/gen_auto_py_helpers.cpp
@@ -15,6 +15,7 @@
 #include "workspace_meta_methods.h"
 #include "workspace_method_extra_doc.h"
 #include "workspace_variables.h"
+#include "workspace_group_friends.h"
 
 String rawify(const String& x) {
   std::stringstream os{x};
@@ -34,6 +35,7 @@ String as_pyarts(const String& x) try {
   const auto& wsgs = internal_workspace_groups();
   const auto& wsvs = workspace_variables();
   const auto& wsms = workspace_methods();
+  const auto& group_friends = workspace_group_friends();
 
   const auto found_in = [&](auto& map) { return map.find(x) not_eq map.end(); };
   const auto found_in_options = [&](auto& key) {
@@ -41,7 +43,7 @@ String as_pyarts(const String& x) try {
         internal_options(), Cmp::eq(key), &EnumeratedOption::name);
   };
 
-  if (found_in_options(x) or found_in(wsgs))
+  if (found_in_options(x) or found_in(wsgs) or found_in(group_friends))
     return std::format(":class:`~pyarts.arts.{}`", x);
   if (found_in(wsms))
     return std::format(":func:`~pyarts.workspace.Workspace.{}`", x);

--- a/src/python_interface/hpy_arts.h
+++ b/src/python_interface/hpy_arts.h
@@ -238,7 +238,7 @@ void generic_interface(py::class_<T, E...>& c) {
 
   if constexpr (arts_xml_ioable<T>) xml_interface(c);
 
-  if constexpr (WorkspaceGroup<T>)
+  if constexpr (requires { PythonWorkspaceGroupInfo<T>::desc(); })
     c.doc() = std::string{PythonWorkspaceGroupInfo<T>::desc()};
 }
 }  // namespace Python

--- a/src/workspace_group_friends.cpp
+++ b/src/workspace_group_friends.cpp
@@ -3,6 +3,7 @@
 #include <arts_options.h>
 
 #include <algorithm>
+#include <stdexcept>
 
 #include "workspace_groups.h"
 

--- a/src/workspace_group_friends.cpp
+++ b/src/workspace_group_friends.cpp
@@ -1,0 +1,632 @@
+#include "workspace_group_friends.h"
+
+#include <arts_options.h>
+
+#include <algorithm>
+
+#include "workspace_groups.h"
+
+namespace {
+std::unordered_map<std::string, WorkspaceGroupRecord> group_friends_internal() {
+  std::unordered_map<std::string, WorkspaceGroupRecord> wsg_data;
+
+  wsg_data["AbsorptionBand"] = {
+      .file = "lbl.h",
+      .desc =
+          R"(Contains all information about bands of related absorption lines.
+
+This information includes
+
+#. A list of :class:`~pyarts.arts.AbsorptionLine`.
+
+#. The line shape profile model.  See *LineByLineLineshape* for available line shape profiles.
+
+#. The frequency cutoff value in [Hz] and type.  See *LineByLineCutoffType* for available cutoff types.
+)",
+  };
+
+  wsg_data["ArrayOfArrayOfGriddedField1"] = {
+      .file = "matpack.h",
+      .desc = "A list of *ArrayOfGriddedField1*\n",
+  };
+
+  wsg_data["ArrayOfArrayOfGriddedField2"] = {
+      .file = "matpack.h",
+      .desc = "A list of *ArrayOfGriddedField2*\n",
+  };
+
+  wsg_data["ArrayOfArrayOfGriddedField3"] = {
+      .file = "matpack.h",
+      .desc = "A list of *ArrayOfGriddedField3*\n",
+  };
+
+  wsg_data["ArrayOfArrayOfIndex"] = {
+      .file = "matpack.h",
+      .desc = "A list of *ArrayOfIndex*\n",
+  };
+
+  wsg_data["ArrayOfArrayOfMatrix"] = {
+      .file = "matpack.h",
+      .desc = "A list of *ArrayOfMatrix*\n",
+  };
+
+  wsg_data["ArrayOfArrayOfScatteringMetaData"] = {
+      .file = "optproperties.h",
+      .desc = "A list of *ArrayOfScatteringMetaData*\n",
+  };
+
+  wsg_data["ArrayOfArrayOfSingleScatteringData"] = {
+      .file = "optproperties.h",
+      .desc = "A list of *ArrayOfSingleScatteringData*\n",
+  };
+
+  wsg_data["ArrayOfArrayOfString"] = {
+      .file = "mystring.h",
+      .desc = "A list of *ArrayOfString*\n",
+  };
+
+  wsg_data["ArrayOfArrayOfTensor3"] = {
+      .file = "matpack.h",
+      .desc = "A list of *ArrayOfTensor3*\n",
+  };
+
+  wsg_data["ArrayOfArrayOfTensor6"] = {
+      .file = "matpack.h",
+      .desc = "A list of *ArrayOfTensor6*\n",
+  };
+
+  wsg_data["ArrayOfArrayOfTime"] = {
+      .file = "artstime.h",
+      .desc = "A list of *ArrayOfTime*\n",
+  };
+
+  wsg_data["XsecRecord"] = {
+      .file = "xsec_fit.h",
+      .desc = R"(A single cross-section record
+
+These cross-section records contains information about the valid temperature and
+pressure ranges as well as well as the fitting coefficients used to compute
+and interpolate the cross-section to other temperatures and pressures
+)",
+  };
+
+  wsg_data["Tensor5"] = {
+      .file = "matpack.h",
+      .desc = "A 5 dimensional array of *Numeric*\n",
+  };
+
+  wsg_data["Tensor6"] = {
+      .file = "matpack.h",
+      .desc = "A 6 dimensional array of *Numeric*\n",
+  };
+
+  wsg_data["Tensor7"] = {
+      .file = "matpack.h",
+      .desc = "A 7 dimensional array of *Numeric*\n",
+  };
+
+  wsg_data["SurfacePoint"] = {
+      .file = "surf.h",
+      .desc =
+          R"--(A surface point.
+
+This keeps two things:
+
+#. The local normal vector.
+
+#. A map of the same keys as *SurfaceField* but towards *Numeric* data.
+   It is similar to how *AtmPoint* is towards *AtmField*.
+)--",
+  };
+
+  wsg_data["StokvecTensor3"] = {
+      .file = "rtepack.h",
+      .desc = "A *Tensor3* but of *Stokvec*.\n",
+  };
+
+  wsg_data["StokvecTensor4"] = {
+      .file = "rtepack.h",
+      .desc = "A *Tensor4* but of *Stokvec*.\n",
+  };
+
+  wsg_data["StokvecTensor5"] = {
+      .file = "rtepack.h",
+      .desc = "A *Tensor5* but of *Stokvec*.\n",
+  };
+
+  wsg_data["StokvecTensor6"] = {
+      .file = "rtepack.h",
+      .desc = "A *Tensor6* but of *Stokvec*.\n",
+  };
+
+  wsg_data["Specmat"] = {
+      .file = "rtepack.h",
+      .desc = "A single Complex Mueller 4x4 matrix.\n",
+  };
+
+  wsg_data["SpeciesTag"] = {
+      .file = "species_tags.h",
+      .desc = R"(A tagged absorption species
+
+These tags are used to help ARTS identify the species
+so that reading routines can find the correct data files.
+)",
+  };
+
+  wsg_data["Sparse"] = {
+      .file = "matpack_sparse.h",
+      .desc = "A sparse version of *Matrix*\n",
+  };
+
+  wsg_data["ScatteringMetaData"] = {
+      .file = "optproperties.h",
+      .desc = "Holds meta data about the scattering\n",
+  };
+
+  wsg_data["SingleScatteringData"] = {
+      .file = "optproperties.h",
+      .desc = "Holds single scattering data\n",
+  };
+
+  wsg_data["SensorPosLos"] = {
+      .file = "obsel.h",
+      .desc = "A position and line-of-sight of a sensor.\n",
+  };
+
+  wsg_data["SensorPosLosVector"] = {
+      .file = "obsel.h",
+      .desc = "Vector of *SensorPosLos*.\n",
+  };
+
+  wsg_data["Rational"] = {
+      .file = "matpack.h",
+      .desc = "Holds a rational number as two *Index* n / d\n",
+  };
+
+  wsg_data["QuantumIdentifierNumericMap"] = {
+      .file = "lbl.h",
+      .desc =
+          R"--(A map from *QuantumIdentifier* to *Numeric*.
+)--",
+      .map_type = true};
+
+  wsg_data["PredefinedModelDataVariant"] = {
+      .file = "predef.h",
+      .desc =
+          R"--(One of the following:
+
+#. :class:`~pyarts.arts.predef.PredefinedModelDataName`
+#. :class:`~pyarts.arts.predef.PredefinedModelDataWaterDataMTCKD4`
+)--",
+  };
+
+  wsg_data["PairOfBlockMatrix"] = {
+      .file = "retrieval_target.h",
+      .desc = R"--(A pair of *BlockMatrix* objects)--",
+  };
+
+  wsg_data["NumericBinaryOperator"] = {
+      .file = "operators.h",
+      .desc = R"--(A simple functional type.
+
+This type will work as a function pointer that takes two *Numeric*
+to produce another *Numeric*.
+
+.. math::
+
+    m = f(x, y)
+
+)--",
+  };
+
+  wsg_data["MuelmatMatrix"] = {
+      .file = "rtepack.h",
+      .desc = "A matrix of *Muelmat*.\n",
+  };
+
+  wsg_data["MatrixOfDisortBDRF"] = {
+      .file = "disort.h",
+      .desc = "A 2 dimensional array of *DisortBDRF*\n",
+  };
+
+  wsg_data["LinemixingSingleEcsData"] = {
+      .file = "lbl.h",
+      .desc =
+          R"--(Data for single species ECS.
+)--",
+  };
+
+  wsg_data["LinemixingSpeciesEcsData"] = {
+      .file = "lbl.h",
+      .desc =
+          R"--(A map from *SpeciesEnum* to *LinemixingSingleEcsData*
+)--",
+      .map_type = true,
+  };
+
+  wsg_data["GriddedField4"] = {
+      .file = "matpack.h",
+      .desc =
+          R"--(A 4 dimensional gridded set of *Numeric* data
+
+The grid is a combination of 4 *Vector*
+
+Both the data and the grid may be named
+)--",
+  };
+
+  wsg_data["GriddedField5"] = {
+      .file = "matpack.h",
+      .desc =
+          R"--(A 5 dimensional gridded set  of *Numeric* data
+
+The grid is a combination of 5 *Vector*
+
+Both the data and the grid may be named
+)--",
+  };
+
+  wsg_data["GriddedField6"] = {
+      .file = "matpack.h",
+      .desc =
+          R"--(A 6 dimensional gridded set of *Numeric* data
+
+The grid is a combination of 6 *Vector*
+
+Both the data and the grid may be named
+)--",
+  };
+
+  wsg_data["DisortBDRF"] = {
+      .file = "disort.h",
+      .desc = "A bidirectional reflectance function\n",
+  };
+
+  wsg_data["ArrayOfTensor3"] = {
+      .file = "matpack.h",
+      .desc = "A list of *Tensor3*\n",
+  };
+
+  wsg_data["ArrayOfTensor4"] = {
+      .file = "matpack.h",
+      .desc = "A list of *Tensor4*\n",
+  };
+
+  wsg_data["ArrayOfTensor5"] = {
+      .file = "matpack.h",
+      .desc = "A list of *Tensor5*\n",
+  };
+
+  wsg_data["ArrayOfTensor6"] = {
+      .file = "matpack.h",
+      .desc = "A list of *Tensor6*\n",
+  };
+
+  wsg_data["ArrayOfTensor7"] = {
+      .file = "matpack.h",
+      .desc = "A list of *Tensor7*\n",
+  };
+
+  wsg_data["ArrayOfSubsurfacePoint"] = {
+      .file = "subsurface.h",
+      .desc =
+          R"--(A list of *SubsurfacePoint*
+)--",
+  };
+
+  wsg_data["ArrayOfStokvecTensor3"] = {
+      .file        = "rtepack.h",
+      .desc        = "A list of *StokvecTensor3*.\n",
+      .array_depth = 1,
+  };
+
+  wsg_data["ArrayOfSpeciesTag"] = {
+      .file = "species_tags.h",
+      .desc = R"--(A list of *SpeciesTag*
+)--",
+  };
+
+  wsg_data["ArrayOfSpeciesIsotope"] = {
+      .file = "isotopologues.h",
+      .desc = "List of *SpeciesIsotope*.\n",
+  };
+
+  wsg_data["ArrayOfSparse"] = {
+      .file = "matpack_sparse.h",
+      .desc = "A list of *Sparse*\n",
+  };
+
+  wsg_data["ArrayOfNamedGriddedField2"] = {
+      .file = "matpack.h",
+      .desc = "A list of *NamedGriddedField2*\n",
+  };
+
+  wsg_data["ArrayOfMuelmatMatrix"] = {
+      .file        = "rtepack.h",
+      .desc        = "A list of *MuelmatMatrix*.\n",
+      .array_depth = 1,
+  };
+
+  wsg_data["ArrayOfGriddedField3"] = {
+      .file = "matpack.h",
+      .desc = "A list of *GriddedField3*\n",
+  };
+
+  wsg_data["ArrayOfGriddedField4"] = {
+      .file = "matpack.h",
+      .desc = "A list of *GriddedField4*\n",
+  };
+
+  wsg_data["ArrayOfGriddedField2"] = {
+      .file = "matpack.h",
+      .desc = "A list of *GriddedField2*\n",
+  };
+
+  wsg_data["ArrayOfGriddedField1"] = {
+      .file = "matpack.h",
+      .desc = "A list of *GriddedField1*\n",
+  };
+
+  wsg_data["AbsorptionLookupTable"] = {
+      .file = "lookup_map.h",
+      .desc = R"(A table of lookup calculations.
+
+Effectively holds a *Tensor4* of pre-computed cross-section data.
+This table is used to interpole to a pressure, temperature, water vmr, and frequency grid.
+)",
+  };
+
+  wsg_data["ArrayOfArrayOfMuelmatMatrix"] = {
+      .file        = "rtepack.h",
+      .desc        = "A list of *ArrayOfMuelmatMatrix*.\n",
+      .array_depth = 2,
+  };
+
+  wsg_data["ArrayOfArrayOfMuelmatVector"] = {
+      .file        = "rtepack.h",
+      .desc        = "A list of *ArrayOfMuelmatVector*.\n",
+      .array_depth = 2,
+  };
+
+  wsg_data["ArrayOfArrayOfVector"] = {
+      .file = "matpack.h",
+      .desc = "A list of *ArrayOfVector*\n",
+  };
+
+  wsg_data["ArrayOfGriddedField1Named"] = {
+      .file = "matpack.h",
+      .desc = "A list of *GriddedField1Named*\n",
+  };
+
+  wsg_data["ArrayOfMatrix"] = {
+      .file = "matpack.h",
+      .desc = "A list of *Matrix*\n",
+  };
+
+  wsg_data["ArrayOfQuantumIdentifier"] = {
+      .file = "quantum.h",
+      .desc = "A list of *QuantumIdentifier*\n",
+  };
+
+  wsg_data["ArrayOfScatteringMetaData"] = {
+      .file = "optproperties.h",
+      .desc = "A list of *ScatteringMetaData*\n",
+  };
+
+  wsg_data["ArrayOfSingleScatteringData"] = {
+      .file = "optproperties.h",
+      .desc = "A list of *SingleScatteringData*\n",
+  };
+
+  wsg_data["ArrayOfTime"] = {
+      .file = "matpack.h",
+      .desc = "A list of *Time*\n",
+  };
+
+  wsg_data["ArrayOfVector"] = {
+      .file = "matpack.h",
+      .desc = "A list of *Vector*\n",
+  };
+
+  wsg_data["AtmData"] = {
+      .file = "atm.h",
+      .desc = R"--(An atmospheric data field.
+
+Each atmospheric data field can be mapped to a single altitude-latitude-longitude coordinate,
+producing a *Numeric* value at that point in the atmosphere.
+
+It holds essentially two things:
+
+#. Rules for how to extrapolate the data in the six directions of the atmosphere (up, down, north, south, east, west).
+
+#. A data field.  This data field is one of the following types:
+
+    #. *Numeric* - The data field is constant in the atmosphere.
+       Cannot consider the extrapolation rules as there is no grid.
+
+    #. *SortedGriddedField3* - The grids are altitude, latitude, longitude.
+       Will consider the extrapolation rules but otherwise performs linear interpolation between all points.
+       With the additional rule that longitude is considerd cyclic around [-180, 180).
+
+    #. *NumericTernaryOperator* - The data field has functional form.
+       Cannot consider the extrapolation rules as there is no grid.
+)--",
+  };
+
+  wsg_data["CartesianSubsurfaceGriddedField3"] = {
+      .file = "rtepack.h",
+      .desc = R"--(A 3-dimensional gridof *Numeric*.
+
+The grids are 1 *DescendingGrid* followed by 2 *AscendingGrid*.
+)--",
+  };
+
+  wsg_data["ComplexGriddedField2"] = {
+      .file = "matpack.h",
+      .desc =
+          R"--(A 2 dimensional gridded set of complex data
+
+The grid is a combination of 2 *Vector*
+
+Both the data and the grid may be named
+)--",
+  };
+
+  wsg_data["JacobianTargetType"] = {
+      .file = "jacobian.h",
+      .desc = R"--(A type of target for use in Jacobian Matrix calculations
+)--",
+  };
+
+  wsg_data["SubsurfacePoint"] = {
+      .file = "subsurface.h",
+      .desc =
+
+          R"--(A surface point.
+
+This keeps a map of the same keys as *SubsurfaceField* but towards *Numeric* data.
+It is similar to how *AtmPoint* is towards *AtmField*.
+)--",
+  };
+
+  wsg_data["SensorObsel"] = {
+      .file = "obsel.h",
+      .desc = R"(A single observation element.
+
+This should result in a single element in a *measurement_vector*.
+
+Expected use of this type is to generate the measurement vector
+of a sensor, where this observation element represent the readout
+from that sensor in a convenient unit (commonly Kelvin or 
+W sr :math:`^{-1}` m :math:`^{-2}` Hz :math:`^{-1}`, but not exclusively)
+
+It deals with averaging the frequency grid sampled by a sensor element
+and the transmission of the sensor system onto the sampling device, as
+well as the sampling device's polarization response.
+
+.. note::
+   Multiple *SensorObsel* can be used to represent a single sensor
+   with multiple channels, such as a sensor with multiple detectors
+   or a sensor with multiple frequency channels.  They then can conveniently
+   share much of their grids, but have different weighting functions
+   and/or different sampling devices.
+)",
+  };
+
+  wsg_data["Propmat"] = {
+      .file = "rtepack.h",
+      .desc = R"--(A single propagation matrix.
+
+Due to the properties of a propagation matrix, only 7 independents need be stored.
+The propagation matrix is thus represented as:
+
+.. math::
+    \mathbf{K} = \left[ \begin {array} {rrrr}
+    A & B & C & D \\
+    B & A & U & V \\
+    C &-U & A & W \\
+    D &-V &-W & A
+    \end {array} \right]
+
+This type is related to *Stokvec* in that its first 4 elements are the same as
+the first 4 elements of *Stokvec* for pure clearsky radiative transfers.
+
+This type is also related to *Muelmat* because it is computed often as the exponent
+of this term multiplied by a negative distance.
+)--",
+  };
+
+  wsg_data["NamedGriddedField2"] = {
+      .file = "matpack.h",
+      .desc =
+          R"--(A 3 dimensional gridded set of *Numeric* data
+
+The grid is a combination of 1 *ArrayOfString* and 2 *Vector*
+
+Both the data and the grid may be named
+)--",
+  };
+
+  wsg_data["GriddedField3"] = {
+      .file = "matpack.h",
+      .desc =
+          R"--(A 3 dimensional gridded set of *Numeric* data
+
+The grid is a combination of 3 *Vector*
+
+Both the data and the grid may be named
+)--",
+  };
+
+  wsg_data["NamedGriddedField3"] = {
+      .file = "matpack.h",
+      .desc =
+          R"--(A 4 dimensional gridded set of *Numeric* data
+
+The grid is a combination of 1 *ArrayOfString* and 3 *Vector*
+
+Both the data and the grid may be named
+)--",
+  };
+
+  wsg_data["MuelmatTensor3"] = {
+      .file = "rtepack.h",
+      .desc = "A *Tensor3* of *Muelmat*.\n",
+  };
+
+  wsg_data["Muelmat"] = {
+      .file = "rtepack.h",
+      .desc = "A single Mueller 4x4 matrix.\n",
+  };
+
+  wsg_data["ArrayOfVector2"] = {
+      .file = "matpack.h",
+      .desc = "A list of *Vector2*\n",
+  };
+
+  wsg_data["GriddedField1"] = {
+      .file = "matpack.h",
+      .desc =
+          R"--(A 1 dimensional gridded set of *Numeric* data
+
+The grid is 1 *Vector*
+
+Both the data and the grid may be named)--",
+  };
+
+  wsg_data["GriddedField1Named"] = {
+      .file = "matpack.h",
+      .desc =
+          R"--(A 3 dimensional gridded set of *Numeric* data
+
+The grid is a combination of 1 *Vector* and 1 *ArrayOfString*
+
+Both the data and the grid may be named
+)--",
+  };
+
+  for (auto& g : internal_options()) {
+    if (wsg_data.find(g.name) != wsg_data.end())
+      throw std::runtime_error(
+          "Duplicate workspace group name (name is reserved as options-group): " +
+          g.name);
+
+    wsg_data[g.name] = {
+        .file = "enums.h",
+        .desc = g.docs(),
+    };
+  }
+
+  for (const auto& [name, g] : internal_workspace_groups()) {
+    if (auto ptr = wsg_data.find(name); ptr != wsg_data.end())
+      wsg_data.erase(ptr);
+  }
+  return wsg_data;
+}
+}  // namespace
+
+const std::unordered_map<std::string, WorkspaceGroupRecord>&
+workspace_group_friends() {
+  static const auto friends = group_friends_internal();
+  return friends;
+}

--- a/src/workspace_group_friends.h
+++ b/src/workspace_group_friends.h
@@ -1,0 +1,5 @@
+#pragma ocne
+
+#include "workspace_groups.h"
+
+const std::unordered_map<std::string, WorkspaceGroupRecord>& workspace_group_friends();

--- a/src/workspace_group_friends.h
+++ b/src/workspace_group_friends.h
@@ -1,5 +1,6 @@
-#pragma ocne
+#pragma once
 
 #include "workspace_groups.h"
 
-const std::unordered_map<std::string, WorkspaceGroupRecord>& workspace_group_friends();
+const std::unordered_map<std::string, WorkspaceGroupRecord>&
+workspace_group_friends();

--- a/src/workspace_groups.cpp
+++ b/src/workspace_groups.cpp
@@ -2,9 +2,30 @@
 
 #include <arts_options.h>
 
+#include <algorithm>
 #include <stdexcept>
 
 #include "workspace_agendas.h"
+
+void add_select_options(
+    std::unordered_map<std::string, WorkspaceGroupRecord>& wsg_data,
+    const std::vector<std::string>& select_options) {
+  const auto& options = internal_options();
+
+  for (const auto& opt : select_options) {
+    auto it = std::ranges::find_if(
+        options, [&opt](const auto& o) { return o.name == opt; });
+
+    if (it == options.end())
+      throw std::runtime_error("Option " + opt +
+                               " not found in internal options.");
+
+    wsg_data[opt] = {
+        .file = "enums.h",
+        .desc = it->docs(),
+    };
+  }
+}
 
 void agenda_operators(
     std::unordered_map<std::string, WorkspaceGroupRecord>& wsg_data) {
@@ -23,21 +44,6 @@ void agenda_operators(
 std::unordered_map<std::string, WorkspaceGroupRecord>
 internal_workspace_groups_creator() {
   std::unordered_map<std::string, WorkspaceGroupRecord> wsg_data;
-
-  wsg_data["AbsorptionBand"] = {
-      .file = "lbl.h",
-      .desc =
-          R"(Contains all information about bands of related absorption lines.
-
-This information includes
-
-#. A list of :class:`~pyarts.arts.AbsorptionLine`.
-
-#. The line shape profile model.  See *LineByLineLineshape* for available line shape profiles.
-
-#. The frequency cutoff value in [Hz] and type.  See *LineByLineCutoffType* for available cutoff types.
-)",
-  };
 
   wsg_data["AbsorptionBands"] = {
       .file     = "lbl.h",
@@ -70,69 +76,9 @@ does not change the global workspace while minimizing the number of variables th
           "Meta type for when methods can take any argument (avoid manual use - there is non)\n",
   };
 
-  wsg_data["ArrayOfArrayOfGriddedField1"] = {
-      .file = "matpack.h",
-      .desc = "A list of *ArrayOfGriddedField1*\n",
-  };
-
-  wsg_data["ArrayOfArrayOfGriddedField2"] = {
-      .file = "matpack.h",
-      .desc = "A list of *ArrayOfGriddedField2*\n",
-  };
-
-  wsg_data["ArrayOfArrayOfGriddedField3"] = {
-      .file = "matpack.h",
-      .desc = "A list of *ArrayOfGriddedField3*\n",
-  };
-
-  wsg_data["ArrayOfArrayOfIndex"] = {
-      .file = "matpack.h",
-      .desc = "A list of *ArrayOfIndex*\n",
-  };
-
-  wsg_data["ArrayOfArrayOfMatrix"] = {
-      .file = "matpack.h",
-      .desc = "A list of *ArrayOfMatrix*\n",
-  };
-
-  wsg_data["ArrayOfArrayOfScatteringMetaData"] = {
-      .file = "optproperties.h",
-      .desc = "A list of *ArrayOfScatteringMetaData*\n",
-  };
-
-  wsg_data["ArrayOfArrayOfSingleScatteringData"] = {
-      .file = "optproperties.h",
-      .desc = "A list of *ArrayOfSingleScatteringData*\n",
-  };
-
   wsg_data["ArrayOfArrayOfSpeciesTag"] = {
       .file = "species_tags.h",
       .desc = "A list of *ArrayOfSpeciesTag*\n",
-  };
-
-  wsg_data["ArrayOfArrayOfString"] = {
-      .file = "mystring.h",
-      .desc = "A list of *ArrayOfString*\n",
-  };
-
-  wsg_data["ArrayOfArrayOfTensor3"] = {
-      .file = "matpack.h",
-      .desc = "A list of *ArrayOfTensor3*\n",
-  };
-
-  wsg_data["ArrayOfArrayOfTensor6"] = {
-      .file = "matpack.h",
-      .desc = "A list of *ArrayOfTensor6*\n",
-  };
-
-  wsg_data["ArrayOfArrayOfTime"] = {
-      .file = "artstime.h",
-      .desc = "A list of *ArrayOfTime*\n",
-  };
-
-  wsg_data["ArrayOfArrayOfVector"] = {
-      .file = "matpack.h",
-      .desc = "A list of *ArrayOfVector*\n",
   };
 
   wsg_data["ArrayOfAtmPoint"] = {
@@ -146,49 +92,9 @@ does not change the global workspace while minimizing the number of variables th
 )",
   };
 
-  wsg_data["ArrayOfGriddedField1"] = {
-      .file = "matpack.h",
-      .desc = "A list of *GriddedField1*\n",
-  };
-
-  wsg_data["ArrayOfGriddedField2"] = {
-      .file = "matpack.h",
-      .desc = "A list of *GriddedField2*\n",
-  };
-
-  wsg_data["ArrayOfGriddedField1Named"] = {
-      .file = "matpack.h",
-      .desc = "A list of *GriddedField1Named*\n",
-  };
-
-  wsg_data["ArrayOfNamedGriddedField2"] = {
-      .file = "matpack.h",
-      .desc = "A list of *NamedGriddedField2*\n",
-  };
-
-  wsg_data["ArrayOfGriddedField3"] = {
-      .file = "matpack.h",
-      .desc = "A list of *GriddedField3*\n",
-  };
-
-  wsg_data["ArrayOfGriddedField4"] = {
-      .file = "matpack.h",
-      .desc = "A list of *GriddedField4*\n",
-  };
-
   wsg_data["ArrayOfIndex"] = {
       .file = "matpack.h",
       .desc = "A list of *Index*\n",
-  };
-
-  wsg_data["ArrayOfMatrix"] = {
-      .file = "matpack.h",
-      .desc = "A list of *Matrix*\n",
-  };
-
-  wsg_data["ArrayOfQuantumIdentifier"] = {
-      .file = "quantum.h",
-      .desc = "A list of *QuantumIdentifier*\n",
   };
 
   wsg_data["ArrayOfQuantumLevelIdentifier"] = {
@@ -206,31 +112,6 @@ does not change the global workspace while minimizing the number of variables th
       .desc = "Meta data for scattering spefcies.",
   };
 
-  wsg_data["ArrayOfScatteringMetaData"] = {
-      .file = "optproperties.h",
-      .desc = "A list of *ScatteringMetaData*\n",
-  };
-
-  wsg_data["ArrayOfSingleScatteringData"] = {
-      .file = "optproperties.h",
-      .desc = "A list of *SingleScatteringData*\n",
-  };
-
-  wsg_data["SpeciesTag"] = {
-      .file = "species_tags.h",
-      .desc = R"(A tagged absorption species
-
-These tags are used to help ARTS identify the species
-so that reading routines can find the correct data files.
-)",
-  };
-
-  wsg_data["ArrayOfSpeciesTag"] = {
-      .file = "species_tags.h",
-      .desc = R"--(A list of *SpeciesTag*
-)--",
-  };
-
   wsg_data["SurfacePropertyTag"] = {
       .file = "surf.h",
       .desc = R"--(A surface property.
@@ -246,11 +127,6 @@ surface properties and ensures we can access them in a consistent way.
       .file = "species.h",
       .desc = R"--(A list of *SpeciesEnum*
 )--",
-  };
-
-  wsg_data["ArrayOfSparse"] = {
-      .file = "matpack_sparse.h",
-      .desc = "A list of *Sparse*\n",
   };
 
   wsg_data["Sun"] = {
@@ -271,51 +147,6 @@ longitude in the sky of the planet and the type)-x-",
   wsg_data["ArrayOfString"] = {
       .file = "mystring.h",
       .desc = "A list of *String*\n",
-  };
-
-  wsg_data["ArrayOfTensor3"] = {
-      .file = "matpack.h",
-      .desc = "A list of *Tensor3*\n",
-  };
-
-  wsg_data["ArrayOfTensor4"] = {
-      .file = "matpack.h",
-      .desc = "A list of *Tensor4*\n",
-  };
-
-  wsg_data["ArrayOfTensor5"] = {
-      .file = "matpack.h",
-      .desc = "A list of *Tensor5*\n",
-  };
-
-  wsg_data["ArrayOfTensor6"] = {
-      .file = "matpack.h",
-      .desc = "A list of *Tensor6*\n",
-  };
-
-  wsg_data["ArrayOfTensor7"] = {
-      .file = "matpack.h",
-      .desc = "A list of *Tensor7*\n",
-  };
-
-  wsg_data["ArrayOfTime"] = {
-      .file = "matpack.h",
-      .desc = "A list of *Time*\n",
-  };
-
-  wsg_data["ArrayOfVector"] = {
-      .file = "matpack.h",
-      .desc = "A list of *Vector*\n",
-  };
-
-  wsg_data["XsecRecord"] = {
-      .file = "xsec_fit.h",
-      .desc = R"(A single cross-section record
-
-These cross-section records contains information about the valid temperature and
-pressure ranges as well as well as the fitting coefficients used to compute
-and interpolate the cross-section to other temperatures and pressures
-)",
   };
 
   wsg_data["ArrayOfXsecRecord"] = {
@@ -346,31 +177,6 @@ An atmospheric field holds two things:
    #. *ScatteringSpeciesProperty*
 
    See each key for more information on what type of data it allows holding.
-)--",
-  };
-
-  wsg_data["AtmData"] = {
-      .file = "atm.h",
-      .desc = R"--(An atmospheric data field.
-
-Each atmospheric data field can be mapped to a single altitude-latitude-longitude coordinate,
-producing a *Numeric* value at that point in the atmosphere.
-
-It holds essentially two things:
-
-#. Rules for how to extrapolate the data in the six directions of the atmosphere (up, down, north, south, east, west).
-
-#. A data field.  This data field is one of the following types:
-
-    #. *Numeric* - The data field is constant in the atmosphere.
-       Cannot consider the extrapolation rules as there is no grid.
-
-    #. *SortedGriddedField3* - The grids are altitude, latitude, longitude.
-       Will consider the extrapolation rules but otherwise performs linear interpolation between all points.
-       With the additional rule that longitude is considerd cyclic around [-180, 180).
-
-    #. *NumericTernaryOperator* - The data field has functional form.
-       Cannot consider the extrapolation rules as there is no grid.
 )--",
   };
 
@@ -429,44 +235,12 @@ The block-structure allows for efficient storage and computation of the covarian
 )",
   };
 
-  wsg_data["GriddedField1"] = {
-      .file = "matpack.h",
-      .desc =
-          R"--(A 1 dimensional gridded set of *Numeric* data
-
-The grid is 1 *Vector*
-
-Both the data and the grid may be named)--",
-  };
-
   wsg_data["GriddedField2"] = {
       .file = "matpack.h",
       .desc =
           R"--(A 2 dimensional gridded set of *Numeric* data
 
 The grid is a combination of 2 *Vector*
-
-Both the data and the grid may be named
-)--",
-  };
-
-  wsg_data["ComplexGriddedField2"] = {
-      .file = "matpack.h",
-      .desc =
-          R"--(A 2 dimensional gridded set of complex data
-
-The grid is a combination of 2 *Vector*
-
-Both the data and the grid may be named
-)--",
-  };
-
-  wsg_data["GriddedField1Named"] = {
-      .file = "matpack.h",
-      .desc =
-          R"--(A 3 dimensional gridded set of *Numeric* data
-
-The grid is a combination of 1 *Vector* and 1 *ArrayOfString*
 
 Both the data and the grid may be named
 )--",
@@ -479,13 +253,6 @@ Both the data and the grid may be named
 )--",
       .map_type = true};
 
-  wsg_data["QuantumIdentifierNumericMap"] = {
-      .file = "lbl.h",
-      .desc =
-          R"--(A map from *QuantumIdentifier* to *Numeric*.
-)--",
-      .map_type = true};
-
   wsg_data["QuantumIdentifierGriddedField1Map"] = {
       .file = "lbl.h",
       .desc =
@@ -493,91 +260,10 @@ Both the data and the grid may be named
 )--",
       .map_type = true};
 
-  wsg_data["NamedGriddedField2"] = {
-      .file = "matpack.h",
-      .desc =
-          R"--(A 3 dimensional gridded set of *Numeric* data
-
-The grid is a combination of 1 *ArrayOfString* and 2 *Vector*
-
-Both the data and the grid may be named
-)--",
-  };
-
-  wsg_data["GriddedField3"] = {
-      .file = "matpack.h",
-      .desc =
-          R"--(A 3 dimensional gridded set of *Numeric* data
-
-The grid is a combination of 3 *Vector*
-
-Both the data and the grid may be named
-)--",
-  };
-
-  wsg_data["NamedGriddedField3"] = {
-      .file = "matpack.h",
-      .desc =
-          R"--(A 4 dimensional gridded set of *Numeric* data
-
-The grid is a combination of 1 *ArrayOfString* and 3 *Vector*
-
-Both the data and the grid may be named
-)--",
-  };
-
-  wsg_data["GriddedField4"] = {
-      .file = "matpack.h",
-      .desc =
-          R"--(A 4 dimensional gridded set of *Numeric* data
-
-The grid is a combination of 4 *Vector*
-
-Both the data and the grid may be named
-)--",
-  };
-
-  wsg_data["GriddedField5"] = {
-      .file = "matpack.h",
-      .desc =
-          R"--(A 5 dimensional gridded set  of *Numeric* data
-
-The grid is a combination of 5 *Vector*
-
-Both the data and the grid may be named
-)--",
-  };
-
-  wsg_data["GriddedField6"] = {
-      .file = "matpack.h",
-      .desc =
-          R"--(A 6 dimensional gridded set of *Numeric* data
-
-The grid is a combination of 6 *Vector*
-
-Both the data and the grid may be named
-)--",
-  };
-
   wsg_data["Index"] = {
       .file       = "matpack.h",
       .desc       = "A 64 bit signed integer type\n",
       .value_type = true,
-  };
-
-  wsg_data["LinemixingSingleEcsData"] = {
-      .file = "lbl.h",
-      .desc =
-          R"--(Data for single species ECS.
-)--",
-  };
-
-  wsg_data["LinemixingSpeciesEcsData"] = {
-      .file = "lbl.h",
-      .desc =
-          R"--(A map from *SpeciesEnum* to *LinemixingSingleEcsData*
-)--",
-      .map_type = true,
   };
 
   wsg_data["LinemixingEcsData"] = {
@@ -593,30 +279,10 @@ Both the data and the grid may be named
       .desc = "A 2 dimensional array of *Numeric*\n",
   };
 
-  wsg_data["DisortBDRF"] = {
-      .file = "disort.h",
-      .desc = "A bidirectional reflectance function\n",
-  };
-
-  wsg_data["MatrixOfDisortBDRF"] = {
-      .file = "disort.h",
-      .desc = "A 2 dimensional array of *DisortBDRF*\n",
-  };
-
   wsg_data["Numeric"] = {
       .file       = "matpack.h",
       .desc       = "IEEE 754 binary64 floating point number\n",
       .value_type = true,
-  };
-
-  wsg_data["PredefinedModelDataVariant"] = {
-      .file = "predef.h",
-      .desc =
-          R"--(One of the following:
-
-#. :class:`~pyarts.arts.predef.PredefinedModelDataName`
-#. :class:`~pyarts.arts.predef.PredefinedModelDataWaterDataMTCKD4`
-)--",
   };
 
   wsg_data["PredefinedModelData"] = {
@@ -659,26 +325,6 @@ It can identify:
 )--",
   };
 
-  wsg_data["Rational"] = {
-      .file = "matpack.h",
-      .desc = "Holds a rational number as two *Index* n / d\n",
-  };
-
-  wsg_data["ScatteringMetaData"] = {
-      .file = "optproperties.h",
-      .desc = "Holds meta data about the scattering\n",
-  };
-
-  wsg_data["SingleScatteringData"] = {
-      .file = "optproperties.h",
-      .desc = "Holds single scattering data\n",
-  };
-
-  wsg_data["Sparse"] = {
-      .file = "matpack_sparse.h",
-      .desc = "A sparse version of *Matrix*\n",
-  };
-
   wsg_data["String"] = {
       .file       = "mystring.h",
       .desc       = "Basic string type\n",
@@ -704,20 +350,6 @@ A surface field effectively holds two things:
 )--",
   };
 
-  wsg_data["SurfacePoint"] = {
-      .file = "surf.h",
-      .desc =
-          R"--(A surface point.
-
-This keeps two things:
-
-#. The local normal vector.
-
-#. A map of the same keys as *SurfaceField* but towards *Numeric* data.
-   It is similar to how *AtmPoint* is towards *AtmField*.
-)--",
-  };
-
   wsg_data["SubsurfaceField"] = {
       .file = "subsurface.h",
       .desc =
@@ -735,24 +367,6 @@ A sub-surface field effectively holds two things:
 )--",
   };
 
-  wsg_data["SubsurfacePoint"] = {
-      .file = "subsurface.h",
-      .desc =
- 
-          R"--(A surface point.
-
-This keeps a map of the same keys as *SubsurfaceField* but towards *Numeric* data.
-It is similar to how *AtmPoint* is towards *AtmField*.
-)--",
-  };
-
-  wsg_data["ArrayOfSubsurfacePoint"] = {
-      .file = "subsurface.h",
-      .desc =
-          R"--(A list of *SubsurfacePoint*
-)--",
-  };
-
   wsg_data["Tensor3"] = {
       .file = "matpack.h",
       .desc = "A 3 dimensional array of *Numeric*\n",
@@ -761,21 +375,6 @@ It is similar to how *AtmPoint* is towards *AtmField*.
   wsg_data["Tensor4"] = {
       .file = "matpack.h",
       .desc = "A 4 dimensional array of *Numeric*\n",
-  };
-
-  wsg_data["Tensor5"] = {
-      .file = "matpack.h",
-      .desc = "A 5 dimensional array of *Numeric*\n",
-  };
-
-  wsg_data["Tensor6"] = {
-      .file = "matpack.h",
-      .desc = "A 6 dimensional array of *Numeric*\n",
-  };
-
-  wsg_data["Tensor7"] = {
-      .file = "matpack.h",
-      .desc = "A 7 dimensional array of *Numeric*\n",
   };
 
   wsg_data["Time"] = {
@@ -787,39 +386,6 @@ It is similar to how *AtmPoint* is towards *AtmField*.
   wsg_data["Vector"] = {
       .file = "matpack.h",
       .desc = "A 1 dimensional array of *Numeric*\n",
-  };
-
-  wsg_data["Propmat"] = {
-      .file = "rtepack.h",
-      .desc = R"--(A single propagation matrix.
-
-Due to the properties of a propagation matrix, only 7 independents need be stored.
-The propagation matrix is thus represented as:
-
-.. math::
-    \mathbf{K} = \left[ \begin {array} {rrrr}
-    A & B & C & D \\
-    B & A & U & V \\
-    C &-U & A & W \\
-    D &-V &-W & A
-    \end {array} \right]
-
-This type is related to *Stokvec* in that its first 4 elements are the same as
-the first 4 elements of *Stokvec* for pure clearsky radiative transfers.
-
-This type is also related to *Muelmat* because it is computed often as the exponent
-of this term multiplied by a negative distance.
-)--",
-  };
-
-  wsg_data["Specmat"] = {
-      .file = "rtepack.h",
-      .desc = "A single Complex Mueller 4x4 matrix.\n",
-  };
-
-  wsg_data["Muelmat"] = {
-      .file = "rtepack.h",
-      .desc = "A single Mueller 4x4 matrix.\n",
   };
 
   wsg_data["Stokvec"] = {
@@ -865,44 +431,14 @@ The components of the Stokes vector are:
       .desc = "A matrix of *Propmat*.\n",
   };
 
-  wsg_data["MuelmatMatrix"] = {
-      .file = "rtepack.h",
-      .desc = "A matrix of *Muelmat*.\n",
-  };
-
   wsg_data["SpecmatMatrix"] = {
       .file = "rtepack.h",
       .desc = "A matrix of *Muelmat*.\n",
   };
 
-  wsg_data["MuelmatTensor3"] = {
-      .file = "rtepack.h",
-      .desc = "A *Tensor3* of *Muelmat*.\n",
-  };
-
   wsg_data["StokvecMatrix"] = {
       .file = "rtepack.h",
       .desc = "A matrix of *Stokvec*.\n",
-  };
-
-  wsg_data["StokvecTensor3"] = {
-      .file = "rtepack.h",
-      .desc = "A *Tensor3* but of *Stokvec*.\n",
-  };
-
-  wsg_data["StokvecTensor4"] = {
-      .file = "rtepack.h",
-      .desc = "A *Tensor4* but of *Stokvec*.\n",
-  };
-
-  wsg_data["StokvecTensor5"] = {
-      .file = "rtepack.h",
-      .desc = "A *Tensor5* but of *Stokvec*.\n",
-  };
-
-  wsg_data["StokvecTensor6"] = {
-      .file = "rtepack.h",
-      .desc = "A *Tensor6* but of *Stokvec*.\n",
   };
 
   wsg_data["StokvecSortedGriddedField1"] = {
@@ -977,12 +513,6 @@ The grids are 6 *AscendingGrid*.
       .array_depth = 1,
   };
 
-  wsg_data["ArrayOfMuelmatMatrix"] = {
-      .file        = "rtepack.h",
-      .desc        = "A list of *MuelmatMatrix*.\n",
-      .array_depth = 1,
-  };
-
   wsg_data["ArrayOfSpecmatMatrix"] = {
       .file        = "rtepack.h",
       .desc        = "A list of *SpecmatMatrix*.\n",
@@ -1001,21 +531,9 @@ The grids are 6 *AscendingGrid*.
       .array_depth = 1,
   };
 
-  wsg_data["ArrayOfStokvecTensor3"] = {
-      .file        = "rtepack.h",
-      .desc        = "A list of *StokvecTensor3*.\n",
-      .array_depth = 1,
-  };
-
   wsg_data["ArrayOfArrayOfPropmatVector"] = {
       .file        = "rtepack.h",
       .desc        = "A list of *ArrayOfPropmatVector*.\n",
-      .array_depth = 2,
-  };
-
-  wsg_data["ArrayOfArrayOfMuelmatVector"] = {
-      .file        = "rtepack.h",
-      .desc        = "A list of *ArrayOfMuelmatVector*.\n",
       .array_depth = 2,
   };
 
@@ -1028,12 +546,6 @@ The grids are 6 *AscendingGrid*.
   wsg_data["ArrayOfArrayOfPropmatMatrix"] = {
       .file        = "rtepack.h",
       .desc        = "A list of *ArrayOfPropmatMatrix*.\n",
-      .array_depth = 2,
-  };
-
-  wsg_data["ArrayOfArrayOfMuelmatMatrix"] = {
-      .file        = "rtepack.h",
-      .desc        = "A list of *ArrayOfMuelmatMatrix*.\n",
       .array_depth = 2,
   };
 
@@ -1053,20 +565,6 @@ to produce another *Numeric*.
 .. math::
 
     m = f(x)
-
-)--",
-  };
-
-  wsg_data["NumericBinaryOperator"] = {
-      .file = "operators.h",
-      .desc = R"--(A simple functional type.
-
-This type will work as a function pointer that takes two *Numeric*
-to produce another *Numeric*.
-
-.. math::
-
-    m = f(x, y)
 
 )--",
   };
@@ -1092,17 +590,6 @@ to produce a single *Numeric*.
 This type flags the type of calculations that should be performed
 when computing the Jacobian matrix or partial derivatives.
 )--",
-  };
-
-  wsg_data["JacobianTargetType"] = {
-      .file = "jacobian.h",
-      .desc = R"--(A type of target for use in Jacobian Matrix calculations
-)--",
-  };
-
-  wsg_data["PairOfBlockMatrix"] = {
-      .file = "retrieval_target.h",
-      .desc = R"--(A pair of *BlockMatrix* objects)--",
   };
 
   wsg_data["JacobianTargetsDiagonalCovarianceMatrixMap"] = {
@@ -1155,11 +642,6 @@ radiation.
       .desc = "A list of *Vector3*\n",
   };
 
-  wsg_data["ArrayOfVector2"] = {
-      .file = "matpack.h",
-      .desc = "A list of *Vector2*\n",
-  };
-
   wsg_data["DescendingGrid"] = {
       .file = "matpack.h",
       .desc = "A sorted *Vector* of always descending values.\n",
@@ -1189,45 +671,6 @@ line-of-sight to get the corresponding spectral radiance.
       .desc = "Contains name and data about an isotope.\n",
   };
 
-  wsg_data["ArrayOfSpeciesIsotope"] = {
-      .file = "isotopologues.h",
-      .desc = "List of *SpeciesIsotope*.\n",
-  };
-
-  wsg_data["SensorPosLos"] = {
-      .file = "obsel.h",
-      .desc = "A position and line-of-sight of a sensor.\n",
-  };
-
-  wsg_data["SensorPosLosVector"] = {
-      .file = "obsel.h",
-      .desc = "Vector of *SensorPosLos*.\n",
-  };
-
-  wsg_data["SensorObsel"] = {
-      .file = "obsel.h",
-      .desc = R"(A single observation element.
-
-This should result in a single element in a *measurement_vector*.
-
-Expected use of this type is to generate the measurement vector
-of a sensor, where this observation element represent the readout
-from that sensor in a convenient unit (commonly Kelvin or 
-W sr :math:`^{-1}` m :math:`^{-2}` Hz :math:`^{-1}`, but not exclusively)
-
-It deals with averaging the frequency grid sampled by a sensor element
-and the transmission of the sensor system onto the sampling device, as
-well as the sampling device's polarization response.
-
-.. note::
-   Multiple *SensorObsel* can be used to represent a single sensor
-   with multiple channels, such as a sensor with multiple detectors
-   or a sensor with multiple frequency channels.  They then can conveniently
-   share much of their grids, but have different weighting functions
-   and/or different sampling devices.
-)",
-  };
-
   wsg_data["ArrayOfSensorObsel"] = {
       .file = "obsel.h",
       .desc = "List of *SensorObsel*.\n",
@@ -1253,15 +696,6 @@ well as the sampling device's polarization response.
 #. *Tensor3* Legendre polynomial coefficients
 #. *Tensor3* Positive boundary condition
 #. *Tensor3* Negative boundary condition
-)",
-  };
-
-  wsg_data["AbsorptionLookupTable"] = {
-      .file = "lookup_map.h",
-      .desc = R"(A table of lookup calculations.
-
-Effectively holds a *Tensor4* of pre-computed cross-section data.
-This table is used to interpole to a pressure, temperature, water vmr, and frequency grid.
 )",
   };
 
@@ -1319,14 +753,6 @@ The grids are 6 *AscendingGrid*.
 )--",
   };
 
-  wsg_data["CartesianSubsurfaceGriddedField3"] = {
-      .file = "rtepack.h",
-      .desc = R"--(A 3-dimensional gridof *Numeric*.
-
-The grids are 1 *DescendingGrid* followed by 2 *AscendingGrid*.
-)--",
-  };
-
   wsg_data["SpectralRadianceTransformOperator"] = {
       .file = "spectral_radiance_transform_operator.h",
       .desc =
@@ -1352,17 +778,15 @@ ray_path_point : PropagationPathPoint
 )--",
   };
 
-  for (auto& g : internal_options()) {
-    if (wsg_data.find(g.name) != wsg_data.end())
-      throw std::runtime_error(
-          "Duplicate workspace group name (name is reserved as options-group): " +
-          g.name);
-
-    wsg_data[g.name] = {
-        .file = "enums.h",
-        .desc = g.docs(),
-    };
-  }
+  add_select_options(wsg_data,
+                     {
+                         "InterpolationExtrapolation",
+                         "SpeciesEnum",
+                         "AtmKey",
+                         "SurfaceKey",
+                         "SubsurfaceKey",
+                         "SpectralRadianceUnitType",
+                     });
 
   agenda_operators(wsg_data);
 

--- a/tests/python/can-reference-into-array-into-method.py
+++ b/tests/python/can-reference-into-array-into-method.py
@@ -10,13 +10,13 @@ import pyarts
 
 ws = pyarts.Workspace()
 
-ws.specs = pyarts.arts.ArrayOfArrayOfString([["O2"]])
+specs = pyarts.arts.ArrayOfArrayOfString([["O2"]])
 
-ws.absorption_speciesSet(species=ws.specs[0])
+ws.absorption_speciesSet(species=specs[0])
 
 x = pyarts.arts.ArrayOfArrayOfSpeciesTag()
 
-ws.absorption_speciesSet(x, species=ws.specs[0])
+ws.absorption_speciesSet(x, species=specs[0])
 
 assert x == ws.absorption_species
 

--- a/tests/python/wsgs/diagnostics-wsg-vs-wsv.py
+++ b/tests/python/wsgs/diagnostics-wsg-vs-wsv.py
@@ -1,3 +1,19 @@
+reason = """
+We do not want any workspace groups that are not used in any workspace method or variable.
+
+You have three options to fix this issue:
+1.  Remove the unused workspace groups.
+2.  Add a dependency of the workspace group to a workspace method or agenda.
+3.  Move the declaration of the workspace group to the group friend list.
+    This is required for one of two reasons:
+    1.  The *Group* syntax is used to reference the group in some other
+        documentation, such as other workspace groups, variables, methods,
+        or agendas.
+    2.  The group is used in a way that requires it to be opaque in the
+        Python bindings.  This is required for all enum-types, all std::vector,
+        and all std::*map types.
+"""
+
 import pyarts
 
 wsvs = pyarts.arts.globals.workspace_variables()
@@ -28,6 +44,7 @@ for wsm in wsms:
 keys = list(wsgs.keys())
 keys.sort()
 
-for wsg in keys:
-    if wsgs[wsg] == 0:
-        print(f"{wsg} is not used in any workspace method and is not a variable")
+errors = [f"\n{wsg} should not be a workspace group"
+          for wsg in keys if wsgs[wsg] == 0]
+
+assert len(errors) == 0, ", and".join(errors) + '\n' + reason

--- a/tests/python/wsgs/diagnostics-wsg-vs-wsv.py
+++ b/tests/python/wsgs/diagnostics-wsg-vs-wsv.py
@@ -1,0 +1,33 @@
+import pyarts
+
+wsvs = pyarts.arts.globals.workspace_variables()
+wsgs = pyarts.arts.globals.workspace_groups()
+wsms = pyarts.arts.globals.workspace_methods()
+
+wsgs = {}.fromkeys(wsgs, 0)
+wsgs["CallbackOperator"] = 1
+
+for wsv in wsvs:
+    wsgs[wsvs[wsv].type] += 1
+
+for wsm in wsms:
+    for nwsv in wsms[wsm].gin_type:
+        if "," in nwsv:
+            for sub_nwsv in nwsv.split(","):
+                wsgs[sub_nwsv.strip()] += 1
+        else:
+            wsgs[nwsv] += 1
+
+    for nwsv in wsms[wsm].gout_type:
+        if "," in nwsv:
+            for sub_nwsv in nwsv.split(","):
+                wsgs[sub_nwsv.strip()] += 1
+        else:
+            wsgs[nwsv] += 1
+
+keys = list(wsgs.keys())
+keys.sort()
+
+for wsg in keys:
+    if wsgs[wsg] == 0:
+        print(f"{wsg} is not used in any workspace method and is not a variable")


### PR DESCRIPTION
This PR adds and enforces the concept of workspace group friends.

A friend is a any group that is required for the workspace to function but which itself is not used directly by an agenda or method.

It is not tested that a workspace group friend is not supposed to be a friend.

There are 2 reasons why a group has to be a friend:

1.  The python interface demands that standard types and value types are made opaque.  This is the case for enums, std::vector, std::unordered_map, ...  (a reminder Array<> is a std::vector).
2. The string replacement referencing is used to link documentation.  That is the documentation strings for some workspace item or friend uses the ``*Group*`` syntax to create a documentation hyperlink.