### PR TITLE
Enforce documentation of types

### DIFF
--- a/src/python_interface/gen_auto_py_variables.cpp
+++ b/src/python_interface/gen_auto_py_variables.cpp
@@ -45,8 +45,7 @@ std::string variable(const std::string& name,
        << "\");\n      ws_val.set_name(\"" << name
        << "\");\n      ws_val.finalize();\n";
 
-  os << "    }, R\"-x-(:class:`~pyarts3.arts." << wsv.type << "` "
-     << unwrap_stars(wsv.desc) << "\n\n";
+  os << "    }, R\"-x-(" << unwrap_stars(wsv.desc) << "\n\n";
 
   if (wsv.type == "Agenda") {
     os << get_agenda_io(name);
@@ -59,7 +58,8 @@ std::string variable(const std::string& name,
 
   os << variable_used_by(name) << '\n';
 
-  return fix_newlines(os.str()) + ")-x-\");\n\n";
+  return fix_newlines(os.str()) + "\n.. :class:`~pyarts3.arts." + wsv.type +
+         "`\n)-x-\");\n\n";
 } catch (std::exception& e) {
   std::cerr << "Error in variable " << '"' << name << '"' << ":\n"
             << e.what() << '\n';

--- a/src/python_interface/hpy_matpack.h
+++ b/src/python_interface/hpy_matpack.h
@@ -35,7 +35,7 @@ void matpack_common_interface(py::class_<mtype>& c) {
       [](py::object& x) { return x.attr("__array__")(); },
       [](mtype& a, const mtype& b) { a = b; },
       py::for_getter(py::rv_policy::reference_internal),
-      "A :class:`~numpy.ndarray` of the object.");
+      "A :class:`~numpy.ndarray` of the object.\n\n.. :class:`~numpy.ndarray`");
 
   c.def("__getstate__",
         [](const py::object& v) { return std::tuple{v.attr("__array__")()}; });
@@ -82,7 +82,7 @@ void matpack_interface(py::class_<matpack::data_t<T, ndim>>& c) {
         if (not dtype.is_none()) {
           return np.attr("asarray")(x, "dtype"_a = dtype, "copy"_a = copy);
         }
-  
+
         return x.cast((copy.is_none() or not py::bool_(copy))
                           ? py::rv_policy::automatic_reference
                           : py::rv_policy::copy);
@@ -109,7 +109,7 @@ void matpack_constant_interface(py::class_<matpack::cdata_t<T, ndim...>>& c) {
       },
       "a"_a);
 
-  c.def_rw("data", &mtype::data, "The data itself");
+  c.def_rw("data", &mtype::data, "The data itself\n\n.. :class:`object`");
 
   c.def(
       "__array__",
@@ -250,18 +250,23 @@ void gridded_data_interface(
         "grid_names"_a = std::array<String, dim>{},
         "grids"_a);
 
-  c.def_rw("dataname", &mtype::data_name, "Name of the data");
+  c.def_rw(
+      "dataname", &mtype::data_name, "Name of the data\n\n.. :class:`String`");
 
-  c.def_rw("data", &mtype::data, "The data itself");
+  c.def_rw("data", &mtype::data, "The data itself\n\n.. :class:`object`");
 
-  c.def_rw("gridnames", &mtype::grid_names, "The grid names");
+  c.def_rw("gridnames",
+           &mtype::grid_names,
+           "The grid names\n\n.. :class:`list[str]`");
 
-  c.def_rw("grids", &mtype::grids, "The grid of the data");
+  c.def_rw("grids",
+           &mtype::grids,
+           "The grid of the data\n\n.. :class:`list[object]`");
 
   c.def_prop_ro_static(
       "dim",
       [](const py::object&) { return mtype::dim; },
-      "Dimension of the field");
+      "Dimension of the field\n\n.. :class:`int`");
 
   c.def("ok", &mtype::ok, "Check the field");
 
@@ -280,7 +285,7 @@ void gridded_data_interface(
       [](py::object& x) { return x.attr("__array__")("copy"_a = false); },
       [](mtype& a, const mtype& b) { a = b; },
       py::for_getter(py::rv_policy::reference_internal),
-      "A :class:`~numpy.ndarray` of the object.");
+      "A :class:`~numpy.ndarray` of the object.\n\n.. :class:`numpy.ndarray`");
 
   c.def(
       "to_dict",

--- a/src/python_interface/hpy_numpy.h
+++ b/src/python_interface/hpy_numpy.h
@@ -201,49 +201,62 @@ void common_ndarray(auto& c) {
 
   c.def("__xor__", &npxor, "value"_a, "See :attr:`numpy.ndarray.__xor__`");
 
-  c.def_prop_ro("T", &npT, "See :attr:`numpy.ndarray.T`");
+  c.def_prop_ro(
+      "T", &npT, "See :attr:`numpy.ndarray.T`.\n\n.. :class:`object`");
 
   // Renamed to behave as data_ as the return type is similar
   c.def_prop_ro("_base",
                 &np_base,
                 py::keep_alive<0, 1>{},
-                "See :attr:`numpy.ndarray.base`");
+                "See :attr:`numpy.ndarray.base`.\n\n.. :class:`object`");
 
   // Renamed because we often have properties with the same name
   c.def_prop_ro("_data",
                 &np_data,
                 py::keep_alive<0, 1>{},
-                "See :attr:`numpy.ndarray.data`");
+                "See :attr:`numpy.ndarray.data`.\n\n.. :class:`object`");
 
-  c.def_prop_ro("dtype", &npdtype, "See :attr:`numpy.ndarray.dtype`");
+  c.def_prop_ro("dtype",
+                &npdtype,
+                "See :attr:`numpy.ndarray.dtype`.\n\n.. :class:`object`");
 
   // Renamed to behave as data_ as the return type is similar
   c.def_prop_ro("_flat",
                 &np_flat,
                 py::keep_alive<0, 1>{},
-                "See :attr:`numpy.ndarray.flat`");
+                "See :attr:`numpy.ndarray.flat`.\n\n.. :class:`object`");
 
   c.def_prop_ro("imag",
                 &npimag,
                 py::keep_alive<0, 1>{},
-                "See :attr:`numpy.ndarray.imag`");
+                "See :attr:`numpy.ndarray.imag`.\n\n.. :class:`object`");
 
-  c.def_prop_ro("itemsize", &npitemsize, "See :attr:`numpy.ndarray.itemsize`");
+  c.def_prop_ro("itemsize",
+                &npitemsize,
+                "See :attr:`numpy.ndarray.itemsize`.\n\n.. :class:`object`");
 
-  c.def_prop_ro("nbytes", &npnbytes, "See :attr:`numpy.ndarray.nbytes`");
+  c.def_prop_ro("nbytes",
+                &npnbytes,
+                "See :attr:`numpy.ndarray.nbytes`.\n\n.. :class:`object`");
 
-  c.def_prop_ro("ndim", &npndim, "See :attr:`numpy.ndarray.ndim`");
+  c.def_prop_ro(
+      "ndim", &npndim, "See :attr:`numpy.ndarray.ndim`.\n\n.. :class:`object`");
 
   c.def_prop_ro("real",
                 &npreal,
                 py::keep_alive<0, 1>{},
-                "See :attr:`numpy.ndarray.real`");
+                "See :attr:`numpy.ndarray.real`.\n\n.. :class:`object`");
 
-  c.def_prop_ro("shape", &npshape, "See :attr:`numpy.ndarray.shape`");
+  c.def_prop_ro("shape",
+                &npshape,
+                "See :attr:`numpy.ndarray.shape`.\n\n.. :class:`object`");
 
-  c.def_prop_ro("size", &npsize, "See :attr:`numpy.ndarray.size`");
+  c.def_prop_ro(
+      "size", &npsize, "See :attr:`numpy.ndarray.size`.\n\n.. :class:`object`");
 
-  c.def_prop_ro("strides", &npstrides, "See :attr:`numpy.ndarray.strides`");
+  c.def_prop_ro("strides",
+                &npstrides,
+                "See :attr:`numpy.ndarray.strides`.\n\n.. :class:`object`");
 
   c.def("flatten",
         &npflatten,

--- a/src/python_interface/py_agenda.cpp
+++ b/src/python_interface/py_agenda.cpp
@@ -77,7 +77,9 @@ void py_agenda(py::module_& m) try {
   py::class_<Wsv> wsv(m, "Wsv");
   generic_interface(wsv);
   wsv.def_prop_ro(
-         "value", [](Wsv& v) { return to_py(v); }, "A workspace variable")
+         "value",
+         [](Wsv& v) { return to_py(v); },
+         "A workspace variable.\n\n.. :class:`~pyarts3.arts.Any`")
       .doc() = "A workspace variable wrapper - no manual use required";
 
   py::class_<Method> methods(m, "Method");
@@ -110,11 +112,11 @@ void py_agenda(py::module_& m) try {
             if (x) return to_py(x.value());
             return py::none();
           },
-          "The value (if any) of a set method")
+          "The value (if any) of a set method.\n\n.. :class:`~pyarts3.arts.Wsv`.\n\n.. :class:`None`")
       .def_prop_ro(
           "name",
           [](const Method& method) { return method.get_name(); },
-          "The name of the method")
+          "The name of the method.\n\n.. :class:`str`")
       .doc() = "The method class of ARTS";
 
   py::class_<Agenda> ag(m, "Agenda");
@@ -150,11 +152,11 @@ so Copy(a, out=b) will not even see the b variable.
       .def_prop_ro(
           "name",
           [](const Agenda& agenda) { return agenda.get_name(); },
-          "The name of the agenda")
+          "The name of the agenda.\n\n.. :class:`str`")
       .def_prop_ro(
           "methods",
           [](const Agenda& agenda) { return agenda.get_methods(); },
-          "The methods of the agenda");
+          "The methods of the agenda.\n\n.. :class:`list[~pyarts3.arts.Method]`");
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format("DEV ERROR:\nCannot initialize agendas\n{}", e.what()));

--- a/src/python_interface/py_atm.cpp
+++ b/src/python_interface/py_atm.cpp
@@ -1,6 +1,7 @@
 #include <atm.h>
 #include <atm_path.h>
 #include <debug.h>
+#include <hpy_arts.h>
 #include <nanobind/stl/array.h>
 #include <nanobind/stl/bind_vector.h>
 #include <nanobind/stl/function.h>
@@ -16,8 +17,6 @@
 #include <stdexcept>
 #include <unordered_map>
 
