### PR TITLE
Fix breakage with Numpy

### DIFF
--- a/src/python_interface/py_basic.cpp
+++ b/src/python_interface/py_basic.cpp
@@ -3,6 +3,7 @@
 #include <nanobind/stl/complex.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/string_view.h>
+#include <nanobind/stl/variant.h>
 #include <python_interface.h>
 
 #include "hpy_arts.h"
@@ -26,22 +27,33 @@ void py_basic(py::module_& m) try {
   py::class_<ValueHolder<Numeric>> num(m, "Numeric");
   value_holder_interface(num);
   generic_interface(num);
+  using nd_numeric = py::ndarray<py::numpy, Numeric, py::ndim<0>, py::c_contig>;
   num.def(
          "__array__",
-         [](ValueHolder<Numeric>& n, py::object dtype, py::object copy) {
-           using nd =
-               py::ndarray<py::numpy, Numeric, py::ndim<0>, py::c_contig>;
+         [](ValueHolder<Numeric>& n,
+            py::object dtype,
+            py::object copy) -> std::variant<nd_numeric, py::object> {
            std::array<size_t, 0> shape{};
 
            auto np = py::module_::import_("numpy");
-           auto x  = nd(n.val.get(), 0, shape.data(), py::cast(n));
-           return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
+           auto x  = nd_numeric(n.val.get(), 0, shape.data(), py::cast(n));
+
+           if (not dtype.is_none()) {
+             if (copy.is_none())
+               return np.attr("asarray")(
+                   x, "dtype"_a = dtype, "copy"_a = false);
+             return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
+           }
+
+           return x.cast((not copy.is_none() and py::bool_(copy))
+                             ? py::rv_policy::copy
+                             : py::rv_policy::automatic_reference);
          },
          "dtype"_a.none() = py::none(),
          "copy"_a.none()  = py::none())
       .def_prop_rw(
           "value",
-          [](py::object& x) { return x.attr("__array__")("copy"_a = false); },
+          [](py::object& x) { return x.attr("__array__")(); },
           [](ValueHolder<Numeric>& a, const ValueHolder<Numeric>& b) { a = b; },
           "A :class:`~numpy.ndarray` of the object.");
   common_ndarray(num);
@@ -49,22 +61,34 @@ void py_basic(py::module_& m) try {
   py::class_<ValueHolder<Index>> ind(m, "Index");
   value_holder_interface(ind);
   generic_interface(ind);
+  using nd_index = py::ndarray<py::numpy, Index, py::ndim<0>, py::c_contig>;
   ind.def(
          "__array__",
-         [](ValueHolder<Index>& n, py::object dtype, py::object copy) {
-           using nd = py::ndarray<py::numpy, Index, py::ndim<0>, py::c_contig>;
+         [](ValueHolder<Index>& n,
+            py::object dtype,
+            py::object copy) -> std::variant<nd_index, py::object> {
            std::array<size_t, 0> shape{};
 
            auto np = py::module_::import_("numpy");
-           auto x  = nd(n.val.get(), 0, shape.data(), py::cast(n));
-           return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
+           auto x  = nd_index(n.val.get(), 0, shape.data(), py::cast(n));
+
+           if (not dtype.is_none()) {
+             if (copy.is_none())
+               return np.attr("asarray")(
+                   x, "dtype"_a = dtype, "copy"_a = false);
+             return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
+           }
+
+           return x.cast((not copy.is_none() and py::bool_(copy))
+                             ? py::rv_policy::copy
+                             : py::rv_policy::automatic_reference);
          },
          "dtype"_a.none() = py::none(),
          "copy"_a.none()  = py::none(),
          "Returns a :class:`~numpy.ndarray` of the object.")
       .def_prop_rw(
           "value",
-          [](py::object& x) { return x.attr("__array__")("copy"_a = false); },
+          [](py::object& x) { return x.attr("__array__")(); },
           [](ValueHolder<Index>& a, const ValueHolder<Index>& b) { a = b; },
           "A :class:`~numpy.ndarray` of the object.");
   common_ndarray(ind);
@@ -74,21 +98,34 @@ void py_basic(py::module_& m) try {
   generic_interface(aos);
 
   auto aoi = py::class_<ArrayOfIndex>(m, "ArrayOfIndex");
+  using nd_index_array =
+      py::ndarray<py::numpy, Index, py::ndim<1>, py::c_contig>;
   aoi.def(
          "__array__",
-         [](ArrayOfIndex& v, py::object dtype, py::object copy) {
-           using nd = py::ndarray<py::numpy, Index, py::ndim<1>, py::c_contig>;
+         [](ArrayOfIndex& v,
+            py::object dtype,
+            py::object copy) -> std::variant<nd_index_array, py::object> {
            std::array<size_t, 1> shape{static_cast<size_t>(v.size())};
 
            auto np = py::module_::import_("numpy");
-           auto x  = nd(v.data(), 1, shape.data(), py::cast(v));
-           return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
+           auto x  = nd_index_array(v.data(), 1, shape.data(), py::cast(v));
+
+           if (not dtype.is_none()) {
+             if (copy.is_none())
+               return np.attr("asarray")(
+                   x, "dtype"_a = dtype, "copy"_a = false);
+             return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
+           }
+
+           return x.cast((not copy.is_none() and py::bool_(copy))
+                             ? py::rv_policy::copy
+                             : py::rv_policy::automatic_reference);
          },
          "dtype"_a.none() = py::none(),
          "copy"_a.none()  = py::none())
       .def_prop_rw(
           "value",
-          [](py::object& x) { return x.attr("__array__")("copy"_a = false); },
+          [](py::object& x) { return x.attr("__array__")(); },
           [](ArrayOfIndex& a, const ArrayOfIndex& b) { a = b; },
           "A :class:`~numpy.ndarray` of the object.");
   common_ndarray(aoi);
@@ -96,23 +133,35 @@ void py_basic(py::module_& m) try {
   generic_interface(aoi);
 
   auto aon = py::class_<ArrayOfNumeric>(m, "ArrayOfNumeric");
+  using nd_numeric_array =
+      py::ndarray<py::numpy, Numeric, py::ndim<1>, py::c_contig>;
   aon.def(
          "__array__",
-         [](ArrayOfNumeric& v, py::object dtype, py::object copy) {
-           using nd =
-               py::ndarray<py::numpy, Numeric, py::ndim<1>, py::c_contig>;
+         [](ArrayOfNumeric& v,
+            py::object dtype,
+            py::object copy) -> std::variant<nd_numeric_array, py::object> {
            std::array<size_t, 1> shape{static_cast<size_t>(v.size())};
 
            auto np = py::module_::import_("numpy");
-           auto x  = nd(v.data(), 1, shape.data(), py::cast(v));
-           return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
+           auto x  = nd_numeric_array(v.data(), 1, shape.data(), py::cast(v));
+
+           if (not dtype.is_none()) {
+             if (copy.is_none())
+               return np.attr("asarray")(
+                   x, "dtype"_a = dtype, "copy"_a = false);
+             return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
+           }
+
+           return x.cast((not copy.is_none() and py::bool_(copy))
+                             ? py::rv_policy::copy
+                             : py::rv_policy::automatic_reference);
          },
          "dtype"_a.none() = py::none(),
          "copy"_a.none()  = py::none(),
          "Returns a :class:`~numpy.ndarray` of the object.")
       .def_prop_rw(
           "value",
-          [](py::object& x) { return x.attr("__array__")("copy"_a = false); },
+          [](py::object& x) { return x.attr("__array__")(); },
           [](ArrayOfNumeric& a, const ArrayOfNumeric& b) { a = b; },
           "A :class:`~numpy.ndarray` of the object.")
       .doc() = "A list of :class:`~pyarts.arts.Numeric`";


### PR DESCRIPTION
Numpy's rules for ``__array__`` are that you should only copy if necessary.  We on the other hand copied all the time.  This PR fixes that.

The rules are [here](https://numpy.org/doc/2.2/user/basics.interoperability.html#the-array-method).