### PR TITLE
Use windows-2022 explicitly in CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -92,7 +92,7 @@ jobs:
             jcheck: 2
 
           - name: windows-default-msvc
-            os: windows-latest
+            os: windows-2022
             preset: default-msvc-conda
             pyarts: "yes"
             check: "yes"


### PR DESCRIPTION
GH transitions to windows-2025 in September. Since this will most likely break things, we stick with 2022 for now until we can test and fix issues with 2025.