-#include <hpy_arts.h>
-
 namespace Python {
 void py_atm(py::module_ &m) try {
   py::class_<Atm::Data> atmdata(m, "AtmData");
@@ -32,13 +31,34 @@ void py_atm(py::module_ &m) try {
           },
           "v"_a,
           "Initialize with a gridded field")
-      .def_rw("data", &Atm::Data::data, "The data")
-      .def_rw("alt_upp", &Atm::Data::alt_upp, "Upper altitude limit")
-      .def_rw("alt_low", &Atm::Data::alt_low, "Lower altitude limit")
-      .def_rw("lat_upp", &Atm::Data::lat_upp, "Upper latitude limit")
-      .def_rw("lat_low", &Atm::Data::lat_low, "Lower latitude limit")
-      .def_rw("lon_upp", &Atm::Data::lon_upp, "Upper longitude limit")
-      .def_rw("lon_low", &Atm::Data::lon_low, "Lower longitude limit")
+      .def_rw(
+          "data",
+          &Atm::Data::data,
+          "The data.\n\n.. :class:`~pyarts3.arts.GeodeticField3`\n\n.. :class:`~pyarts3.arts.Numeric`\n\n.. :class:`~pyarts3.arts.NumericTernaryOperator`")
+      .def_rw(
+          "alt_upp",
+          &Atm::Data::alt_upp,
+          "Upper altitude limit\n\n.. :class:`~pyarts3.arts.InterpolationExtrapolation`")
+      .def_rw(
+          "alt_low",
+          &Atm::Data::alt_low,
+          "Lower altitude limit\n\n.. :class:`~pyarts3.arts.InterpolationExtrapolation`")
+      .def_rw(
+          "lat_upp",
+          &Atm::Data::lat_upp,
+          "Upper latitude limit\n\n.. :class:`~pyarts3.arts.InterpolationExtrapolation`")
+      .def_rw(
+          "lat_low",
+          &Atm::Data::lat_low,
+          "Lower latitude limit\n\n.. :class:`~pyarts3.arts.InterpolationExtrapolation`")
+      .def_rw(
+          "lon_upp",
+          &Atm::Data::lon_upp,
+          "Upper longitude limit\n\n.. :class:`~pyarts3.arts.InterpolationExtrapolation`")
+      .def_rw(
+          "lon_low",
+          &Atm::Data::lon_low,
+          "Lower longitude limit\n\n.. :class:`~pyarts3.arts.InterpolationExtrapolation`")
       .def(
           "set_extrapolation",
           [](Atm::Data &self, InterpolationExtrapolation x) {
@@ -69,7 +89,9 @@ void py_atm(py::module_ &m) try {
           "lat"_a,
           "lon"_a,
           "Get the weights of neighbors at a position")
-      .def_prop_ro("data_type", &Atm::Data::data_type, "The data type")
+      .def_prop_ro("data_type",
+                   &Atm::Data::data_type,
+                   "The data type\n\n.. :class:`~pyarts3.arts.String`")
       .def("__getstate__",
            [](const Atm::Data &t) {
              return std::make_tuple(t.data,
@@ -114,10 +136,18 @@ void py_atm(py::module_ &m) try {
   auto fld = py::class_<AtmField>(m, "AtmField");
   generic_interface(fld);
 
-  pnt.def_rw("temperature", &AtmPoint::temperature, "Temperature [K]")
-      .def_rw("pressure", &AtmPoint::pressure, "Pressure [Pa]")
-      .def_rw("mag", &AtmPoint::mag, "Magnetic field [T]")
-      .def_rw("wind", &AtmPoint::wind, "Wind field [m/s]")
+  pnt.def_rw("temperature",
+             &AtmPoint::temperature,
+             "Temperature [K]\n\n.. :class:`~pyarts3.arts.Numeric`")
+      .def_rw("pressure",
+              &AtmPoint::pressure,
+              "Pressure [Pa]\n\n.. :class:`~pyarts3.arts.Numeric`")
+      .def_rw("mag",
+              &AtmPoint::mag,
+              "Magnetic field [T]\n\n.. :class:`~pyarts3.arts.Vector3`")
+      .def_rw("wind",
+              &AtmPoint::wind,
+              "Wind field [m/s]\n\n.. :class:`~pyarts3.arts.Vector3`")
       .def(
           "number_density",
           [](AtmPoint &atm, std::variant<SpeciesEnum, SpeciesIsotope> key) {
@@ -305,7 +335,7 @@ Parameters
           "Get the data as a list")
       .def_rw("top_of_atmosphere",
               &AtmField::top_of_atmosphere,
-              "Top of the atmosphere [m]");
+              "Top of the atmosphere [m]\n\n.. :class:`~pyarts3.arts.Numeric`");
 
   m.def(
       "frequency_shift",
@@ -622,9 +652,6 @@ Parameters
            [](AtmField &self, const AtmKeyVal &key, const Atm::Data &x) {
              self[key] = x;
            })
-      .def_rw("top_of_atmosphere",
-              &AtmField::top_of_atmosphere,
-              "Top of the atmosphere [m]")
       .def("__getstate__",
            [](const AtmField &t) {
              auto k = t.keys();
@@ -654,11 +681,30 @@ Parameters
                   k[i]) = v[i];
           });
 
-  fld.def_rw("nlte", &AtmField::nlte, "NLTE data");
-  fld.def_rw("specs", &AtmField::specs, "Species data");
-  fld.def_rw("isots", &AtmField::isots, "Isotopologue ratio data");
-  fld.def_rw("other", &AtmField::other, "Basic atmospheric data");
-  fld.def_rw("ssprops", &AtmField::ssprops, "Scattering species properties data");
+  fld.def_rw(
+      "nlte",
+      &AtmField::nlte,
+      "NLTE data\n\n.. :class:`dict[~pyarts3.arts.QuantumIdentifier, ~pyarts3.arts.AtmData]`");
+
+  fld.def_rw(
+      "specs",
+      &AtmField::specs,
+      "Species data\n\n.. :class:`dict[~pyarts3.arts.SpeciesEnum, ~pyarts3.arts.AtmData]`");
+
+  fld.def_rw(
+      "isots",
+      &AtmField::isots,
+      "Isotopologue ratio data\n\n.. :class:`dict[~pyarts3.arts.SpeciesIsotope, ~pyarts3.arts.AtmData]`");
+
+  fld.def_rw(
+      "other",
+      &AtmField::other,
+      "Basic atmospheric data\n\n.. :class:`dict[~pyarts3.arts.AtmKey, ~pyarts3.arts.AtmData]`");
+
+  fld.def_rw(
+      "ssprops",
+      &AtmField::ssprops,
+      "Scattering species properties data\n\n.. :class:`dict[~pyarts3.arts.ScatteringSpeciesProperty, ~pyarts3.arts.AtmData]`");
 
   pnt.def(
       "to_dict",

--- a/src/python_interface/py_basic.cpp
+++ b/src/python_interface/py_basic.cpp
@@ -52,7 +52,7 @@ void py_basic(py::module_& m) try {
           "value",
           [](py::object& x) { return x.attr("__array__")(); },
           [](ValueHolder<Numeric>& a, const ValueHolder<Numeric>& b) { a = b; },
-          "A :class:`~numpy.ndarray` of the object.");
+          "A :class:`~numpy.ndarray` of the object.\n\n.. :class:`numpy.ndarray`");
   common_ndarray(num);
 
   py::class_<ValueHolder<Index>> ind(m, "Index");
@@ -84,7 +84,7 @@ void py_basic(py::module_& m) try {
           "value",
           [](py::object& x) { return x.attr("__array__")(); },
           [](ValueHolder<Index>& a, const ValueHolder<Index>& b) { a = b; },
-          "A :class:`~numpy.ndarray` of the object.");
+          "A :class:`~numpy.ndarray` of the object.\n\n.. :class:`numpy.ndarray`");
   common_ndarray(ind);
 
   auto aos = py::class_<ArrayOfString>(m, "ArrayOfString");
@@ -118,7 +118,7 @@ void py_basic(py::module_& m) try {
           "value",
           [](py::object& x) { return x.attr("__array__")(); },
           [](ArrayOfIndex& a, const ArrayOfIndex& b) { a = b; },
-          "A :class:`~numpy.ndarray` of the object.");
+          "A :class:`~numpy.ndarray` of the object.\n\n.. :class:`numpy.ndarray`");
   common_ndarray(aoi);
   value_holder_vector_interface(aoi);
   generic_interface(aoi);
@@ -151,7 +151,7 @@ void py_basic(py::module_& m) try {
           "value",
           [](py::object& x) { return x.attr("__array__")(); },
           [](ArrayOfNumeric& a, const ArrayOfNumeric& b) { a = b; },
-          "A :class:`~numpy.ndarray` of the object.")
+          "A :class:`~numpy.ndarray` of the object.\n\n.. :class:`numpy.ndarray`")
       .doc() = "A list of :class:`~pyarts3.arts.Numeric`";
   common_ndarray(aon);
   value_holder_vector_interface(aon);

--- a/src/python_interface/py_cia.cpp
+++ b/src/python_interface/py_cia.cpp
@@ -23,11 +23,11 @@ void py_cia(py::module_& m) try {
       .def_prop_ro(
           "specs",
           [](const CIARecord& c) { return c.TwoSpecies(); },
-          ":class:`list` The two species")
+          "The two species\n\n.. :class:`tuple[pyarts3.arts.SpeciesEnum, pyarts3.arts.SpeciesEnum]`")
       .def_prop_ro(
           "data",
           [](const CIARecord& c) { return c.Data(); },
-          ":class:`~pyarts3.arts.ArrayOfGriddedField2` Data by bands")
+          "Data by bands\n\n.. :class:`~pyarts3.arts.ArrayOfGriddedField2`")
       .def(
           "propagation_matrix",
           [](const CIARecord& self,

--- a/src/python_interface/py_disort.cpp
+++ b/src/python_interface/py_disort.cpp
@@ -224,48 +224,48 @@ void py_disort(py::module_& m) try {
   generic_interface(disort_settings);
   disort_settings.def_rw("quadrature_dimension",
                          &DisortSettings::quadrature_dimension,
-                         ":class:`Index`");
+                         ".. :class:`Index`");
   disort_settings.def_rw("legendre_polynomial_dimension",
                          &DisortSettings::legendre_polynomial_dimension,
-                         ":class:`Index`");
+                         ".. :class:`Index`");
   disort_settings.def_rw("fourier_mode_dimension",
                          &DisortSettings::fourier_mode_dimension,
-                         ":class:`Index`");
-  disort_settings.def_rw("nfreq", &DisortSettings::nfreq, ":class:`Index`");
-  disort_settings.def_rw("nlay", &DisortSettings::nlay, ":class:`Index`");
+                         ".. :class:`Index`");
+  disort_settings.def_rw("nfreq", &DisortSettings::nfreq, ".. :class:`Index`");
+  disort_settings.def_rw("nlay", &DisortSettings::nlay, ".. :class:`Index`");
   disort_settings.def_rw("solar_azimuth_angle",
                          &DisortSettings::solar_azimuth_angle,
-                         ":class:`Vector`");
+                         ".. :class:`Vector`");
   disort_settings.def_rw("solar_zenith_angle",
                          &DisortSettings::solar_zenith_angle,
-                         ":class:`Vector`");
+                         ".. :class:`Vector`");
   disort_settings.def_rw(
-      "solar_source", &DisortSettings::solar_source, ":class:`Vector`");
+      "solar_source", &DisortSettings::solar_source, ".. :class:`Vector`");
   disort_settings.def_rw(
       "bidirectional_reflectance_distribution_functions",
       &DisortSettings::bidirectional_reflectance_distribution_functions,
-      ":class:`MatrixOfDisortBDRF`");
+      ".. :class:`MatrixOfDisortBDRF`");
   disort_settings.def_rw("optical_thicknesses",
                          &DisortSettings::optical_thicknesses,
-                         ":class:`Matrix`");
+                         ".. :class:`Matrix`");
   disort_settings.def_rw("single_scattering_albedo",
                          &DisortSettings::single_scattering_albedo,
-                         ":class:`Matrix`");
+                         ".. :class:`Matrix`");
   disort_settings.def_rw("fractional_scattering",
                          &DisortSettings::fractional_scattering,
-                         ":class:`Matrix`");
+                         ".. :class:`Matrix`");
   disort_settings.def_rw("source_polynomial",
                          &DisortSettings::source_polynomial,
-                         ":class:`Tensor3`");
+                         ".. :class:`Tensor3`");
   disort_settings.def_rw("legendre_coefficients",
                          &DisortSettings::legendre_coefficients,
-                         ":class:`Tensor3`");
+                         ".. :class:`Tensor3`");
   disort_settings.def_rw("positive_boundary_condition",
                          &DisortSettings::positive_boundary_condition,
-                         ":class:`Tensor3`");
+                         ".. :class:`Tensor3`");
   disort_settings.def_rw("negative_boundary_condition",
                          &DisortSettings::negative_boundary_condition,
-                         ":class:`Tensor3`");
+                         ".. :class:`Tensor3`");
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format("DEV ERROR:\nCannot initialize disort\n{}", e.what()));

--- a/src/python_interface/py_fwd.cpp
+++ b/src/python_interface/py_fwd.cpp
@@ -33,7 +33,8 @@ void py_fwd(py::module_& m) try {
             StokvecVector out(frequency.size());
 
             if (arts_omp_in_parallel() or arts_omp_get_max_threads() == 1 or
-                static_cast<Index>(frequency.size()) < arts_omp_get_max_threads()) {
+                static_cast<Index>(frequency.size()) <
+                    arts_omp_get_max_threads()) {
               std::transform(
                   frequency.begin(),
                   frequency.end(),
@@ -51,7 +52,7 @@ void py_fwd(py::module_& m) try {
                 }
               }
 
-              if(not error.empty()) throw std::runtime_error(error);
+              if (not error.empty()) throw std::runtime_error(error);
             }
             return out;
           },
@@ -59,9 +60,10 @@ void py_fwd(py::module_& m) try {
           "pos"_a,
           "los"_a,
           "Geometric planar spectral radiance")
-      .def_prop_ro("altitude",
-                   &SpectralRadianceOperator::altitude,
-                   "The altitude of the top of the atmosphere [m]");
+      .def_prop_ro(
+          "altitude",
+          &SpectralRadianceOperator::altitude,
+          "The altitude of the top of the atmosphere [m]\n\n.. :class:`AscendingGrid`");
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format("DEV ERROR:\nCannot initialize fwd\n{}", e.what()));

--- a/src/python_interface/py_global.cpp
+++ b/src/python_interface/py_global.cpp
@@ -59,22 +59,22 @@ void py_global(py::module_& m) try {
   global.doc() = "Global settings and data";
 
   py::class_<Parameters>(global, "parameters")
-      .def_rw_static(
-          "includepath",
-          &parameters.includepath,
-          ":class:`~pyarts3.arts.ArrayOfString` Automatic include paths")
+      .def_rw_static("includepath",
+                     &parameters.includepath,
+                     "Automatic include paths\n\n.. :class:`ArrayOfString`")
       .def_rw_static("datapath",
                      &parameters.datapath,
-                     ":class:`~pyarts3.arts.ArrayOfString` Automatic data paths")
-      .def_rw_static(
-          "numthreads",
-          &parameters.numthreads,
-          ":class:`~pyarts3.arts.Index` Number of threads allowed to start")
+                     "Automatic data paths\n\n.. :class:`ArrayOfString`")
+      .def_rw_static("numthreads",
+                     &parameters.numthreads,
+                     "Number of threads allowed to start\n\n.. :class:`Index`")
       .doc() = "Access to static settings data";
 
   py::class_<WorkspaceGroupRecord>(global, "WorkspaceGroupRecord")
