### PR TITLE
Make an optional min-tau-step in CPP-DISORT

### DIFF
--- a/examples/1-getting-started/3-disort/1.clearsky-radiance.py
+++ b/examples/1-getting-started/3-disort/1.clearsky-radiance.py
@@ -3,7 +3,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 PLOT = False
-toa = 100e3
+toa = 120e3
 lat = 0
 lon = 0
 NQuad = 40

--- a/src/workspace_method_extra_doc.cpp
+++ b/src/workspace_method_extra_doc.cpp
@@ -58,7 +58,7 @@ Before that, a concise overview of what each option do is available by the types
           enumstrs::disort_settings_agenda_setup_sun_typeNames<>.size() *
           enumstrs::disort_settings_agenda_setup_surface_typeNames<>.size(),
       method_name,
-      
+
       method.in[0].substr(1),
       method.in[1].substr(1),
       method.in[2].substr(1),
@@ -85,9 +85,10 @@ Before that, a concise overview of what each option do is available by the types
                                           std::string{space_setting},
                                           std::string{sun_setting},
                                           std::string{surface_setting},
-                                          y);
-              docstr = replace(
-                  x.sphinx_list(), "[-99, 0, 99]", "lambertian_reflection");
+                                          y,
+                                          123);
+              docstr = replace(replace(
+                  x.sphinx_list(), "[-99, 0, 99]", "lambertian_reflection"), "123", "min_optical_depth");
             } catch (std::exception& e) {
               docstr = std::format("Invalid combination: {}", e.what());
             }
@@ -96,7 +97,7 @@ Before that, a concise overview of what each option do is available by the types
                 R"(
 ------------------------------------------------------------
 
-``{}({}="{}", {}="{}", {}="{}", {}="{}", {}="{}", {}=lambertian_reflection)``
+``{}({}="{}", {}="{}", {}="{}", {}="{}", {}="{}", {}=lambertian_reflection, min_optical_depth=min_optical_depth)``
 
 {}
 )",

--- a/src/workspace_methods.cpp
+++ b/src/workspace_methods.cpp
@@ -2122,10 +2122,7 @@ outside of this range simply uses the formalism of  the select ``hydrostatic_opt
                     "fixed_specific_gas_constant",
                     "fixed_atmospheric_temperature",
                     "hydrostatic_option"},
-      .gin_type  = {"GeodeticField2,Numeric",
-                    "Numeric",
-                    "Numeric",
-                    "String"},
+      .gin_type  = {"GeodeticField2,Numeric", "Numeric", "Numeric", "String"},
       .gin_value = {std::nullopt,
                     Numeric{-1},
                     Numeric{-1},
@@ -5067,6 +5064,19 @@ calculation in which the *measurement_jacobian* and the gain matrix *measurement
       .out    = {"scattering_species"},
   };
 
+  wsm_data["disort_settingsOpticalThicknessFromPath"] = {
+      .desc   = R"(Get optical thickness from path.
+)",
+      .author = {"Richard Larsson"},
+      .out    = {"disort_settings"},
+      .in     = {"disort_settings", "ray_path", "ray_path_propagation_matrix"},
+      .gin    = {"min_optical_depth"},
+      .gin_type  = {"Numeric"},
+      .gin_value = {Numeric{1e-11}},
+      .gin_desc =
+          {"The minimum increase in optical thickness per level.  The DISORT algorithm employed is numerically unstable if the change between levels is too small."},
+  };
+
   wsm_data["disort_settings_agendaSetup"] = {
       .desc =
           R"--(Setup for Disort standard calculations.
@@ -5074,28 +5084,39 @@ calculation in which the *measurement_jacobian* and the gain matrix *measurement
 This method allows setting up *disort_settings_agenda* by named options.
 A description of the options is given below.
 )--",
-      .author    = {"Richard Larsson"},
-      .out       = {"disort_settings_agenda"},
-      .gin       = {"layer_emission_setting",
-                    "scattering_setting",
-                    "space_setting",
-                    "sun_setting",
-                    "surface_setting",
-                    "surface_lambertian_value"},
-      .gin_type  = {"String", "String", "String", "String", "String", "Vector"},
-      .gin_value = {String{"LinearInTau"},
-                    String{"None"},
-                    String{"CosmicMicrowaveBackgroundRadiation"},
-                    String{"None"},
-                    String{"Thermal"},
-                    Vector{}},
+      .author = {"Richard Larsson"},
+      .out    = {"disort_settings_agenda"},
+      .gin    = {"layer_emission_setting",
+                 "scattering_setting",
+                 "space_setting",
+                 "sun_setting",
+                 "surface_setting",
+                 "surface_lambertian_value",
+                 wsm_data["disort_settingsOpticalThicknessFromPath"].gin[0]},
+      .gin_type =
+          {"String",
+           "String",
+           "String",
+           "String",
+           "String",
+           "Vector",
+           wsm_data["disort_settingsOpticalThicknessFromPath"].gin_type[0]},
+      .gin_value =
+          {String{"LinearInTau"},
+           String{"None"},
+           String{"CosmicMicrowaveBackgroundRadiation"},
+           String{"None"},
+           String{"Thermal"},
+           Vector{},
+           wsm_data["disort_settingsOpticalThicknessFromPath"].gin_value[0]},
       .gin_desc =
           {"Layer emission settings",
            "Scattering settings",
            "Space settings",
            "Sun settings",
            "Surface settings",
-           "Surface lambertian value (must be the size of the frequency grid; used only when surface is set to a Lambertian variant)"},
+           "Surface lambertian value (must be the size of the frequency grid; used only when surface is set to a Lambertian variant)",
+           wsm_data["disort_settingsOpticalThicknessFromPath"].gin_desc[0]},
   };
 
   wsm_data["disort_settingsLegendreCoefficientsFromPath"] = {
@@ -5235,19 +5256,6 @@ This is WIP and should not be used.
       .author = {"Richard Larsson"},
       .out    = {"disort_settings"},
       .in     = {"disort_settings"},
-  };
-
-  wsm_data["disort_settingsOpticalThicknessFromPath"] = {
-      .desc   = R"(Get optical thickness from path.
-)",
-      .author = {"Richard Larsson"},
-      .out    = {"disort_settings"},
-      .in     = {"disort_settings", "ray_path", "ray_path_propagation_matrix"},
-      .gin    = {"allow_fixing"},
-      .gin_type  = {"Index"},
-      .gin_value = {Index{0}},
-      .gin_desc =
-          {"Flag to allow fixing of the optical thickness - it must be strictly increasing, this does that"},
   };
 
   wsm_data["disort_settingsNoSurfaceScattering"] = {


### PR DESCRIPTION
The optional value default is 1e-11.  This is controlled by the user.

I did not manage to identify when and how things break by low tau-steps but 1e-11 seems like a good value of delta-tau