-      .def_ro("file", &WorkspaceGroupRecord::file, "File path")
-      .def_ro("desc", &WorkspaceGroupRecord::desc, "Description")
+      .def_ro(
+          "file", &WorkspaceGroupRecord::file, "File path\n\n.. :class:`str`")
+      .def_ro(
+          "desc", &WorkspaceGroupRecord::desc, "Description\n\n.. :class:`str`")
       .doc() = "Workspace group records";
 
   global.def(
@@ -90,9 +90,11 @@ Return
   py::class_<WorkspaceVariableRecord>(global, "WorkspaceVariableRecord")
       .def_ro("default_value",
               &WorkspaceVariableRecord::default_value,
-              "Default value")
-      .def_ro("type", &WorkspaceVariableRecord::type, "Type")
-      .def_ro("desc", &WorkspaceVariableRecord::desc, "Description")
+              "Default value\n\n.. :class:`Wsv`\n\n.. :class:`None`")
+      .def_ro("type", &WorkspaceVariableRecord::type, "Type\n\n.. :class:`str`")
+      .def_ro("desc",
+              &WorkspaceVariableRecord::desc,
+              "Description\n\n.. :class:`str`")
       .doc() = "Workspace variable records";
 
   global.def(
@@ -107,30 +109,42 @@ Return
 
   py::class_<WorkspaceMethodInternalRecord>(global,
                                             "WorkspaceMethodInternalRecord")
-      .def_ro("output", &WorkspaceMethodInternalRecord::out, "Outputs")
-      .def_ro("input", &WorkspaceMethodInternalRecord::in, "Inputs")
-      .def_ro("author", &WorkspaceMethodInternalRecord::author, "Authors")
-      .def_ro("gout", &WorkspaceMethodInternalRecord::gout, "Generic output")
+      .def_ro("output",
+              &WorkspaceMethodInternalRecord::out,
+              "Outputs\n\n.. :class:`list[str]`")
+      .def_ro("input",
+              &WorkspaceMethodInternalRecord::in,
+              "Inputs\n\n.. :class:`list[str]`")
+      .def_ro("author",
+              &WorkspaceMethodInternalRecord::author,
+              "Authors\n\n.. :class:`list[str]`")
+      .def_ro("gout",
+              &WorkspaceMethodInternalRecord::gout,
+              "Generic output\n\n.. :class:`list[str]`")
       .def_ro("gout_type",
               &WorkspaceMethodInternalRecord::gout_type,
-              "Generic output type")
+              "Generic output type\n\n.. :class:`list[str]`")
       .def_ro("gout_desc",
               &WorkspaceMethodInternalRecord::gout_desc,
-              "Generic output description")
-      .def_ro("gin", &WorkspaceMethodInternalRecord::gin, "Generic input")
+              "Generic output description\n\n.. :class:`list[str]`")
+      .def_ro("gin",
+              &WorkspaceMethodInternalRecord::gin,
+              "Generic input\n\n.. :class:`list[str]`")
       .def_ro("gin_type",
               &WorkspaceMethodInternalRecord::gin_type,
-              "Generic input type")
+              "Generic input type\n\n.. :class:`list[str]`")
       .def_ro("gin_desc",
               &WorkspaceMethodInternalRecord::gin_desc,
-              "Generic input description")
+              "Generic input description\n\n.. :class:`list[str]`")
       .def_ro("gin_value",
               &WorkspaceMethodInternalRecord::gin_value,
-              "Generic input default value")
+              "Generic input default value\n\n.. :class:`list[Wsv | None]`")
       .def_ro("pass_workspace",
               &WorkspaceMethodInternalRecord::pass_workspace,
-              "Pass workspace")
-      .def_ro("desc", &WorkspaceMethodInternalRecord::desc, "Description")
+              "Pass workspace\n\n.. :class:`bool`")
+      .def_ro("desc",
+              &WorkspaceMethodInternalRecord::desc,
+              "Description\n\n.. :class:`str`")
       .doc() = "Method records used as workspace variables";
 
   global.def(
@@ -145,9 +159,15 @@ Return
 
   py::class_<WorkspaceAgendaInternalRecord>(global,
                                             "WorkspaceAgendaInternalRecord")
-      .def_ro("desc", &WorkspaceAgendaInternalRecord::desc, "Description")
-      .def_ro("output", &WorkspaceAgendaInternalRecord::output, "Outputs")
-      .def_ro("input", &WorkspaceAgendaInternalRecord::input, "Inputs")
+      .def_ro("desc",
+              &WorkspaceAgendaInternalRecord::desc,
+              "Description\n\n.. :class:`str`")
+      .def_ro("output",
+              &WorkspaceAgendaInternalRecord::output,
+              "Outputs\n\n.. :class:`list[str]`")
+      .def_ro("input",
+              &WorkspaceAgendaInternalRecord::input,
+              "Inputs\n\n.. :class:`list[str]`")
       .doc() = "Agenda records used as workspace variables";
 
   global.def(
@@ -206,21 +226,23 @@ Parameters
       .def_ro_static(
           "is_lgpl",
           &global_data::is_lgpl,
-          "Whether the ARTS library is compiled licensed under the LGPL")
+          "Whether the ARTS library is compiled licensed under the LGPL\n\n.. :class:`bool`")
       .def_ro_static(
           "has_sht",
           &global_data::has_sht,
-          "Whether the ARTS library is compiled to be able to use the SHT library")
+          "Whether the ARTS library is compiled to be able to use the SHT library\n\n.. :class:`bool`")
       .def_ro_static(
           "has_cdisort",
           &global_data::has_cdisort,
-          "Whether the ARTS library is compiled with CDisort support")
-      .def_ro_static("has_profiling",
-                     &global_data::has_profiling,
-                     "Whether the ARTS library is compiled with time profiling")
-      .def_ro_static("arts_source_dir",
-                     &global_data::arts_source_dir,
-                     "The original ARTS source directory, if available")
+          "Whether the ARTS library is compiled with CDisort support\n\n.. :class:`bool`")
+      .def_ro_static(
+          "has_profiling",
+          &global_data::has_profiling,
+          "Whether the ARTS library is compiled with time profiling\n\n.. :class:`bool`")
+      .def_ro_static(
+          "arts_source_dir",
+          &global_data::arts_source_dir,
+          "The original ARTS source directory, if available\n\n.. :class:`str`")
       .def("__repr__",
            [](const global_data&) {
              return std::format(R"(Global state of ARTS:

--- a/src/python_interface/py_interp.cpp
+++ b/src/python_interface/py_interp.cpp
@@ -40,10 +40,14 @@ py::class_<T>& interp_class_(py::class_<T>& cl) {
       .def_prop_ro(
           "order",
           [](const T& l) { return l.size() - 1; },
-          "The order of interpolation")
-      .def_rw("indx", &T::indx, "The interpolation positions")
-      .def_rw("data", &T::data, "The interpolation weights")
-      .def("__len__", &T::size, "The interpolation size")
+          "The order of interpolation\n\n.. :class:`Index`")
+      .def_rw("indx",
+              &T::indx,
+              "The interpolation positions\n\n.. :class:`list[Index]`")
+      .def_rw("data",
+              &T::data,
+              "The interpolation weights\n\n.. :class:`list[Numeric]`")
+      .def("__len__", &T::size, "The interpolation size\n\n.. :class:`Index`")
       .def("__getstate__",
            [](const T& self) { return std::make_tuple(self.indx, self.data); })
       .def("__setstate__",
@@ -100,6 +104,7 @@ void py_interp(py::module_& m) {
       py::bind_vector<std::vector<lc>, py::rv_policy::reference_internal>(
           interp, "ArrayOfLagrangeCyclic");
   interp_vec_class(vid_).doc() = "List of :class:`~pyarts3.arts.Lagrange`";
-  interp_vec_class(vlc_).doc() = "List of :class:`~pyarts3.arts.LagrangeCyclic`";
+  interp_vec_class(vlc_).doc() =
+      "List of :class:`~pyarts3.arts.LagrangeCyclic`";
 }
 }  // namespace Python

--- a/src/python_interface/py_jac.cpp
+++ b/src/python_interface/py_jac.cpp
@@ -19,77 +19,104 @@ namespace Python {
 void py_jac(py::module_& m) try {
   py::class_<ErrorKey> errkey(m, "ErrorKey");
   errkey.doc() = "Error key";
-  errkey.def_rw("y_start",
-                &ErrorKey::y_start,
-                "Start index of target in measurement vector");
   errkey.def_rw(
-      "y_size", &ErrorKey::y_size, "Size of target in measurement vector");
+      "y_start",
+      &ErrorKey::y_start,
+      "Start index of target in measurement vector\n\n.. :class:`Index`");
+  errkey.def_rw("y_size",
+                &ErrorKey::y_size,
+                "Size of target in measurement vector\n\n.. :class:`Index`");
 
   py::class_<Jacobian::AtmTarget> atm(m, "JacobianAtmTarget");
   atm.doc() = "Atmospheric target";
-  atm.def_ro("type", &Jacobian::AtmTarget::type, "Type of target");
-  atm.def_ro("d", &Jacobian::AtmTarget::d, "Perturbation magnitude");
-  atm.def_ro("target_pos", &Jacobian::AtmTarget::target_pos, "Target position");
+  atm.def_ro("type",
+             &Jacobian::AtmTarget::type,
+             "Type of target\n\n.. :class:`AtmKeyVal`");
+  atm.def_ro("d",
+             &Jacobian::AtmTarget::d,
+             "Perturbation magnitude\n\n.. :class:`Numeric`");
+  atm.def_ro("target_pos",
+             &Jacobian::AtmTarget::target_pos,
+             "Target position\n\n.. :class:`Index`");
   atm.def_ro("x_start",
              &Jacobian::AtmTarget::x_start,
-             "Start index of target in state vector");
-  atm.def_ro(
-      "x_size", &Jacobian::AtmTarget::x_size, "Size of target in state vector");
+             "Start index of target in state vector\n\n.. :class:`Index`");
+  atm.def_ro("x_size",
+             &Jacobian::AtmTarget::x_size,
+             "Size of target in state vector\n\n.. :class:`Index`");
   str_interface(atm);
 
   py::class_<Jacobian::SurfaceTarget> surf(m, "JacobianSurfaceTarget");
   surf.doc() = "Surface target";
-  surf.def_ro("type", &Jacobian::SurfaceTarget::type, "Type of target");
-  surf.def_ro("d", &Jacobian::SurfaceTarget::d, "Perturbation magnitude");
-  surf.def_ro(
-      "target_pos", &Jacobian::SurfaceTarget::target_pos, "Target position");
+  surf.def_ro("type",
+              &Jacobian::SurfaceTarget::type,
+              "Type of target\n\n.. :class:`SurfaceKeyVal`");
+  surf.def_ro("d",
+              &Jacobian::SurfaceTarget::d,
+              "Perturbation magnitude\n\n.. :class:`Numeric`");
+  surf.def_ro("target_pos",
+              &Jacobian::SurfaceTarget::target_pos,
+              "Target position\n\n.. :class:`Index`");
   surf.def_ro("x_start",
               &Jacobian::SurfaceTarget::x_start,
-              "Start index of target in state vector");
+              "Start index of target in state vector\n\n.. :class:`Index`");
   surf.def_ro("x_size",
               &Jacobian::SurfaceTarget::x_size,
-              "Size of target in state vector");
+              "Size of target in state vector\n\n.. :class:`Index`");
   str_interface(surf);
 
   py::class_<Jacobian::LineTarget> line(m, "JacobianLineTarget");
   line.doc() = "Line target";
-  line.def_ro("type", &Jacobian::LineTarget::type, "Type of target");
-  line.def_ro("d", &Jacobian::LineTarget::d, "Perturbation magnitude");
-  line.def_ro(
-      "target_pos", &Jacobian::LineTarget::target_pos, "Target position");
+  line.def_ro("type",
+              &Jacobian::LineTarget::type,
+              "Type of target\n\n.. :class:`LineKeyVal`");
+  line.def_ro("d",
+              &Jacobian::LineTarget::d,
+              "Perturbation magnitude\n\n.. :class:`Numeric`");
+  line.def_ro("target_pos",
+              &Jacobian::LineTarget::target_pos,
+              "Target position\n\n.. :class:`Index`");
   line.def_ro("x_start",
               &Jacobian::LineTarget::x_start,
-              "Start index of target in state vector");
+              "Start index of target in state vector\n\n.. :class:`Index`");
   line.def_ro("x_size",
               &Jacobian::LineTarget::x_size,
-              "Size of target in state vector");
+              "Size of target in state vector\n\n.. :class:`Index`");
   str_interface(line);
 
   py::class_<Jacobian::SensorTarget> sensor(m, "JacobianSensorTarget");
   sensor.doc() = "Sensor target";
-  sensor.def_ro("type", &Jacobian::SensorTarget::type, "Type of target");
-  sensor.def_ro("d", &Jacobian::SensorTarget::d, "Perturbation magnitude");
-  sensor.def_ro(
-      "target_pos", &Jacobian::SensorTarget::target_pos, "Target position");
+  sensor.def_ro("type",
+                &Jacobian::SensorTarget::type,
+                "Type of target\n\n.. :class:`SensorKeyVal`");
+  sensor.def_ro("d",
+                &Jacobian::SensorTarget::d,
+                "Perturbation magnitude\n\n.. :class:`Numeric`");
+  sensor.def_ro("target_pos",
+                &Jacobian::SensorTarget::target_pos,
+                "Target position\n\n.. :class:`Index`");
   sensor.def_ro("x_start",
                 &Jacobian::SensorTarget::x_start,
-                "Start index of target in state vector");
+                "Start index of target in state vector\n\n.. :class:`Index`");
   sensor.def_ro("x_size",
                 &Jacobian::SensorTarget::x_size,
-                "Size of target in state vector");
+                "Size of target in state vector\n\n.. :class:`Index`");
   str_interface(sensor);
 
   py::class_<Jacobian::ErrorTarget> error(m, "JacobianErrorTarget");
   error.doc() = "Error target";
-  error.def_ro("type", &Jacobian::ErrorTarget::type, "Type of target");
-  error.def_ro(
-      "target_pos", &Jacobian::ErrorTarget::target_pos, "Target position");
+  error.def_ro("type",
+               &Jacobian::ErrorTarget::type,
+               "Type of target\n\n.. :class:`ErrorKeyVal`");
+  error.def_ro("target_pos",
+               &Jacobian::ErrorTarget::target_pos,
+               "Target position\n\n.. :class:`Index`");
   error.def_ro("x_start",
                &Jacobian::ErrorTarget::x_start,
-               "Start index of target in state vector");
+               "Start index of target in state vector\n\n.. :class:`Index`");
   error.def_ro("x_size",
                &Jacobian::ErrorTarget::x_size,
-               "Size of target in state vector");
+               "Size of target in state vector\n\n.. :class:`Index`");
   str_interface(error);
 
   py::bind_vector<std::vector<Jacobian::AtmTarget>>(m, "ArrayOfAtmTargets")
@@ -106,12 +133,25 @@ void py_jac(py::module_& m) try {
 
   py::class_<JacobianTargets> jacs(m, "JacobianTargets");
   generic_interface(jacs);
-  jacs.def_rw("atm", &JacobianTargets::atm, "List of atmospheric targets");
-  jacs.def_rw("surf", &JacobianTargets::surf, "List of surface targets");
-  jacs.def_rw("subsurf", &JacobianTargets::subsurf, "List of subsurface targets");
-  jacs.def_rw("line", &JacobianTargets::line, "List of line targets");
-  jacs.def_rw("sensor", &JacobianTargets::sensor, "List of sensor targets");
-  jacs.def_rw("error", &JacobianTargets::error, "List of error targets");
+  jacs.def_rw("atm",
+              &JacobianTargets::atm,
+              "List of atmospheric targets\n\n.. :class:`ArrayOfAtmTargets`");
+  jacs.def_rw("surf",
+              &JacobianTargets::surf,
+              "List of surface targets\n\n.. :class:`ArrayOfSurfaceTarget`");
+  jacs.def_rw(
+      "subsurf",
+      &JacobianTargets::subsurf,
+      "List of subsurface targets\n\n.. :class:`ArrayOfSubsurfaceTarget`");
+  jacs.def_rw("line",
+              &JacobianTargets::line,
+              "List of line targets\n\n.. :class:`ArrayOfLineTarget`");
+  jacs.def_rw("sensor",
+              &JacobianTargets::sensor,
+              "List of sensor targets\n\n.. :class:`ArrayOfSensorTarget`");
+  jacs.def_rw("error",
+              &JacobianTargets::error,
+              "List of error targets\n\n.. :class:`ArrayOfErrorTarget`");
   jacs.def("x_size",
            &JacobianTargets::x_size,
            "The size of the model state vector.");

--- a/src/python_interface/py_lbl.cpp
+++ b/src/python_interface/py_lbl.cpp
@@ -28,13 +28,23 @@ void py_lbl(py::module_& m) try {
   auto lbl = m.def_submodule("lbl", "Line-by-line helper functions");
 
   py::class_<lbl::line_key> line_key(lbl, "line_key");
-  line_key.def_rw("band", &lbl::line_key::band, "The band");
-  line_key.def_rw("line", &lbl::line_key::line, "The line");
-  line_key.def_rw("spec", &lbl::line_key::spec, "The species");
-  line_key.def_rw("ls_var", &lbl::line_key::ls_var, "The line shape variable");
+  line_key.def_rw("band",
+                  &lbl::line_key::band,
+                  "The band\n\n.. :class:`QuantumIdentifier`");
+  line_key.def_rw("line", &lbl::line_key::line, "The line\n\n.. :class:`int`");
   line_key.def_rw(
-      "ls_coeff", &lbl::line_key::ls_coeff, "The line shape coefficient");
-  line_key.def_rw("var", &lbl::line_key::var, "The variable");
+      "spec", &lbl::line_key::spec, "The species\n\n.. :class:`int`");
+  line_key.def_rw(
+      "ls_var",
+      &lbl::line_key::ls_var,
+      "The line shape variable\n\n.. :class:`LineShapeModelVariable`");
+  line_key.def_rw(
+      "ls_coeff",
+      &lbl::line_key::ls_coeff,
+      "The line shape coefficient\n\n.. :class:`LineShapeModelCoefficient`");
+  line_key.def_rw("var",
+                  &lbl::line_key::var,
+                  "The variable\n\n.. :class:`LineByLineVariable`");
   line_key.doc() = "A key for a line";
   str_interface(line_key);
 
@@ -48,14 +58,14 @@ void py_lbl(py::module_& m) try {
           [](lbl::temperature::data& self, LineShapeModelType x) {
             self = lbl::temperature::data{x, self.X()};
           },
-          ":class:`~pyarts3.arts.TemperatureModelType` The type of the model")
+          "The type of the model\n\n.. :class:`~pyarts3.arts.TemperatureModelType`")
       .def_prop_rw(
           "data",
           [](lbl::temperature::data& self) { return self.X(); },
           [](lbl::temperature::data& self, const Vector& x) {
             self = lbl::temperature::data{self.Type(), x};
           },
-          ":class:`~pyarts3.arts.Vector` The coefficients")
+          "The coefficients\n\n.. :class:`~pyarts3.arts.Vector`")
       .def("__getstate__",
            [](const lbl::temperature::data& v) {
              return std::tuple<LineShapeModelType, Vector>{v.Type(), v.X()};
@@ -98,9 +108,13 @@ void py_lbl(py::module_& m) try {
   vector_interface(lsvtml);
 
   py::class_<lbl::line_shape::species_model>(m, "LineShapeSpeciesModel")
+      .def_rw("species",
+              &lbl::line_shape::species_model::species,
+              "The species\n\n.. :class:`SpeciesEnum`")
       .def_rw(
-          "species", &lbl::line_shape::species_model::species, "The species")
-      .def_rw("data", &lbl::line_shape::species_model::data, "The data")
+          "data",
+          &lbl::line_shape::species_model::data,
+          "The data\n\n.. :class:`list[tuple[LineShapeModelVariable, TemperatureModel]]`")
       .def("__getitem__",
            [](py::object& x, const py::object& key) {
              return x.attr("data").attr("__getitem__")(key);
@@ -175,11 +189,13 @@ void py_lbl(py::module_& m) try {
   py::class_<lbl::line_shape::model>(m, "LineShapeModel")
       .def_rw("one_by_one",
               &lbl::line_shape::model::one_by_one,
-              "If true, the lines are treated one by one")
-      .def_rw("T0", &lbl::line_shape::model::T0, "The reference temperature")
+              "If true, the lines are treated one by one\n\n.. :class:`bool`")
+      .def_rw("T0",
+              &lbl::line_shape::model::T0,
+              "The reference temperature\n\n.. :class:`Numeric`")
       .def_rw("single_models",
               &lbl::line_shape::model::single_models,
-              "The single models")
+              "The single models\n\n.. :class:`list[LineShapeSpeciesModel]`")
       .def("G0", &lbl::line_shape::model::G0, "The G0 coefficient", "atm"_a)
       .def("Y", &lbl::line_shape::model::Y, "The Y coefficient", "atm"_a)
       .def("D0", &lbl::line_shape::model::D0, "The D0 coefficient", "atm"_a)
@@ -202,20 +218,19 @@ void py_lbl(py::module_& m) try {
       .doc() = "Line shape model";
 
   py::class_<lbl::zeeman::model>(m, "ZeemanLineModel")
-      .def_rw(
-          "on",
-          &lbl::zeeman::model::on,
-          ":class:`~pyarts3.arts.Bool` If True, the Zeeman effect is included")
+      .def_rw("on",
+              &lbl::zeeman::model::on,
+              "If True, the Zeeman effect is included\n\n.. :class:`bool`")
       .def_prop_rw(
           "gl",
           [](lbl::zeeman::model& z) { return z.gl(); },
           [](lbl::zeeman::model& z, Numeric g) { z.gl(g); },
-          ":class:`~pyarts3.arts.Numeric` The lower level statistical weight")
+          "The lower level statistical weight\n\n.. :class:`Numeric`")
       .def_prop_rw(
           "gu",
           [](lbl::zeeman::model& z) { return z.gu(); },
           [](lbl::zeeman::model& z, Numeric g) { z.gu(g); },
-          ":class:`~pyarts3.arts.Numeric` The upper level statistical weight")
+          "The upper level statistical weight\n\n.. :class:`Numeric`")
       .def(
           "strengths",
           [](const lbl::zeeman::model& mod, const QuantumState& qn) {
@@ -242,33 +257,37 @@ void py_lbl(py::module_& m) try {
       .doc() = "Zeeman model";
 
   py::class_<lbl::line>(m, "AbsorptionLine")
-      .def_rw("a",
-              &lbl::line::a,
-              ":class:`~pyarts3.arts.Numeric` The Einstein coefficient [1 / s]")
-      .def_rw("f0",
-              &lbl::line::f0,
-              ":class:`~pyarts3.arts.Numeric` The line center frequency [Hz]")
-      .def_rw("e0",
-              &lbl::line::e0,
-              ":class:`~pyarts3.arts.Numeric` The lower level energy [J]")
+      .def_rw(
+          "a",
+          &lbl::line::a,
+          "The Einstein coefficient [1 / s]\n\n.. :class:`Numeric`")
+      .def_rw(
+          "f0",
+          &lbl::line::f0,
+          "The line center frequency [Hz]\n\n.. :class:`Numeric`")
+      .def_rw(
+          "e0",
+          &lbl::line::e0,
+          "The lower level energy [J]\n\n.. :class:`Numeric`")
       .def_rw(
           "gu",
           &lbl::line::gu,
-          ":class:`~pyarts3.arts.Numeric` The upper level statistical weight [-]")
+          "The upper level statistical weight [-]\n\n.. :class:`Numeric`")
       .def_rw(
           "gl",
           &lbl::line::gl,
-          ":class:`~pyarts3.arts.Numeric` The lower level statistical weight [-]")
+          "The lower level statistical weight [-]\n\n.. :class:`Numeric`")
       .def_rw("z",
               &lbl::line::z,
-              ":class:`~pyarts3.arts.ZeemanLineModel` The Zeeman model")
-      .def_rw("ls",
-              &lbl::line::ls,
-              ":class:`~pyarts3.arts.LineShapeModel` The line shape model")
+              "The Zeeman model\n\n.. :class:`~pyarts3.arts.ZeemanLineModel`")
+      .def_rw(
+          "ls",
+          &lbl::line::ls,
+          "The line shape model\n\n.. :class:`~pyarts3.arts.LineShapeModel`")
       .def_rw(
           "qn",
           &lbl::line::qn,
-          ":class:`~pyarts3.arts.QuantumNumberLocalState` The local quantum numbers of this line")
+          "The local quantum numbers of this line\n\n.. :class:`~pyarts3.arts.QuantumState`")
       .def(
           "s",
           [](const lbl::line& self, py::object& T, py::object& Q) {
@@ -290,16 +309,22 @@ void py_lbl(py::module_& m) try {
 
   auto ll  = py::bind_vector<std::vector<lbl::line>,
                              py::rv_policy::reference_internal>(m, "LineList");
-  ll.doc() = "A list of absorption lines";
+  ll.doc() = "A list of :class:`AbsorptionLine`";
   vector_interface(ll);
 
   py::class_<AbsorptionBand> ab(m, "AbsorptionBand");
-  ab.def_rw("lines", &AbsorptionBand::lines, "The lines in the band")
-      .def_rw("lineshape", &AbsorptionBand::lineshape, "The lineshape type")
-      .def_rw("cutoff", &AbsorptionBand::cutoff, "The cutoff type")
+  ab.def_rw("lines",
+            &AbsorptionBand::lines,
+            "The lines in the band\n\n.. :class:`LineList`")
+      .def_rw("lineshape",
+              &AbsorptionBand::lineshape,
+              "The lineshape type\n\n.. :class:`LineByLineLineshape`")
+      .def_rw("cutoff",
+              &AbsorptionBand::cutoff,
+              "The cutoff type\n\n.. :class:`LineByLineCutoffType`")
       .def_rw("cutoff_value",
               &AbsorptionBand::cutoff_value,
-              "The cutoff value [Hz]")
+              "The cutoff value [Hz]\n\n.. :class:`Numeric`")
       .def(
           "keep_frequencies",
           [](AbsorptionBand& band, Vector2 freqs) {
@@ -481,16 +506,16 @@ T0 : float
   py::class_<LinemixingSingleEcsData> ed(m, "LinemixingSingleEcsData");
   ed.def_rw("scaling",
             &LinemixingSingleEcsData::scaling,
-            ":class:`~pyarts3.arts.TemperatureModel`");
+            ".. :class:`~pyarts3.arts.TemperatureModel`");
   ed.def_rw("beta",
             &LinemixingSingleEcsData::beta,
-            ":class:`~pyarts3.arts.TemperatureModel`");
+            ".. :class:`~pyarts3.arts.TemperatureModel`");
   ed.def_rw("lambda_",  // Fix name, not python
             &LinemixingSingleEcsData::lambda,
-            ":class:`~pyarts3.arts.TemperatureModel`");
+            ".. :class:`~pyarts3.arts.TemperatureModel`");
   ed.def_rw("collisional_distance",
             &LinemixingSingleEcsData::collisional_distance,
-            ":class:`~pyarts3.arts.TemperatureModel`");
+            ".. :class:`~pyarts3.arts.TemperatureModel`");
   ed.def("Q",
          &LinemixingSingleEcsData::Q,
          "J"_a,

--- a/src/python_interface/py_lookup.cpp
+++ b/src/python_interface/py_lookup.cpp
@@ -8,29 +8,32 @@ namespace Python {
 void py_lookup(py::module_& m) try {
   py::class_<AbsorptionLookupTable> alt(m, "AbsorptionLookupTable");
   generic_interface(alt);
+  alt.def_rw("f_grid",
+             &AbsorptionLookupTable::f_grid,
+             "The frequency grid in Hz\n\n.. :class:`AscendingGrid`");
   alt.def_rw(
-      "f_grid", &AbsorptionLookupTable::f_grid, "The frequency grid in Hz");
-  alt.def_rw("log_p_grid",
-             &AbsorptionLookupTable::log_p_grid,
-             "The pressure grid in log Pa [same dimension as atm]");
+      "log_p_grid",
+      &AbsorptionLookupTable::log_p_grid,
+      "The pressure grid in log Pa [same dimension as atm]\n\n.. :class:`DescendingGrid`");
   alt.def_rw(
       "t_pert",
       &AbsorptionLookupTable::t_pert,
-      "The temperautre perturbation grid in K [any number of elements or empty for nothing]");
+      "The temperature perturbation grid in K [any number of elements or empty for nothing]\n\n.. :class:`AscendingGrid`");
   alt.def_rw(
       "w_pert",
       &AbsorptionLookupTable::w_pert,
-
-      "The humidity perturbation grid in fractional units [any number of elements or empty for nothing]");
-  alt.def_rw("water_atmref",
-             &AbsorptionLookupTable::water_atmref,
-             "Local grids so that pressure interpolation may work");
-  alt.def_rw("t_atmref",
-             &AbsorptionLookupTable::t_atmref,
-             "Local grids so that pressure interpolation may work");
+      "The humidity perturbation grid in fractional units [any number of elements or empty for nothing]\n\n.. :class:`AscendingGrid`");
+  alt.def_rw(
+      "water_atmref",
+      &AbsorptionLookupTable::water_atmref,
+      "Local grids so that pressure interpolation may work\n\n.. :class:`Vector`");
+  alt.def_rw(
+      "t_atmref",
+      &AbsorptionLookupTable::t_atmref,
+      "Local grids so that pressure interpolation may work\n\n.. :class:`Vector`");
   alt.def_rw("xsec",
              &AbsorptionLookupTable::xsec,
-             "The absorption cross section table");
+             "The absorption cross section table\n\n.. :class:`Tensor4`");
 
   auto alts = py::bind_map<AbsorptionLookupTables>(m, "AbsorptionLookupTables");
   generic_interface(alts);

--- a/src/python_interface/py_math.cpp
+++ b/src/python_interface/py_math.cpp
@@ -209,9 +209,9 @@ deg : int
 
 Returns
 -------
-x : List[float]
+x : list[float]
     The abscissas
-w : List[float]
+w : list[float]
     The weights
 )");
 
@@ -233,9 +233,9 @@ deg : int
 
 Returns
 -------
-x : List[float]
+x : list[float]
     The abscissas
-w : List[float]
+w : list[float]
     The weights
 )");
 
@@ -292,9 +292,9 @@ nmax : int
 
 Returns
 -------
-Pnm : SchmidtMatrix
+Pnm : ~pyarts3.arts.math.SchmidtMatrix
     The Polynominal matrix (nmax+1 x nmax+1).
-dPnm : SchmidtMatrix
+dPnm : ~pyarts3.arts.math.SchmidtMatrix
     The Polynominal matrix derivative (nmax+1 x nmax+1).
 )");
 } catch (std::exception& e) {

--- a/src/python_interface/py_matpack.cpp
+++ b/src/python_interface/py_matpack.cpp
@@ -187,8 +187,11 @@ void py_matpack(py::module_& m) try {
       .def(py::init<String>(), "From :class:`str`")
       .def("__float__", [](const Rational& x) { return Numeric(x); })
       .def("__int__", [](const Rational& x) { return Index(x); })
-      .def_rw("n", &Rational::numer, ":class:`int` Numerator")
-      .def_rw("d", &Rational::denom, ":class:`int` Denominator")
+      .def_rw(
+          "n", &Rational::numer, ":class:`int` Numerator\n\n.. :class:`Index`")
+      .def_rw("d",
+              &Rational::denom,
+              ":class:`int` Denominator\n\n.. :class:`Index`")
       .def("__getstate__",
            [](const Rational& self) {
              return std::make_tuple(self.numer, self.denom);

--- a/src/python_interface/py_matpack.cpp
+++ b/src/python_interface/py_matpack.cpp
@@ -188,10 +188,10 @@ void py_matpack(py::module_& m) try {
       .def("__float__", [](const Rational& x) { return Numeric(x); })
       .def("__int__", [](const Rational& x) { return Index(x); })
       .def_rw(
-          "n", &Rational::numer, ":class:`int` Numerator\n\n.. :class:`Index`")
+          "n", &Rational::numer, "Numerator\n\n.. :class:`Index`")
       .def_rw("d",
               &Rational::denom,
-              ":class:`int` Denominator\n\n.. :class:`Index`")
+              "Denominator\n\n.. :class:`Index`")
       .def("__getstate__",
            [](const Rational& self) {
              return std::make_tuple(self.numer, self.denom);

--- a/src/python_interface/py_path.cpp
+++ b/src/python_interface/py_path.cpp
@@ -15,22 +15,22 @@ void py_path(py::module_& m) try {
 
   pppp.def_rw("pos_type",
               &PropagationPathPoint::pos_type,
-              ":class:`~pyarts3.arts.PathPositionType` Path position type")
+              "Path position type\n\n.. :class:`PathPositionType`")
       .def_rw("los_type",
               &PropagationPathPoint::los_type,
-              ":class:`~pyarts3.arts.PathPositionType` Path line-of-sight type")
+              "Path line-of-sight type\n\n.. :class:`PathPositionType`")
       .def_rw("pos",
               &PropagationPathPoint::pos,
-              ":class:`~pyarts3.arts.Vector3` Path position")
+              "Path position\n\n.. :class:`~pyarts3.arts.Vector3`")
       .def_rw("los",
               &PropagationPathPoint::los,
-              ":class:`~pyarts3.arts.Vector2` Path line-of-sight")
+              "Path line-of-sight\n\n.. :class:`~pyarts3.arts.Vector2`")
       .def_rw("nreal",
               &PropagationPathPoint::nreal,
-              ":class:`float` Path real refractive index")
+              "Path real refractive index\n\n.. :class:`Numeric`")
       .def_rw("ngroup",
               &PropagationPathPoint::ngroup,
-              ":class:`float` Path group refractive index");
+              "Path group refractive index\n\n.. :class:`Numeric`");
 
   auto a1 = py::bind_vector<ArrayOfPropagationPathPoint,
                             py::rv_policy::reference_internal>(

--- a/src/python_interface/py_predefined.cpp
+++ b/src/python_interface/py_predefined.cpp
@@ -1,5 +1,5 @@
-#include <nanobind/stl/unordered_map.h>
 #include <nanobind/stl/bind_map.h>
+#include <nanobind/stl/unordered_map.h>
 #include <nanobind/stl/variant.h>
 #include <predefined/predef.h>
 #include <python_interface.h>
@@ -7,7 +7,6 @@
 #include <filesystem>
 #include <memory>
 #include <unordered_map>
-
 
 #include "debug.h"
 #include "hpy_arts.h"
@@ -22,26 +21,26 @@ void internalCKDMT400(py::module_& m) {
       .def(py::init<Absorption::PredefinedModel::MT_CKD400::WaterData>())
       .def_rw("ref_temp",
               &Absorption::PredefinedModel::MT_CKD400::WaterData::ref_temp,
-              ":class:`float` Reference temperature")
+              "Reference temperature\n\n.. :class:`Numeric`")
       .def_rw("ref_press",
               &Absorption::PredefinedModel::MT_CKD400::WaterData::ref_press,
-              ":class:`float` Reference pressure")
+              "Reference pressure\n\n.. :class:`Numeric`")
       .def_rw("ref_h2o_vmr",
               &Absorption::PredefinedModel::MT_CKD400::WaterData::ref_h2o_vmr,
-              ":class:`float` Reference water VMR")
+              "Reference water VMR\n\n.. :class:`Numeric`")
       .def_rw(
           "self_absco_ref",
           &Absorption::PredefinedModel::MT_CKD400::WaterData::self_absco_ref,
-          ":class:`list` Self absorption")
+          "Self absorption\n\n.. :class:`Vector`")
       .def_rw("for_absco_ref",
               &Absorption::PredefinedModel::MT_CKD400::WaterData::for_absco_ref,
-              ":class:`list` Foreign absorption")
+              "Foreign absorption\n\n.. :class:`Vector`")
       .def_rw("wavenumbers",
               &Absorption::PredefinedModel::MT_CKD400::WaterData::wavenumbers,
-              ":class:`list` Wavenumbers")
+              "Wavenumbers\n\n.. :class:`Vector`")
       .def_rw("self_texp",
               &Absorption::PredefinedModel::MT_CKD400::WaterData::self_texp,
-              ":class:`list` Self temperature exponent")
+              "Self temperature exponent\n\n.. :class:`Vector`")
       .def("__getstate__",
            [](const Absorption::PredefinedModel::MT_CKD400::WaterData& t) {
              return std::make_tuple(
@@ -935,7 +934,10 @@ void py_predefined(py::module_& m) try {
   predef.doc() = "Contains predefined absorption models";
 
   py::class_<PredefinedModelDataVariant> var(m, "PredefinedModelDataVariant");
-  var.def_rw("data", &PredefinedModelDataVariant::data, "The data");
+  var.def_rw(
+      "data",
+      &PredefinedModelDataVariant::data,
+      "The data\n\n.. :class:`~pyarts3.arts.predef.ModelName`\n\n.. :class:`~pyarts3.arts.predef.MTCKD400WaterData`");
   generic_interface(var);
 
   //! ARTS Workspace class, must live on the main (m) namespace

--- a/src/python_interface/py_quantum.cpp
+++ b/src/python_interface/py_quantum.cpp
@@ -23,9 +23,10 @@ void py_quantum(py::module_& m) try {
   qval.def(py::init<String>())
       .def(py::init<Rational>())
       .def(py::init<QuantumNumberType>())
-      .def_rw("value",
-              &Quantum::Value::value,
-              ":class:`~pyarts3.arts.String` or :class:`~pyarts3.arts.Rational`")
+      .def_rw(
+          "value",
+          &Quantum::Value::value,
+          "Quantum number value\n\n.. :class:`~pyarts3.arts.String`\n\n..:class:`~pyarts3.arts.Rational`")
       .def("__getstate__",
            [](const Quantum::Value& qnv) {
              return std::tuple<std::string>{std::format("{}", qnv)};
@@ -38,9 +39,13 @@ void py_quantum(py::module_& m) try {
   generic_interface(qval);
 
   py::class_<Quantum::UpperLower> qul(m, "QuantumUpperLower");
-  qul.def_rw("upper", &Quantum::UpperLower::upper, "Upper state");
-  qul.def_rw("lower", &Quantum::UpperLower::lower, "Lower state");
-  qul.doc() = "Uppler and lower quantum number values";
+  qul.def_rw("upper",
+             &Quantum::UpperLower::upper,
+             "Upper state\n\n.. :class:`QuantumValue`");
+  qul.def_rw("lower",
+             &Quantum::UpperLower::lower,
+             "Lower state\n\n.. :class:`QuantumValue`");
+  qul.doc() = "Upper and lower quantum number values";
   generic_interface(qul);
 
   auto qlvl = py::bind_map<QuantumLevel, py::rv_policy::reference_internal>(
@@ -55,14 +60,21 @@ void py_quantum(py::module_& m) try {
 
   py::class_<QuantumIdentifier> qid(m, "QuantumIdentifier");
   qid.def(py::init_implicit<const std::string_view>());
-  qid.def_rw("isot", &QuantumIdentifier::isot, "Isotopologue");
-  qid.def_rw("state", &QuantumIdentifier::state, "State");
+  qid.def_rw("isot",
+             &QuantumIdentifier::isot,
+             "Isotopologue\n\n.. :class:`SpeciesIsotope`");
+  qid.def_rw(
+      "state", &QuantumIdentifier::state, "State\n\n.. :class:`QuantumState`");
   generic_interface(qid);
 
   py::class_<QuantumLevelIdentifier> qlid(m, "QuantumLevelIdentifier");
   qlid.def(py::init_implicit<const std::string_view>());
-  qlid.def_rw("isot", &QuantumLevelIdentifier::isot, "Isotopologue");
-  qlid.def_rw("state", &QuantumLevelIdentifier::state, "State");
+  qlid.def_rw("isot",
+              &QuantumLevelIdentifier::isot,
+              "Isotopologue\n\n.. :class:`SpeciesIsotope`");
+  qlid.def_rw("state",
+              &QuantumLevelIdentifier::state,
+              "State\n\n.. :class:`QuantumLevel`");
   generic_interface(qlid);
 
   qid.def(py::self == py::self)

--- a/src/python_interface/py_quantum.cpp
+++ b/src/python_interface/py_quantum.cpp
@@ -26,7 +26,7 @@ void py_quantum(py::module_& m) try {
       .def_rw(
           "value",
           &Quantum::Value::value,
-          "Quantum number value\n\n.. :class:`~pyarts3.arts.String`\n\n..:class:`~pyarts3.arts.Rational`")
+          "Quantum number value\n\n.. :class:`~pyarts3.arts.String`\n\n.. :class:`~pyarts3.arts.Rational`")
       .def("__getstate__",
            [](const Quantum::Value& qnv) {
              return std::tuple<std::string>{std::format("{}", qnv)};

--- a/src/python_interface/py_retrieval.cpp
+++ b/src/python_interface/py_retrieval.cpp
@@ -11,14 +11,18 @@ void py_retrieval(py::module_& m) try {
                              py::rv_policy::reference_internal>(
       m, "JacobianTargetsDiagonalCovarianceMatrixMap");
   generic_interface(jtdcmm);
-  
+
   py::class_<PairOfBlockMatrix> pobm(m, "PairOfBlockMatrix");
   generic_interface(pobm);
-  pobm.def_rw("first", &PairOfBlockMatrix::first, "Matrix");
-  pobm.def_rw("second", &PairOfBlockMatrix::second, "Inverse of Matrix");
+  pobm.def_rw(
+      "first", &PairOfBlockMatrix::first, "Matrix\n\n.. :class:`BlockMatrix`");
+  pobm.def_rw("second",
+              &PairOfBlockMatrix::second,
+              "Inverse of Matrix\n\n.. :class:`BlockMatrix`");
 
   py::class_<JacobianTargetType> jtt(m, "JacobianTargetType");
-  jtt.def_rw("value", &JacobianTargetType::target, "Target");
+  jtt.def_rw(
+      "value", &JacobianTargetType::target, "Target\n\n.. :class:`object`");
   generic_interface(jtt);
 } catch (std::exception& e) {
   throw std::runtime_error(

--- a/src/python_interface/py_rtepack.cpp
+++ b/src/python_interface/py_rtepack.cpp
@@ -93,7 +93,7 @@ void rtepack_array(py::class_<matpack::data_t<T, M>> &c) {
       "value",
       [](py::object &x) { return x.attr("__array__")(); },
       [](matpack::data_t<T, M> &x, matpack::data_t<T, M> &y) { x = y; },
-      "A :class:`~numpy.ndarray` of the object.");
+      "A :class:`~numpy.ndarray` of the object.\n\n.. :class:`~numpy.ndarray`");
 
   common_ndarray(c);
 }
@@ -154,7 +154,7 @@ void py_rtepack(py::module_ &m) try {
           "value",
           [](py::object &x) { return x.attr("__array__")(); },
           [](Stokvec &x, Stokvec &y) { x = y; },
-          "A :class:`~numpy.ndarray` of the object.");
+          "A :class:`~numpy.ndarray` of the object.\n\n.. :class:`~numpy.ndarray`");
   common_ndarray(sv);
   generic_interface(sv);
   py::implicitly_convertible<PolarizationChoice, Stokvec>();
@@ -223,7 +223,7 @@ void py_rtepack(py::module_ &m) try {
           "value",
           [](py::object &x) { return x.attr("__array__")(); },
           [](Propmat &x, Propmat &y) { x = y; },
-          "A :class:`~numpy.ndarray` of the object.");
+          "A :class:`~numpy.ndarray` of the object.\n\n.. :class:`~numpy.ndarray`");
   common_ndarray(pm);
   generic_interface(pm);
 
@@ -273,7 +273,7 @@ void py_rtepack(py::module_ &m) try {
           "value",
           [](py::object &x) { return x.attr("__array__")(); },
           [](Muelmat &x, Muelmat &y) { x = y; },
-          "A :class:`~numpy.ndarray` of the object.");
+          "A :class:`~numpy.ndarray` of the object.\n\n.. :class:`~numpy.ndarray`");
   common_ndarray(mm);
   generic_interface(mm);
 
@@ -327,7 +327,7 @@ void py_rtepack(py::module_ &m) try {
           "value",
           [](py::object &x) { return x.attr("__array__")(); },
           [](Specmat &x, Specmat &y) { x = y; },
-          "A :class:`~numpy.ndarray` of the object.");
+          "A :class:`~numpy.ndarray` of the object.\n\n.. :class:`~numpy.ndarray`");
   common_ndarray(cmm);
   generic_interface(cmm);
 

--- a/src/python_interface/py_scattering.cpp
+++ b/src/python_interface/py_scattering.cpp
@@ -26,31 +26,31 @@ void py_scattering(py::module_& m) try {
   generic_interface(ssdb);
   ssdb.def_rw("ptype",
               &SingleScatteringData::ptype,
-              ":class:`~pyarts3.arts.PType` The type")
+              "The type\n\n.. :class:`~pyarts3.arts.PType`")
       .def_rw("description",
               &SingleScatteringData::description,
-              ":class:`~pyarts3.arts.String` The description")
+              "The description\n\n.. :class:`~pyarts3.arts.String`")
       .def_rw("f_grid",
               &SingleScatteringData::f_grid,
-              ":class:`~pyarts3.arts.Vector` The frequency grid")
+              "The frequency grid\n\n.. :class:`~pyarts3.arts.Vector`")
       .def_rw("T_grid",
               &SingleScatteringData::T_grid,
-              ":class:`~pyarts3.arts.Vector` The temperature grid")
+              "The temperature grid\n\n.. :class:`~pyarts3.arts.Vector`")
       .def_rw("za_grid",
               &SingleScatteringData::za_grid,
-              ":class:`~pyarts3.arts.Vector` The zenith grid")
+              "The zenith grid\n\n.. :class:`~pyarts3.arts.Vector`")
       .def_rw("aa_grid",
               &SingleScatteringData::aa_grid,
-              ":class:`~pyarts3.arts.Vector` The azimuth grid")
+              "The azimuth grid\n\n.. :class:`~pyarts3.arts.Vector`")
       .def_rw("pha_mat_data",
               &SingleScatteringData::pha_mat_data,
-              ":class:`~pyarts3.arts.Tensor7` The phase matrix")
+              "The phase matrix\n\n.. :class:`~pyarts3.arts.Tensor7`")
       .def_rw("ext_mat_data",
               &SingleScatteringData::ext_mat_data,
-              ":class:`~pyarts3.arts.Tensor5` The extinction matrix")
+              "The extinction matrix\n\n.. :class:`~pyarts3.arts.Tensor5`")
       .def_rw("abs_vec_data",
               &SingleScatteringData::abs_vec_data,
-              ":class:`~pyarts3.arts.Tensor5` The absorption vector")
+              "The absorption vector\n\n.. :class:`~pyarts3.arts.Tensor5`")
       .def("__getstate__",
            [](const SingleScatteringData& self) {
              return py::make_tuple(self.ptype,
@@ -82,23 +82,24 @@ void py_scattering(py::module_& m) try {
   generic_interface(smdb);
   smdb.def_rw("description",
               &ScatteringMetaData::description,
-              ":class:`~pyarts3.arts.String` The description")
+              "The description\n\n.. :class:`~pyarts3.arts.String`")
       .def_rw("source",
               &ScatteringMetaData::source,
-              ":class:`~pyarts3.arts.String` The source")
+              "The source\n\n.. :class:`~pyarts3.arts.String`")
       .def_rw("refr_index",
               &ScatteringMetaData::refr_index,
-              ":class:`~pyarts3.arts.String` The refractive index")
-      .def_rw("mass", &ScatteringMetaData::mass, ":class:`float` The mass")
+              "The refractive index\n\n.. :class:`~pyarts3.arts.String`")
+      .def_rw(
+          "mass", &ScatteringMetaData::mass, "The mass\n\n.. :class:`float`")
       .def_rw("diameter_max",
               &ScatteringMetaData::diameter_max,
-              ":class:`float` The max diameter")
+              "The max diameter\n\n.. :class:`float`")
       .def_rw("diameter_volume_equ",
               &ScatteringMetaData::diameter_volume_equ,
-              ":class:`float` The volume equivalent diameter")
+              "The volume equivalent diameter\n\n.. :class:`float`")
       .def_rw("diameter_area_equ_aerodynamical",
               &ScatteringMetaData::diameter_area_equ_aerodynamical,
-              ":class:`float` The diameter area equivalent")
+              "The diameter area equivalent\n\n.. :class:`float`")
       .def("__getstate__",
            [](const ScatteringMetaData& self) {
              return py::make_tuple(self.description,

--- a/src/python_interface/py_scattering_species.cpp
+++ b/src/python_interface/py_scattering_species.cpp
@@ -235,20 +235,24 @@ auto bind_single_scattering_data(py::module_& m, const std::string& name) {
   //        "absorption_vector"_a,
   //        "backscatter_matrix"_a,
   //        "forwardscatter_matrix"_a)
-  s.def_rw("properties", &SSDClass::properties, "Particle properties")
-      .def_rw("phase_matrix", &SSDClass::phase_matrix, "Phase matrix")
+  s.def_rw("properties",
+           &SSDClass::properties,
+           "Particle properties\n\n.. :class:`object`")
+      .def_rw("phase_matrix",
+              &SSDClass::phase_matrix,
+              "Phase matrix\n\n.. :class:`object`")
       .def_rw("extinction_matrix",
               &SSDClass::extinction_matrix,
-              "Extinction matrix")
+              "Extinction matrix\n\n.. :class:`object`")
       .def_rw("absorption_vector",
               &SSDClass::absorption_vector,
-              "Absorption vector")
+              "Absorption vector\n\n.. :class:`object`")
       .def_rw("backscatter_matrix",
               &SSDClass::backscatter_matrix,
-              "Back scatter matrix")
+              "Back scatter matrix\n\n.. :class:`object`")
       .def_rw("forwardscatter_matrix",
               &SSDClass::forwardscatter_matrix,
-              "Forward scatter matrix")
+              "Forward scatter matrix\n\n.. :class:`object`")
       .def_static("from_legacy_tro",
                   &SSDClass::from_legacy_tro,
                   "ssd"_a,
@@ -269,15 +273,15 @@ auto bind_bulk_scattering_properties(py::module_& m, const std::string& name) {
       m, name.c_str());
   s.def_rw("phase_matrix",
            &scattering::BulkScatteringProperties<format, repr>::phase_matrix,
-           "Phase matrix")
+           "Phase matrix\n\n.. :class:`object`")
       .def_rw("extinction_matrix",
               &scattering::BulkScatteringProperties<format,
                                                     repr>::extinction_matrix,
-              "Extinction matrix")
+              "Extinction matrix\n\n.. :class:`object`")
       .def_rw("absorption_vector",
               &scattering::BulkScatteringProperties<format,
                                                     repr>::absorption_vector,
-              "Absorption vector");
+              "Absorption vector\n\n.. :class:`object`");
   return s;
 }
 
@@ -286,13 +290,13 @@ void py_scattering_species(py::module_& m) try {
                                                "ScatteringTroSpectralVector");
   stsv.def_rw("phase_matrix",
               &ScatteringTroSpectralVector::phase_matrix,
-              "Phase matrix")
+              "Phase matrix\n\n.. :class:`object`")
       .def_rw("extinction_matrix",
               &ScatteringTroSpectralVector::extinction_matrix,
-              "Extinction matrix")
+              "Extinction matrix\n\n.. :class:`object`")
       .def_rw("absorption_vector",
               &ScatteringTroSpectralVector::absorption_vector,
-              "Absorption vector");
+              "Absorption vector\n\n.. :class:`object`");
   stsv.def_static(
       "to_gridded",
       [](const SpecmatMatrix& phase_matrix, const std::shared_ptr<Vector>& f) {
@@ -318,7 +322,10 @@ void py_scattering_species(py::module_& m) try {
   sgstro.def(py::init<>());
   sgstro.def(py::init_implicit<ScatteringGeneralSpectralTROFunc>());
   sgstro.def(py::init_implicit<ScatteringGeneralSpectralTROFunc::func_t>());
-  sgstro.def_rw("f", &ScatteringGeneralSpectralTRO::f, "Frequency grid");
+  sgstro.def_rw(
+      "f",
+      &ScatteringGeneralSpectralTRO::f,
+      "Frequency grid\n\n.. :class:`ScatteringGeneralSpectralTROFunc`");
   sgstro.doc() = "Scattering general spectral TRO";
   str_interface(stsv);
 
@@ -331,10 +338,10 @@ void py_scattering_species(py::module_& m) try {
   ssp.def(py::init<std::string, ParticulateProperty>(), "Constructor")
       .def_rw("species_name",
               &ScatteringSpeciesProperty::species_name,
-              "Species name")
+              "Species name\n\n.. :class:`str`")
       .def_rw("pproperty",
               &ScatteringSpeciesProperty::pproperty,
-              "Particulate property");
+              "Particulate property\n\n.. :class:`ParticulateProperty`");
 
   //   using BulkScatteringPropertiesTROSpectral =
   //       std::variant<scattering::BulkScatteringProperties<
@@ -400,32 +407,35 @@ void py_scattering_species(py::module_& m) try {
   irr_grid.def(py::init<Vector>())
       .def_rw("value",
               &scattering::IrregularZenithAngleGrid::angles,
-              "Zenith angle grid")
+              "Zenith angle grid\n\n.. :class:`Vector`")
       .doc() = "Irregular zenith angle grid";
   common_ndarray(irr_grid);
 
   py::class_<scattering::GaussLegendreGrid> gauss_grid(m, "GaussLegendreGrid");
   gauss_grid.def(py::init<Index>())
-      .def_rw("value",
-              &scattering::GaussLegendreGrid::angles,
-              "Zenith angle grid for Legendre calculations")
+      .def_rw(
+          "value",
+          &scattering::GaussLegendreGrid::angles,
+          "Zenith angle grid for Legendre calculations\n\n.. :class:`Vector`")
       .doc() = "Gaussian Legendre grid";
   common_ndarray(gauss_grid);
 
   py::class_<scattering::DoubleGaussGrid> double_gauss_grid(m,
                                                             "DoubleGaussGrid");
   double_gauss_grid.def(py::init<Index>())
-      .def_rw("value",
-              &scattering::DoubleGaussGrid::angles,
-              "Zenith angle grid for Double Gauss calculations")
+      .def_rw(
+          "value",
+          &scattering::DoubleGaussGrid::angles,
+          "Zenith angle grid for Double Gauss calculations\n\n.. :class:`Vector`")
       .doc() = "Double Gaussian grid";
   common_ndarray(double_gauss_grid);
 
   py::class_<scattering::LobattoGrid> lobatto_grid(m, "LobattoGrid");
   lobatto_grid.def(py::init<Index>())
-      .def_rw("value",
-              &scattering::LobattoGrid::angles,
-              "Zenith angle grid for Lobatto calculations")
+      .def_rw(
+          "value",
+          &scattering::LobattoGrid::angles,
+          "Zenith angle grid for Lobatto calculations\n\n.. :class:`Vector`")
       .doc() = "Lobatto grid";
   common_ndarray(lobatto_grid);
 
@@ -433,7 +443,7 @@ void py_scattering_species(py::module_& m) try {
   fejer_grid.def(py::init<Index>())
       .def_rw("value",
               &scattering::FejerGrid::angles,
-              "Zenith angle grid for Fejer calculations")
+              "Zenith angle grid for Fejer calculations\n\n.. :class:`Vector`")
       .doc() = "Fejer grid";
   common_ndarray(fejer_grid);
 
@@ -546,14 +556,24 @@ void py_scattering_species(py::module_& m) try {
 
   py::class_<scattering::ParticleProperties>(m, "ParticleProperties")
       .def(py::init<>())
-      .def_rw("name", &scattering::ParticleProperties::name, "Name")
-      .def_rw("source", &scattering::ParticleProperties::source, "Source")
+      .def_rw("name",
+              &scattering::ParticleProperties::name,
+              "Name\n\n.. :class:`str`")
+      .def_rw("source",
+              &scattering::ParticleProperties::source,
+              "Source\n\n.. :class:`str`")
       .def_rw("refractive_index",
               &scattering::ParticleProperties::refractive_index,
-              "Refractive index")
-      .def_rw("mass", &scattering::ParticleProperties::mass, "Mass")
-      .def_rw("d_veq", &scattering::ParticleProperties::d_veq, "Diameter")
-      .def_rw("d_max", &scattering::ParticleProperties::d_max, "Max diameter")
+              "Refractive index\n\n.. :class:`float`")
+      .def_rw("mass",
+              &scattering::ParticleProperties::mass,
+              "Mass\n\n.. :class:`float`")
+      .def_rw("d_veq",
+              &scattering::ParticleProperties::d_veq,
+              "Diameter\n\n.. :class:`float`")
+      .def_rw("d_max",
+              &scattering::ParticleProperties::d_max,
+              "Max diameter\n\n.. :class:`float`")
       .doc() = "Particle properties";
 
   bind_single_scattering_data<double,
@@ -630,12 +650,13 @@ void py_scattering_species(py::module_& m) try {
            py::arg("psd"),
            py::arg("mass_size_rel_a") = -1.0,
            py::arg("mass_size_rel_b") = -1.0)
-      .def("get_bulk_scattering_properties_tro_spectral",
-           &ScatteringHabit::get_bulk_scattering_properties_tro_spectral,
-           "point"_a,
-           "f_grid"_a,
-           "degree"_a,
-           "Get the bulk scattering properties for totally random orientation but ignores the degree")
+      .def(
+          "get_bulk_scattering_properties_tro_spectral",
+          &ScatteringHabit::get_bulk_scattering_properties_tro_spectral,
+          "point"_a,
+          "f_grid"_a,
+          "degree"_a,
+          "Get the bulk scattering properties for totally random orientation but ignores the degree")
       .doc() =
       "A scattering habit combines a particle habit with a PSD so that it can be used as a scattering species.";
 

--- a/src/python_interface/py_sensor.cpp
+++ b/src/python_interface/py_sensor.cpp
@@ -43,10 +43,11 @@ void py_sensor(py::module_& m) try {
           "value",
           [](py::object& x) { return x.attr("__array__")(); },
           [](SensorPosLos& a, const SensorPosLos& b) { a = b; },
-          "A :class:`~numpy.ndarray` of the object.")
+          "A :class:`~numpy.ndarray` of the object.\n\n.. :class:`~numpy.ndarray`")
       .def(py::init<Vector3, Vector2>(), "From pos and los")
-      .def_rw("pos", &SensorPosLos::pos, "Position")
-      .def_rw("los", &SensorPosLos::los, "Line of sight");
+      .def_rw("pos", &SensorPosLos::pos, "Position\n\n.. :class:`Vector3`")
+      .def_rw(
+          "los", &SensorPosLos::los, "Line of sight\n\n.. :class:`Vector2`");
 
   py::class_<SensorPosLosVector> vsplos(m, "SensorPosLosVector");
   generic_interface(vsplos);
@@ -113,7 +114,7 @@ void py_sensor(py::module_& m) try {
                                   .los = {row[3], row[4]}};
             });
           },
-          "A :class:`~numpy.ndarray` of the object.")
+          "A :class:`~numpy.ndarray` of the object.\n\n.. :class:`~numpy.ndarray`")
       .def("__getstate__",
            [](const py::object& self) {
              return py::make_tuple(self.attr("value"));
@@ -127,16 +128,19 @@ void py_sensor(py::module_& m) try {
   so.def(py::init<const AscendingGrid&,
                   const SensorPosLosVector&,
                   StokvecMatrix>())
-      .def_prop_ro("f_grid", &SensorObsel::f_grid, "Frequency grid")
+      .def_prop_ro("f_grid",
+                   &SensorObsel::f_grid,
+                   "Frequency grid\n\n.. :class:`AscendingGrid`")
       .def_prop_ro(
           "weight_matrix",
           [](const SensorObsel& self) {
             return StokvecMatrix{self.weight_matrix()};
           },
-          "Weights matrix")
-      .def_prop_ro("poslos",
-                   &SensorObsel::poslos_grid,
-                   "Position and line of sight grid");
+          "Weights matrix\n\n.. :class:`StokvecMatrix`")
+      .def_prop_ro(
+          "poslos",
+          &SensorObsel::poslos_grid,
+          "Position and line of sight grid\n\n.. :class:`SensorPosLosVector`");
 
   auto a0 = py::bind_vector<Array<SensorPosLosVector>,
                             py::rv_policy::reference_internal>(

--- a/src/python_interface/py_sparse.cpp
+++ b/src/python_interface/py_sparse.cpp
@@ -73,63 +73,43 @@ arr : :class:`scipy.sparse.csr_matrix`
 
   sp.def(
       "arcsin",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("arcsin")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("arcsin")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "arcsinh",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("arcsinh")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("arcsinh")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "arctan",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("arctan")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("arctan")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "arctanh",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("arctanh")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("arctanh")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "argmax",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("argmax")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("argmax")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "argmin",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("argmin")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("argmin")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "asformat",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("asformat")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("asformat")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "asfptype",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("asfptype")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("asfptype")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "astype",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("astype")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("astype")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "ceil",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("ceil")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("ceil")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "check_format",
@@ -139,21 +119,15 @@ arr : :class:`scipy.sparse.csr_matrix`
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "conj",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("conj")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("conj")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "conjugate",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("conjugate")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("conjugate")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "copy",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("copy")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("copy")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "count_nonzero",
@@ -163,33 +137,23 @@ arr : :class:`scipy.sparse.csr_matrix`
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "data",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("data")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("data")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "deg2rad",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("deg2rad")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("deg2rad")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "diagonal",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("diagonal")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("diagonal")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "dot",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("dot")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("dot")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "dtype",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("dtype")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("dtype")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "eliminate_zeros",
@@ -199,45 +163,31 @@ arr : :class:`scipy.sparse.csr_matrix`
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "expm1",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("expm1")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("expm1")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "floor",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("floor")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("floor")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "format",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("format")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("format")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "getH",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("getH")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("getH")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "get_shape",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("get_shape")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("get_shape")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "getcol",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("getcol")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("getcol")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "getformat",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("getformat")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("getformat")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "getmaxprint",
@@ -247,15 +197,11 @@ arr : :class:`scipy.sparse.csr_matrix`
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "getnnz",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("getnnz")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("getnnz")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "getrow",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("getrow")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("getrow")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "has_canonical_format",
@@ -271,183 +217,123 @@ arr : :class:`scipy.sparse.csr_matrix`
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "imag",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("imag")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("imag")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "indices",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("indices")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("indices")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "indptr",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("indptr")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("indptr")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "log1p",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("log1p")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("log1p")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "max",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("max")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("max")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "maximum",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("maximum")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("maximum")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "maxprint",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("maxprint")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("maxprint")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "mean",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("mean")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("mean")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "min",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("min")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("min")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "minimum",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("minimum")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("minimum")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "multiply",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("multiply")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("multiply")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "nanmax",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("nanmax")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("nanmax")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "nanmin",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("nanmin")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("nanmin")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "ndim",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("ndim")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("ndim")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "nnz",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("nnz")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("nnz")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "nonzero",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("nonzero")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("nonzero")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "power",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("power")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("power")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "prune",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("prune")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("prune")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "rad2deg",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("rad2deg")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("rad2deg")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "real",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("real")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("real")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "reshape",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("reshape")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("reshape")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "resize",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("resize")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("resize")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "rint",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("rint")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("rint")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "set_shape",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("set_shape")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("set_shape")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "setdiag",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("setdiag")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("setdiag")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "shape",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("shape")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("shape")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "sign",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("sign")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("sign")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "sin",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("sin")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("sin")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "sinh",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("sinh")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("sinh")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "size",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("size")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("size")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "sort_indices",
@@ -463,15 +349,11 @@ arr : :class:`scipy.sparse.csr_matrix`
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "sqrt",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("sqrt")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("sqrt")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "sum",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("sum")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("sum")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "sum_duplicates",
@@ -481,75 +363,51 @@ arr : :class:`scipy.sparse.csr_matrix`
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "tan",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("tan")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("tan")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "tanh",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("tanh")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("tanh")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "tobsr",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("tobsr")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("tobsr")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "tocoo",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("tocoo")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("tocoo")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "tocsc",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("tocsc")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("tocsc")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "todense",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("todense")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("todense")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "todia",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("todia")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("todia")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "todok",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("todok")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("todok")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "tolil",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("tolil")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("tolil")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "trace",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("trace")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("trace")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "transpose",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("transpose")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("transpose")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
   sp.def(
       "trunc",
-      [](py::object& self) {
-        return self.attr("tocsr")().attr("trunc")();
-      },
+      [](py::object& self) { return self.attr("tocsr")().attr("trunc")(); },
       "See :class:`scipy.sparse.csr_matrix`, but for no input arguments.");
 
   auto a1 = py::bind_vector<ArrayOfSparse, py::rv_policy::reference_internal>(
@@ -577,7 +435,7 @@ arr : :class:`scipy.sparse.csr_matrix`
                   std::make_shared<Sparse>(**std::get_if<Sparse*>(&y)));
             }
           },
-          ":class:`~pyarts3.arts.Matrix` or :class:`~pyarts3.arts.Sparse` The matrix held inside the instance")
+          "The matrix held inside the instance\n\n.. :class:`~pyarts3.arts.Matrix`\n\n.. :class:`~pyarts3.arts.Sparse`")
       .def("__getstate__",
            [](const Block& self) {
              if (self.is_sparse())
@@ -654,7 +512,7 @@ arr : :class:`scipy.sparse.csr_matrix`
       [](BlockMatrix& bm, const std::variant<Matrix, Sparse>& mat) {
         std::visit([&bm](auto& m) { bm = m; }, mat);
       },
-      "The matrix of the block");
+      "The matrix of the block\n\n.. :class:`~pyarts3.arts.Matrix`\n\n.. :class:`~pyarts3.arts.Sparse`");
   bm.def(
       "__array__",
       [](py::object& v, py::object dtype, py::object copy) {
@@ -669,7 +527,7 @@ arr : :class:`scipy.sparse.csr_matrix`
       [](BlockMatrix& a, const std::variant<Matrix, Sparse>& b) {
         std::visit([&a](auto& c) { a = c; }, b);
       },
-      "A :class:`~numpy.ndarray` or :class:`scipy.sparse.csr_matrix` of the object.");
+      "A python friendly version of the object.\n\n.. :class:`~numpy.ndarray`\n\n.. :class:`scipy.sparse.csr_matrix`");
   common_ndarray(bm);
   generic_interface(bm);
 
@@ -681,7 +539,7 @@ arr : :class:`scipy.sparse.csr_matrix`
           [](CovarianceMatrix& x, std::vector<Block> y) {
             x.get_blocks() = std::move(y);
           },
-          ":class:`list` of :class:`~pyarts3.arts.Block`")
+          "The blocks\n\n.. :class:`list[~pyarts3.arts.Block]`")
       .def("__getstate__",
            [](CovarianceMatrix& self) {
              return std::tuple<std::vector<Block>, std::vector<Block>>(

--- a/src/python_interface/py_species.cpp
+++ b/src/python_interface/py_species.cpp
@@ -71,10 +71,10 @@ void py_species(py::module_& m) try {
           "Builtin values")
       .def_ro_static("maxsize",
                      &SpeciesIsotopologueRatios::maxsize,
-                     ":class:`int` The max size of the data")
+                     "The max size of the data\n\n.. :class:`int`")
       .def_rw("data",
               &SpeciesIsotopologueRatios::data,
-              ":class:`list` The max size of the data")
+              "The isotopologue ratios\n\n.. :class:`list[Numeric]`")
       .def("__getstate__",
            [](const SpeciesIsotopologueRatios& self) {
              return std::make_tuple(self.data);
@@ -145,24 +145,26 @@ void py_species(py::module_& m) try {
           "Partition function")
       .def_ro("spec",
               &SpeciesIsotope::spec,
-              ":class:`~pyarts3.arts.Species` The species")
-      .def_ro("isotname",
-              &SpeciesIsotope::isotname,
-              ":class:`str` A custom name that is unique for this Species type")
+              "The species\n\n.. :class:`~pyarts3.arts.SpeciesEnum`")
+      .def_ro(
+          "isotname",
+          &SpeciesIsotope::isotname,
+          "A custom name that is unique for this Species type\n\n.. :class:`str`")
       .def_ro(
           "mass",
           &SpeciesIsotope::mass,
-          ":class:`float` The mass of the isotope in units of grams per mol. It is Nan if not defined")
+          "The mass of the isotope in units of grams per mol. It is Nan if not defined\n\n.. :class:`float`")
       .def_ro(
           "gi",
           &SpeciesIsotope::gi,
-          ":class:`float` The degeneracy of states of the molecule. It is -1 if not defined.")
+          "The degeneracy of states of the molecule. It is -1 if not defined.\n\n.. :class:`float`")
       .def_prop_ro("name",
                    &SpeciesIsotope::FullName,
-                   ":class:`~pyarts3.arts.String` The full name")
-      .def_prop_ro("predef",
-                   &SpeciesIsotope::is_predefined,
-                   ":class:`bool` Check if this represents a predefined model")
+                   "The full name\n\n.. :class:`String`")
+      .def_prop_ro(
+          "predef",
+          &SpeciesIsotope::is_predefined,
+          "Check if this represents a predefined model\n\n.. :class:`bool`")
       .def("__getstate__",
            [](const SpeciesIsotope& self) {
              return std::make_tuple(
@@ -187,13 +189,14 @@ void py_species(py::module_& m) try {
 
   py::class_<SpeciesTag> stag(m, "SpeciesTag");
   generic_interface(stag);
-  stag.def_rw("spec_ind", &SpeciesTag::spec_ind, ":class:`int` Species index")
+  stag.def_rw(
+          "spec_ind", &SpeciesTag::spec_ind, "Species index\n\n.. :class:`int`")
       .def_rw("type",
               &SpeciesTag::type,
-              ":class:`~pyarts3.arts.SpeciesTagType` Type of tag")
+              "Type of tag\n\n.. :class:`~pyarts3.arts.SpeciesTagType`")
       .def_rw("cia_2nd_species",
               &SpeciesTag::cia_2nd_species,
-              ":class:`~pyarts3.arts.Species` CIA species")
+              "CIA species\n\n.. :class:`~pyarts3.arts.SpeciesEnum`")
       .def(
           "partfun",
           [](const SpeciesTag& self, Numeric T) {
@@ -214,7 +217,7 @@ Returns
           "T"_a)
       .def_prop_ro("full_name",
                    &SpeciesTag::FullName,
-                   ":class:`~pyarts3.arts.String` The full name")
+                   "The full name\n\n.. :class:`~pyarts3.arts.String`")
       .def(py::self == py::self)
       .def("__getstate__",
            [](const SpeciesTag& self) {

--- a/src/python_interface/py_star.cpp
+++ b/src/python_interface/py_star.cpp
@@ -12,15 +12,16 @@ void py_star(py::module_& m) try {
   generic_interface(suns);
   suns.def_rw("description",
               &Sun::description,
-              ":class:`~pyarts3.arts.String` Sun description")
+              "Sun description\n\n.. :class:`~pyarts3.arts.String`")
       .def_rw(
           "spectrum",
           &Sun::spectrum,
-          ":class:`~pyarts3.arts.Matrix` Sun spectrum, monochrmatic radiance spectrum at the surface of the sun")
-      .def_rw("radius", &Sun::radius, ":class:`float` Sun radius")
-      .def_rw("distance", &Sun::distance, ":class:`float` Sun distance")
-      .def_rw("latitude", &Sun::latitude, ":class:`float` Sun latitude")
-      .def_rw("longitude", &Sun::longitude, ":class:`float` Sun longitude")
+          "Sun spectrum, monochromatic radiance spectrum at the surface of the sun\n\n.. :class:`~pyarts3.arts.Matrix`")
+      .def_rw("radius", &Sun::radius, "Sun radius\n\n.. :class:`float`")
+      .def_rw("distance", &Sun::distance, "Sun distance\n\n.. :class:`float`")
+      .def_rw("latitude", &Sun::latitude, "Sun latitude\n\n.. :class:`float`")
+      .def_rw(
+          "longitude", &Sun::longitude, "Sun longitude\n\n.. :class:`float`")
       .def("__getstate__",
            [](const Sun& self) {
              return std::

--- a/src/python_interface/py_surf.cpp
+++ b/src/python_interface/py_surf.cpp
@@ -25,11 +25,22 @@ void py_surf(py::module_ &m) try {
           },
           "v"_a,
           "Initialize with a sorted field")
-      .def_rw("data", &Surf::Data::data, "The data")
-      .def_rw("lat_upp", &Surf::Data::lat_upp, "Upper latitude limit")
-      .def_rw("lat_low", &Surf::Data::lat_low, "Lower latitude limit")
-      .def_rw("lon_upp", &Surf::Data::lon_upp, "Upper longitude limit")
-      .def_rw("lon_low", &Surf::Data::lon_low, "Lower longitude limit")
+      .def_rw(
+          "data",
+          &Surf::Data::data,
+          "The data\n\n.. :class:`GeodeticField2`\n\n.. :class:`Numeric`\n\n.. :class:`NumericBinaryOperator`")
+      .def_rw("lat_upp",
+              &Surf::Data::lat_upp,
+              "Upper latitude limit\n\n.. :class:`InterpolationExtrapolation`")
+      .def_rw("lat_low",
+              &Surf::Data::lat_low,
+              "Lower latitude limit\n\n.. :class:`InterpolationExtrapolation`")
+      .def_rw("lon_upp",
+              &Surf::Data::lon_upp,
+              "Upper longitude limit\n\n.. :class:`InterpolationExtrapolation`")
+      .def_rw("lon_low",
+              &Surf::Data::lon_low,
+              "Lower longitude limit\n\n.. :class:`InterpolationExtrapolation`")
       .def(
           "set_extrapolation",
           [](Surf::Data &self, InterpolationExtrapolation x) {
@@ -79,7 +90,9 @@ void py_surf(py::module_ &m) try {
           "lat"_a,
           "lon"_a,
           "Get the weights of neighbors at a position")
-      .def_prop_ro("data_type", &Surf::Data::data_type, "The data type")
+      .def_prop_ro("data_type",
+                   &Surf::Data::data_type,
+                   "The data type\n\n.. :class:`String`")
       .def("__getstate__",
            [](const Surf::Data &t) {
              return std::make_tuple(
@@ -106,7 +119,9 @@ void py_surf(py::module_ &m) try {
   py::class_<SurfacePropertyTag> spt =
       py::class_<SurfacePropertyTag>(m, "SurfacePropertyTag");
   generic_interface(spt);
-  spt.def_rw("name", &SurfacePropertyTag::name, "Name of property");
+  spt.def_rw("name",
+             &SurfacePropertyTag::name,
+             "Name of property\n\n.. :class:`String`");
   spt.def(py::init_implicit<String>());
 
   auto pnt = py::class_<SurfacePoint>(m, "SurfacePoint");
@@ -125,15 +140,22 @@ void py_surf(py::module_ &m) try {
            surface_fieldPlanet(*sf, planet, 0.0);
          },
          "planet"_a)
-      .def_rw("ellipsoid",
-              &SurfaceField::ellipsoid,
-              "Ellipsoid parameters (semi-major axis, semi-minor axis)");
+      .def_rw(
+          "ellipsoid",
+          &SurfaceField::ellipsoid,
+          "Ellipsoid parameters (semi-major axis, semi-minor axis)\n\n.. :class:`Vector2`");
   generic_interface(fld);
   py::implicitly_convertible<String, SurfaceField>();
 
-  pnt.def_rw("temperature", &SurfacePoint::temperature, "Temperature [K]")
-      .def_rw("elevation", &SurfacePoint::elevation, "Surface elevation [m]")
-      .def_rw("normal", &SurfacePoint::normal, "Surface normal vector")
+  pnt.def_rw("temperature",
+             &SurfacePoint::temperature,
+             "Temperature [K]\n\n.. :class:`Numeric`")
+      .def_rw("elevation",
+              &SurfacePoint::elevation,
+              "Surface elevation [m]\n\n.. :class:`Numeric`")
+      .def_rw("normal",
+              &SurfacePoint::normal,
+              "Surface normal vector\n\n.. :class:`Vector2`")
       .def(
           "__getitem__",
           [](SurfacePoint &surf, SurfaceKey x) {
@@ -280,15 +302,24 @@ void py_surf(py::module_ &m) try {
                    k[i]) = v[i];
              }
            });
-  fld.def_rw("other", &SurfaceField::other, "Other data in the surface field")
-      .def_rw("props", &SurfaceField::props, "Properties of the surface field");
+  fld.def_rw(
+         "other",
+         &SurfaceField::other,
+         "Other data in the surface field\n\n.. :class:`dict[SurfaceKey, SurfaceData]`")
+      .def_rw(
+          "props",
+          &SurfaceField::props,
+          "Properties of the surface field\n\n.. :class:`dict[SurfacePropertyTag, SurfaceData]`");
 
   py::class_<SubsurfaceField> ssf(m, "SubsurfaceField");
   ssf.def_rw(
-      "other", &SubsurfaceField::other, "Other data in the subsurface field");
-  ssf.def_rw("bottom_depth",
-             &SubsurfaceField::bottom_depth,
-             "The depth of the bottom of the subsurface [m]");
+      "other",
+      &SubsurfaceField::other,
+      "Other data in the subsurface field\n\n.. :class:`dict[SubsurfaceKey, SurfaceData]`");
+  ssf.def_rw(
+      "bottom_depth",
+      &SubsurfaceField::bottom_depth,
+      "The depth of the bottom of the subsurface [m]\n\n.. :class:`Numeric`");
   generic_interface(ssf);
 
   py::class_<SubsurfacePoint> ssp(m, "SubsurfacePoint");

--- a/src/python_interface/py_time.cpp
+++ b/src/python_interface/py_time.cpp
@@ -32,12 +32,12 @@ void py_time(py::module_& m) try {
           "From :class:`float` seconds from Unix time start")
       .def(py::init<std::string>(),
            "From :class:`str` of form \"YYYY-MM-DD hh:mm:ss\"")
-      .def_rw("time", &Time::time, ":class:`datetime.datetime` The time")
+      .def_rw("time", &Time::time, "The time\n\n.. :class:`~datetime.datetime`")
       .def_prop_rw(
           "sec",
           [](const Time& t) { return t.Seconds(); },
           [](Time& t, Numeric n) { return t.Seconds(n); },
-          ":class:`float` Time from Unix start")
+          "Time from Unix start\n\n.. :class:`float`")
       .def(
           "__add__",
           [](Time& t, Numeric n) {
@@ -90,18 +90,19 @@ void py_time(py::module_& m) try {
   py::implicitly_convertible<std::string, Time>();
   py::implicitly_convertible<Numeric, Time>();
 
-  auto a1 = py::bind_vector<ArrayOfTime, py::rv_policy::reference_internal>(
-                m, "ArrayOfTime")
-                .def_prop_ro(
-                    "as_datetime",
-                    [](const ArrayOfTime& in)
-                        -> std::vector<std::chrono::system_clock::time_point> {
-                      const Index n = in.size();
-                      std::vector<std::chrono::system_clock::time_point> out(n);
-                      for (Index i = 0; i < n; i++) out[i] = in[i].time;
-                      return out;
-                    },
-                    "A :class:`list` of :class:`datetime.datetime`");
+  auto a1 =
+      py::bind_vector<ArrayOfTime, py::rv_policy::reference_internal>(
+          m, "ArrayOfTime")
+          .def_prop_ro(
+              "as_datetime",
+              [](const ArrayOfTime& in)
+                  -> std::vector<std::chrono::system_clock::time_point> {
+                const Index n = in.size();
+                std::vector<std::chrono::system_clock::time_point> out(n);
+                for (Index i = 0; i < n; i++) out[i] = in[i].time;
+                return out;
+              },
+              "Convert to time lists\n\n.. :class:`list[~datetime.datetime]`");
 
   generic_interface(a1);
 

--- a/src/python_interface/py_xsec_fit.cpp
+++ b/src/python_interface/py_xsec_fit.cpp
@@ -13,25 +13,30 @@ void py_xsec(py::module_& m) try {
   py::class_<XsecRecord> xsec(m, "XsecRecord");
   generic_interface(xsec);
   xsec.def_ro_static(
-          "version", &XsecRecord::mversion, ":class:`int` The version")
+          "version", &XsecRecord::mversion, "The version\n\n.. :class:`int`")
       .def_rw("species",
               &XsecRecord::mspecies,
-              ":class:`~pyarts3.arts.Species` The species")
-      .def_rw("fitcoeffs",
-              &XsecRecord::mfitcoeffs,
-              ":class:`~pyarts3.arts.ArrayOfGriddedField2` Fit coefficients")
-      .def_rw("fitminpressures",
-              &XsecRecord::mfitminpressures,
-              ":class:`~pyarts3.arts.ArrayOfGriddedField2` Fit coefficients")
-      .def_rw("fitmaxpressures",
-              &XsecRecord::mfitmaxpressures,
-              ":class:`~pyarts3.arts.ArrayOfGriddedField2` Fit coefficients")
-      .def_rw("fitmintemperatures",
-              &XsecRecord::mfitmintemperatures,
-              ":class:`~pyarts3.arts.ArrayOfGriddedField2` Fit coefficients")
-      .def_rw("fitmaxtemperatures",
-              &XsecRecord::mfitmaxtemperatures,
-              ":class:`~pyarts3.arts.ArrayOfGriddedField2` Fit coefficients")
+              "The species\n\n.. :class:`~pyarts3.arts.SpeciesEnum`")
+      .def_rw(
+          "fitcoeffs",
+          &XsecRecord::mfitcoeffs,
+          "Fit coefficients\n\n.. :class:`~pyarts3.arts.ArrayOfGriddedField2`")
+      .def_rw(
+          "fitminpressures",
+          &XsecRecord::mfitminpressures,
+          "Fit coefficients\n\n.. :class:`~pyarts3.arts.ArrayOfGriddedField2`")
+      .def_rw(
+          "fitmaxpressures",
+          &XsecRecord::mfitmaxpressures,
+          "Fit coefficients\n\n.. :class:`~pyarts3.arts.ArrayOfGriddedField2`")
+      .def_rw(
+          "fitmintemperatures",
+          &XsecRecord::mfitmintemperatures,
+          "Fit coefficients\n\n.. :class:`~pyarts3.arts.ArrayOfGriddedField2`")
+      .def_rw(
+          "fitmaxtemperatures",
+          &XsecRecord::mfitmaxtemperatures,
+          "Fit coefficients\n\n.. :class:`~pyarts3.arts.ArrayOfGriddedField2`")
       .def(
           "propagation_matrix",
           [](const XsecRecord& self,
@@ -360,8 +365,8 @@ abs : Vector
       },
       "f"_a,
       "atm"_a,
-      "spec"_a          = SpeciesEnum::Bath,
-      "kwargs"_a        = py::kwargs{},
+      "spec"_a   = SpeciesEnum::Bath,
+      "kwargs"_a = py::kwargs{},
       R"--(Computes the Hitran cross-section absorption in 1/m
 
 Parameters

--- a/src/python_interface/py_zeeman.cpp
+++ b/src/python_interface/py_zeeman.cpp
@@ -78,17 +78,25 @@ void py_zeeman(py::module_& m) try {
       .def_prop_ro_static(
           "sm",
           [](py::object&) { return lbl::zeeman::pol::sm; },
-          R"-x-(Sigma minus)-x-")
+          R"-x-(Sigma minus
+.. :class:`int`
+)-x-")
       .def_prop_ro_static(
           "sp",
           [](py::object&) { return lbl::zeeman::pol::sp; },
-          R"-x-(Sigma plus)-x-")
+          R"-x-(Sigma plus
+.. :class:`int`
+)-x-")
       .def_prop_ro_static(
-          "pi", [](py::object&) { return lbl::zeeman::pol::pi; }, R"-x-(Pi)-x-")
+          "pi", [](py::object&) { return lbl::zeeman::pol::pi; }, R"-x-(Pi
+.. :class:`int`
+)-x-")
       .def_prop_ro_static(
           "no",
           [](py::object&) { return lbl::zeeman::pol::no; },
-          R"-x-(Unpolarized)-x-")
+          R"-x-(Unpolarized
+.. :class:`int`
+)-x-")
       .def("__str__", [](const lbl::zeeman::pol& x) { return from(x); })
       .def("__repr__", [](const lbl::zeeman::pol& x) { return from(x); })
       .doc() = "Polarization state of Zeeman calculations";
@@ -96,42 +104,63 @@ void py_zeeman(py::module_& m) try {
 
   py::class_<lbl::zeeman::magnetic_angles>(zee, "MagneticAngles")
       .def(py::init<Vector3, Vector2>())
-      .def_ro("u", &lbl::zeeman::magnetic_angles::u, "Magnetic u")
-      .def_ro("v", &lbl::zeeman::magnetic_angles::v, "Magnetic v")
-      .def_ro("w", &lbl::zeeman::magnetic_angles::w, "Magnetic w")
-      .def_ro("sa", &lbl::zeeman::magnetic_angles::sa, "Magnetic cos(asimuth)")
-      .def_ro("ca", &lbl::zeeman::magnetic_angles::ca, "Magnetic sin(asimuth)")
-      .def_ro("sz", &lbl::zeeman::magnetic_angles::sz, "Magnetic sin(zenith)")
-      .def_ro("cz", &lbl::zeeman::magnetic_angles::cz, "Magnetic cos(zenith)")
+      .def_ro("u",
+              &lbl::zeeman::magnetic_angles::u,
+              "Magnetic u\n\n.. :class:`Numeric`")
+      .def_ro("v",
+              &lbl::zeeman::magnetic_angles::v,
+              "Magnetic v\n\n.. :class:`Numeric`")
+      .def_ro("w",
+              &lbl::zeeman::magnetic_angles::w,
+              "Magnetic w\n\n.. :class:`Numeric`")
+      .def_ro("sa",
+              &lbl::zeeman::magnetic_angles::sa,
+              "Magnetic cos(asimuth)\n\n.. :class:`Numeric`")
+      .def_ro("ca",
+              &lbl::zeeman::magnetic_angles::ca,
+              "Magnetic sin(asimuth)\n\n.. :class:`Numeric`")
+      .def_ro("sz",
+              &lbl::zeeman::magnetic_angles::sz,
+              "Magnetic sin(zenith)\n\n.. :class:`Numeric`")
+      .def_ro("cz",
+              &lbl::zeeman::magnetic_angles::cz,
+              "Magnetic cos(zenith)\n\n.. :class:`Numeric`")
       .def_ro("H",
               &lbl::zeeman::magnetic_angles::H,
-              "Absolute magnetic field strength")
-      .def_ro("uct", &lbl::zeeman::magnetic_angles::uct, "Angle constant")
+              "Absolute magnetic field strength\n\n.. :class:`Numeric`")
+      .def_ro("uct",
+              &lbl::zeeman::magnetic_angles::uct,
+              "Angle constant\n\n.. :class:`Numeric`")
       .def_ro("duct",
               &lbl::zeeman::magnetic_angles::duct,
-              "Derivative of angle constant")
+              "Derivative of angle constant\n\n.. :class:`Numeric`")
+      .def_prop_ro("theta",
+                   &lbl::zeeman::magnetic_angles::theta,
+                   "Magnetic angle theta\n\n.. :class:`Numeric`")
+      .def_prop_ro("eta",
+                   &lbl::zeeman::magnetic_angles::eta,
+                   "Magnetic angle eta\n\n.. :class:`Numeric`")
       .def_prop_ro(
-          "theta", &lbl::zeeman::magnetic_angles::theta, "Magnetic angle theta")
+          "dtheta_du",
+          &lbl::zeeman::magnetic_angles::dtheta_du,
+          "Derivative of theta with respect to u\n\n.. :class:`Numeric`")
       .def_prop_ro(
-          "eta", &lbl::zeeman::magnetic_angles::eta, "Magnetic angle eta")
-      .def_prop_ro("dtheta_du",
-                   &lbl::zeeman::magnetic_angles::dtheta_du,
-                   "Derivative of theta with respect to u")
-      .def_prop_ro("dtheta_dv",
-                   &lbl::zeeman::magnetic_angles::dtheta_dv,
-                   "Derivative of theta with respect to v")
-      .def_prop_ro("dtheta_dw",
-                   &lbl::zeeman::magnetic_angles::dtheta_dw,
-                   "Derivative of theta with respect to w")
+          "dtheta_dv",
+          &lbl::zeeman::magnetic_angles::dtheta_dv,
+          "Derivative of theta with respect to v\n\n.. :class:`Numeric`")
+      .def_prop_ro(
+          "dtheta_dw",
+          &lbl::zeeman::magnetic_angles::dtheta_dw,
+          "Derivative of theta with respect to w\n\n.. :class:`Numeric`")
       .def_prop_ro("deta_du",
                    &lbl::zeeman::magnetic_angles::deta_du,
-                   "Derivative of eta with respect to u")
+                   "Derivative of eta with respect to u\n\n.. :class:`Numeric`")
       .def_prop_ro("deta_dv",
                    &lbl::zeeman::magnetic_angles::deta_dv,
-                   "Derivative of eta with respect to v")
+                   "Derivative of eta with respect to v\n\n.. :class:`Numeric`")
       .def_prop_ro("deta_dw",
                    &lbl::zeeman::magnetic_angles::deta_dw,
-                   "Derivative of eta with respect to w")
+                   "Derivative of eta with respect to w\n\n.. :class:`Numeric`")
       .doc() =
       "Magnetic angles for the Zeeman effect, note that the numbers are in radians.";
 

--- a/src/workspace_group_friends.cpp
+++ b/src/workspace_group_friends.cpp
@@ -445,7 +445,7 @@ It holds essentially two things:
     #. *Numeric* - The data field is constant in the atmosphere.
        Cannot consider the extrapolation rules as there is no grid.
 
-    #. *SortedGriddedField3* - The grids are altitude, latitude, longitude.
+    #. *GeodeticField3* - The grids are altitude, latitude, longitude.
        Will consider the extrapolation rules but otherwise performs linear interpolation between all points.
        With the additional rule that longitude is considerd cyclic around [-180, 180).
 

--- a/src/workspace_groups.cpp
+++ b/src/workspace_groups.cpp
@@ -73,7 +73,7 @@ does not change the global workspace while minimizing the number of variables th
   wsg_data["Any"] = {
       .file = "supergeneric.h",
       .desc =
-          "Meta type for when methods can take any argument (avoid manual use - there is non)\n",
+          "Meta type for any workspace group (see :doc:`workspace.groups`)\n",
   };
 
   wsg_data["ArrayOfArrayOfSpeciesTag"] = {
@@ -773,25 +773,29 @@ The grids are 6 *AscendingGrid*.
 
   wsg_data["ZenithGrid"] = {
       .file = "matpack.h",
-      .desc = R"--(A 1-dimensional vector of *Numeric* that are guaranteed to be within the range [0, 180].
+      .desc =
+          R"--(A 1-dimensional vector of *Numeric* that are guaranteed to be within the range [0, 180].
 )--",
   };
 
   wsg_data["AzimuthGrid"] = {
       .file = "matpack.h",
-      .desc = R"--(A 1-dimensional vector of *Numeric* that are guaranteed to be within the range [0, 360).
+      .desc =
+          R"--(A 1-dimensional vector of *Numeric* that are guaranteed to be within the range [0, 360).
 )--",
   };
 
   wsg_data["LonGrid"] = {
       .file = "matpack.h",
-      .desc = R"--(A 1-dimensional vector of *Numeric* that are guaranteed to be within the range [-180, 180).
+      .desc =
+          R"--(A 1-dimensional vector of *Numeric* that are guaranteed to be within the range [-180, 180).
 )--",
   };
 
   wsg_data["LatGrid"] = {
       .file = "matpack.h",
-      .desc = R"--(A 1-dimensional vector of *Numeric* that are guaranteed to be within the range [-90, 90].
+      .desc =
+          R"--(A 1-dimensional vector of *Numeric* that are guaranteed to be within the range [-90, 90].
 )--",
   };
 


### PR DESCRIPTION
This enforces that the type information for attributes and properties added to ``pyarts3.arts`` is documented.  It does not check whether the type information is valid.

The following must now be added to all new attributes:

```
R"(Here is a docstring

.. :class:`here-is-the-type`)"
```

The syntax uses Sphinx's comment system, so the type will not appear in the doc-string itself.  Instead when I am looking at the type, I extract the information.  If your type can have multiple types (i.e., is a variant), you can just repeat
```
.. :class:`more-types`
```
as you please.

*We should have some sort of enfored internal-links-work policy, but I have no idea how to find it.  Some text is even colored as if it is a link even though it is not in the current settings...