### PR TITLE
Sorted disort

### DIFF
--- a/examples/1-getting-started/3-disort/1.clearsky-radiance.py
+++ b/examples/1-getting-started/3-disort/1.clearsky-radiance.py
@@ -66,19 +66,19 @@ if PLOT:
 
     plt.semilogy(
         f,
-        ws.disort_spectral_radiance_field[:, 0, 0, : (NQuad // 2)],
+        ws.disort_spectral_radiance_field.data[:, 0, 0, : (NQuad // 2)],
         label="disort",
     )
     plt.semilogy(f, ws.spectral_radiance[:, 0], "k--", lw=3)
     plt.semilogy(
         f,
-        ws.disort_spectral_radiance_field[:, 0, 0, 0],
+        ws.disort_spectral_radiance_field.data[:, 0, 0, (NQuad // 2) - 1],
         "g:",
         lw=3,
     )
     plt.semilogy(
         f,
-        ws.disort_spectral_radiance_field[:, 0, 0, (NQuad // 2) - 1],
+        ws.disort_spectral_radiance_field.data[:, 0, 0, 0],
         "m:",
         lw=3,
     )
@@ -89,7 +89,7 @@ if PLOT:
 # %% The last test should be that we are close to the correct values
 
 assert np.allclose(
-    ws.disort_spectral_radiance_field[:, 0, 0, NQuad // 2-1]
+    ws.disort_spectral_radiance_field.data[:, 0, 0, 0]
     / ws.spectral_radiance[:, 0],
     1,
     rtol=1e-3,

--- a/examples/1-getting-started/3-disort/2.clearsky-flux.py
+++ b/examples/1-getting-started/3-disort/2.clearsky-flux.py
@@ -52,7 +52,8 @@ ws.disort_spectral_flux_fieldFromAgenda(
 )
 
 assert np.allclose(
-    ws.disort_spectral_flux_field[:, :2].flatten()
+    np.append(ws.disort_spectral_flux_field.up,
+              ws.disort_spectral_flux_field.down_diffuse, axis=1).flatten()
     / np.array(
         [
             2.65924430e-15,

--- a/examples/1-getting-started/3-disort/3.clearsky-flux-from-dataset.py
+++ b/examples/1-getting-started/3-disort/3.clearsky-flux-from-dataset.py
@@ -68,7 +68,7 @@ if not pyarts.arts.globals.data.is_lgpl:
     ws.disort_spectral_flux_fieldFromAgenda()
 
     plt.semilogy(pyarts.arts.convert.freq2kaycm(ws.frequency_grid),
-                ws.disort_spectral_flux_field[:, 1])
+                ws.disort_spectral_flux_field.down_diffuse)
 
     f, s = pyarts.plots.AtmField.plot(ws.atmospheric_field,
                             alts=np.linspace(0, ws.atmospheric_field.top_of_atmosphere))

--- a/examples/1-getting-started/4-scattering/disort/disort.sht.py
+++ b/examples/1-getting-started/4-scattering/disort/disort.sht.py
@@ -188,7 +188,7 @@ def calculate_tbs_disort():
         disort_fourier_mode_dimension=1,
         max_step=100
     )
-    disort_stokes = [[ws.disort_spectral_radiance_field[f_ind, 0, 0, 19], 0.0, 0.0, 0.0] for f_ind in range(3)]
+    disort_stokes = [[ws.disort_spectral_radiance_field.data[f_ind, 0, 0, 0], 0.0, 0.0, 0.0] for f_ind in range(3)]
     ws.spectral_radiance = disort_stokes
     ws.spectral_radianceApplyForwardUnit(ray_path_point=ws.ray_path[0])
     return ws.spectral_radiance.value.copy()[:, 0]

--- a/python/src/pyarts3/recipe/SpectralAtmosphericFlux.py
+++ b/python/src/pyarts3/recipe/SpectralAtmosphericFlux.py
@@ -32,7 +32,8 @@ class SpectralAtmosphericFlux:
         solar_latitude: float = 0.0,
         solar_longitude: float = 0.0,
         species=["H2O-161", "O2-66", "N2-44", "CO2-626", "O3-XFIT"],
-        remove_lines_percentile: dict[pyarts.arts.SpeciesEnum, float] | float | None = None,
+        remove_lines_percentile: dict[pyarts.arts.SpeciesEnum,
+                                      float] | float | None = None,
     ):
         """Compute the total flux for a given atmospheric profile and surface temperature
 
@@ -172,7 +173,8 @@ class SpectralAtmosphericFlux:
         # Shape is f x 3 x np, we want 3 x f x np
 
         return (
-            Flux(*np.einsum("ijk->jik", self.ws.disort_spectral_flux_field)),
+            Flux(self.ws.disort_spectral_flux_field.up, self.ws.disort_spectral_flux_field.down_diffuse,
+                 self.ws.disort_spectral_flux_field.down_direct),
             np.array(
                 [
                     0.5 * (self.ws.ray_path[i].pos[0] + self.ws.ray_path[i + 1].pos[0])

--- a/src/core/disort-cpp/disort.h
+++ b/src/core/disort-cpp/disort.h
@@ -6,10 +6,22 @@
 
 #include <format>
 #include <iosfwd>
+#include <string_view>
 
 #include "disort-eigen.h"
+#include "matpack_mdspan_helpers_grid_t.h"
 
 namespace disort {
+struct fluxes {
+  AscendingGrid frequency_grid;
+  DescendingGrid altitude_grid;  // level
+  Matrix up;
+  Matrix down_diffuse;
+  Matrix down_direct;
+
+  void resize(AscendingGrid frequency_grid, DescendingGrid altitude_grid);
+};
+
 struct BDRF {
   using func_t = CustomOperator<void,
                                 MatrixView,
@@ -622,40 +634,42 @@ struct DisortSettings {
   Index quadrature_dimension{0};
   Index legendre_polynomial_dimension{0};
   Index fourier_mode_dimension{0};
-  Index nfreq{0};
-  Index nlay{0};
 
-  // nfreq
+  // Grids
+  AscendingGrid frequency_grid{};
+  DescendingGrid altitude_grid{};  // levels not layers
+
+  // frequency_grid.size()
   Vector solar_azimuth_angle{};
 
-  // nfreq
+  // frequency_grid.size()
   Vector solar_zenith_angle{};
 
-  // nfreq
+  // frequency_grid.size()
   Vector solar_source{};
 
-  // nfreq x nbrdf
+  // frequency_grid.size() x nbrdf
   MatrixOfDisortBDRF bidirectional_reflectance_distribution_functions{};
 
-  // nfreq x nlay
+  // frequency_grid.size() x [altitude_grid.size() - 1]
   Matrix optical_thicknesses{};
 
-  // nfreq x nlay
+  // frequency_grid.size() x [altitude_grid.size() - 1]
   Matrix single_scattering_albedo{};
 
-  // nfreq x nlay
+  // frequency_grid.size() x [altitude_grid.size() - 1]
   Matrix fractional_scattering{};
 
-  // nfreq x nlay x nsrc
+  // frequency_grid.size() x [altitude_grid.size() - 1] x nsrc
   Tensor3 source_polynomial{};
 
-  // nfreq x nlay x legendre_polynomial_dimension_full <- last is unknown at construction, must be larger or equal to legendre_polynomial_dimension
+  // frequency_grid.size() x [altitude_grid.size() - 1] x legendre_polynomial_dimension_full <- last is unknown at construction, must be larger or equal to legendre_polynomial_dimension
   Tensor3 legendre_coefficients{};
 
-  // nfreq x fourier_mode_dimension x quadrature_dimension / 2
+  // frequency_grid.size() x fourier_mode_dimension x quadrature_dimension / 2
   Tensor3 positive_boundary_condition{};
 
-  // nfreq x fourier_mode_dimension x quadrature_dimension / 2.
+  // frequency_grid.size() x fourier_mode_dimension x quadrature_dimension / 2.
   Tensor3 negative_boundary_condition{};
 
   DisortSettings() = default;
@@ -663,10 +677,11 @@ struct DisortSettings {
   void resize(Index quadrature_dimension,
               Index legendre_polynomial_dimension,
               Index fourier_mode_dimension,
-              Index nfreq,
-              Index nlay);
+              AscendingGrid frequency_grid,
+              DescendingGrid altitude_grid);
 
-  [[nodiscard]] Index frequency_count() const { return nfreq; }
+  [[nodiscard]] Index frequency_count() const { return frequency_grid.size(); }
+  [[nodiscard]] Index layer_count() const { return altitude_grid.size() - 1; }
 
   [[nodiscard]] disort::main_data init() const;
   disort::main_data& set(disort::main_data&, Index iv) const;
@@ -918,11 +933,11 @@ legendre_polynomial_dimension: ")-x-"sv,
 fourier_mode_dimension:        ")-x-"sv,
           v.fourier_mode_dimension,
           R"-x-(
-nfreq:                         ")-x-"sv,
-          v.nfreq,
+frequency_grid.size():         ")-x-"sv,
+          v.frequency_grid.size(),
           R"-x-(
-nlay:                          ")-x-"sv,
-          v.nlay,
+altitude_grid.size():          ")-x-"sv,
+          v.altitude_grid.size(),
           R"-x-(
 nsrc:                          ")-x-"sv,
           v.source_polynomial.ncols(),
@@ -933,38 +948,37 @@ nbrdf:                         ")-x-"sv,
 
 solar_source.shape():                                     ")-x-"sv,
           v.solar_source.shape(),
-          R"-x-( - should be nfreq.
+          R"-x-( - should be frequency_grid.size().
 solar_zenith_angle.shape():                               ")-x-"sv,
           v.solar_zenith_angle.shape(),
-          R"-x-( - should be nfreq.
+          R"-x-( - should be frequency_grid.size().
 solar_azimuth_angle.shape():                              ")-x-"sv,
-
           v.solar_azimuth_angle.shape(),
-          R"-x-( - should be nfreq.
+          R"-x-( - should be frequency_grid.size().
 bidirectional_reflectance_distribution_functions.shape(): ")-x-"sv,
           v.bidirectional_reflectance_distribution_functions.shape(),
-          R"-x-( - should be nfreq x nbrdf.
+          R"-x-( - should be frequency_grid.size() x nbrdf.
 optical_thicknesses.shape():                              ")-x-"sv,
           v.optical_thicknesses.shape(),
-          R"-x-( - should be nfreq x nlay.
+          R"-x-( - should be frequency_grid.size() x [altitude_grid.size() - 1].
 single_scattering_albedo.shape():                         ")-x-"sv,
           v.single_scattering_albedo.shape(),
-          R"-x-( - should be nfreq x nlay.
+          R"-x-( - should be frequency_grid.size() x [altitude_grid.size() - 1].
 fractional_scattering.shape():                            ")-x-"sv,
           v.fractional_scattering.shape(),
-          R"-x-( - should be nfreq x nlay.
+          R"-x-( - should be frequency_grid.size() x [altitude_grid.size() - 1].
 source_polynomial.shape():                                ")-x-"sv,
           v.source_polynomial.shape(),
-          R"-x-( - should be nfreq x nlay x nsrc.
+          R"-x-( - should be frequency_grid.size() x [altitude_grid.size() - 1] x nsrc.
 legendre_coefficients.shape():                            ")-x-"sv,
           v.legendre_coefficients.shape(),
-          R"-x-( - should be nfreq x nlay x nleg.
+          R"-x-( - should be frequency_grid.size() x [altitude_grid.size() - 1] x nleg.
 positive_boundary_condition.shape():                      ")-x-"sv,
           v.positive_boundary_condition.shape(),
-          R"-x-( - should be nfreq x nlay x (quadrature_dimension / 2).
+          R"-x-( - should be frequency_grid.size() x [altitude_grid.size() - 1] x (quadrature_dimension / 2).
 negative_boundary_condition.shape():                      ")-x-"sv,
           v.negative_boundary_condition.shape(),
-          R"-x-( - should be nfreq x nlay x (quadrature_dimension / 2).)-x-"sv);
+          R"-x-( - should be frequency_grid.size() x [altitude_grid.size() - 1] x (quadrature_dimension / 2).)-x-"sv);
     }
     return tags.format(
         ctx,
@@ -977,11 +991,11 @@ legendre_polynomial_dimension: ")-x-"sv,
 fourier_mode_dimension:        ")-x-"sv,
         v.fourier_mode_dimension,
         R"-x-(
-nfreq:                         ")-x-"sv,
-        v.nfreq,
+frequency_grid:                ")-x-"sv,
+        v.frequency_grid,
         R"-x-(
-nlay:                          ")-x-"sv,
-        v.nlay,
+altitude_grid:                 ")-x-"sv,
+        v.altitude_grid,
         R"-x-(
 nsrc:                          ")-x-"sv,
         v.source_polynomial.ncols(),
@@ -1060,4 +1074,44 @@ struct xml_io_stream<DisortSettings> {
   static void read(std::istream& is,
                    DisortSettings& x,
                    bifstream* pbifs = nullptr);
+};
+
+using DisortFlux = disort::fluxes;
+
+template <>
+struct xml_io_stream_name<DisortFlux> {
+  constexpr static std::string_view name = "DisortFlux"sv;
+};
+
+template <>
+struct xml_io_stream_aggregate<DisortFlux> {
+  constexpr static bool value = true;
+};
+
+template <>
+struct std::formatter<DisortFlux> {
+  format_tags tags;
+
+  [[nodiscard]] constexpr auto& inner_fmt() { return *this; }
+  [[nodiscard]] constexpr auto& inner_fmt() const { return *this; }
+
+  constexpr std::format_parse_context::iterator parse(
+      std::format_parse_context& ctx) {
+    return parse_format_tags(tags, ctx);
+  }
+
+  template <class FmtContext>
+  FmtContext::iterator format(const DisortFlux& v, FmtContext& ctx) const {
+    auto sep = tags.sep(true);
+    return tags.format(ctx,
+                       v.frequency_grid,
+                       sep,
+                       v.altitude_grid,
+                       sep,
+                       v.up,
+                       sep,
+                       v.down_diffuse,
+                       sep,
+                       v.down_direct);
+  }
 };

--- a/src/core/matpack/matpack_mdspan_helpers_gridded_data_t.h
+++ b/src/core/matpack/matpack_mdspan_helpers_gridded_data_t.h
@@ -191,6 +191,7 @@ using GriddedField5 =
 using GriddedField6 = matpack::
     gridded_data_t<Numeric, Vector, Vector, Vector, Vector, Vector, Vector>;
 
+using ZenithGriddedField1 = matpack::gridded_data_t<Numeric, ZenithGrid>;
 using SortedGriddedField1 = matpack::gridded_data_t<Numeric, AscendingGrid>;
 using SortedGriddedField2 =
     matpack::gridded_data_t<Numeric, AscendingGrid, AscendingGrid>;

--- a/src/m_cdisort.cc
+++ b/src/m_cdisort.cc
@@ -107,7 +107,7 @@ void setup_cdisort(disort_state& ds,
 void setup_cdisort_for_frequency(
     disort_state& ds,
     const disort::main_data& dis,
-    const Vector& phis,
+    const AzimuthGrid& phis,
     const ArrayOfAtmPoint& ray_path_atmospheric_point,
     const Numeric& frequency) {
   // fill up azimuth angle and temperature array
@@ -213,7 +213,7 @@ void disort_spectral_radiance_fieldCalcCdisort(
     const ArrayOfAscendingGrid& ray_path_frequency_grid,
     const ArrayOfPropagationPathPoint& ray_path,
     const SurfaceField& surface_field,
-    const Vector& phis) {
+    const AzimuthGrid& phis) {
   ARTS_TIME_REPORT
 
   using Conversion::acosd;

--- a/src/m_cdisort.cc
+++ b/src/m_cdisort.cc
@@ -61,7 +61,8 @@ void setup_cdisort(disort_state& ds,
   ds.flag.general_source = FALSE;
   ds.flag.output_uum     = FALSE;
 
-  ds.nlyr = static_cast<int>(disort_settings.layer_count());  // pressure.nelem() - 1
+  ds.nlyr =
+      static_cast<int>(disort_settings.layer_count());  // pressure.nelem() - 1
 
   ds.flag.brdf_type = BRDF_NONE;
 
@@ -119,7 +120,7 @@ void setup_cdisort_for_frequency(
   }
 
   for (Index i = 0; i < ds.numu / 2; i++) {
-    ds.umu[i] = dis.mu()[ds.numu - i - 1];
+    ds.umu[i]               = dis.mu()[ds.numu - i - 1];
     ds.umu[i + ds.numu / 2] = dis.mu()[i];
   }
 
@@ -205,9 +206,8 @@ void run_cdisort(Tensor3View disort_spectral_radiance_field,
 }  // namespace
 
 void disort_spectral_radiance_fieldCalcCdisort(
-    Tensor4& disort_spectral_radiance_field,
-    Vector& disort_quadrature_angles,
-    Vector& disort_quadrature_weights,
+    DisortRadiance& disort_spectral_radiance_field,
+    ZenithGriddedField1& disort_quadrature,
     const DisortSettings& disort_settings,
     const ArrayOfAtmPoint& ray_path_atmospheric_point,
     const ArrayOfAscendingGrid& ray_path_frequency_grid,
@@ -216,29 +216,21 @@ void disort_spectral_radiance_fieldCalcCdisort(
     const AzimuthGrid& phis) {
   ARTS_TIME_REPORT
 
-  using Conversion::acosd;
-
   const Index nv    = disort_settings.frequency_count();
-  const Index np    = disort_settings.layer_count();
-  const Index nquad = disort_settings.quadrature_dimension;
-
-  disort_spectral_radiance_field.resize(nv, np, phis.size(), nquad);
 
   disort::main_data dis = disort_settings.init();
+
+  disort_quadrature = dis.gridded_weights();
 
   const Numeric surface_temperature =
       surface_field.single_value(SurfaceKey::t,
                                  ray_path[ray_path.size() - 1].latitude(),
                                  ray_path[ray_path.size() - 1].longitude());
 
-  //! Supplementary outputs
-  disort_quadrature_weights = dis.weights();
-  disort_quadrature_angles.resize(nquad);
-
-  std::transform(dis.mu().begin(),
-                 dis.mu().end(),
-                 disort_quadrature_angles.begin(),
-                 [](const Numeric& mu) { return acosd(mu); });
+  disort_spectral_radiance_field.resize(disort_settings.frequency_grid,
+                                        disort_settings.altitude_grid,
+                                        phis,
+                                        disort_quadrature.grid<0>());
 
   disort_state ds;
   setup_cdisort(ds, phis, disort_settings, dis, surface_temperature);
@@ -260,7 +252,7 @@ void disort_spectral_radiance_fieldCalcCdisort(
                                   ray_path_atmospheric_point,
                                   ray_path_frequency_grid[0][iv]);
 
-      run_cdisort(disort_spectral_radiance_field[iv], ds, out);
+      run_cdisort(disort_spectral_radiance_field.data[iv], ds, out);
 
       /* Free allocated memory */
       c_disort_out_free(&ds, &out);
@@ -270,6 +262,9 @@ void disort_spectral_radiance_fieldCalcCdisort(
       if (error.empty()) error = e.what();
     }
   }
+
+  //! FIXME: It would be nice to remove this if the internal angles can be solved
+  disort_spectral_radiance_field.sort(dis.mu());
 
   ARTS_USER_ERROR_IF(
       error.size(), "Error occurred in disort-spectral:\n{}", error);

--- a/src/m_cdisort.cc
+++ b/src/m_cdisort.cc
@@ -61,7 +61,7 @@ void setup_cdisort(disort_state& ds,
   ds.flag.general_source = FALSE;
   ds.flag.output_uum     = FALSE;
 
-  ds.nlyr = static_cast<int>(disort_settings.nlay);  // pressure.nelem() - 1
+  ds.nlyr = static_cast<int>(disort_settings.layer_count());  // pressure.nelem() - 1
 
   ds.flag.brdf_type = BRDF_NONE;
 
@@ -218,8 +218,8 @@ void disort_spectral_radiance_fieldCalcCdisort(
 
   using Conversion::acosd;
 
-  const Index nv    = disort_settings.nfreq;
-  const Index np    = disort_settings.nlay;
+  const Index nv    = disort_settings.frequency_count();
+  const Index np    = disort_settings.layer_count();
   const Index nquad = disort_settings.quadrature_dimension;
 
   disort_spectral_radiance_field.resize(nv, np, phis.size(), nquad);

--- a/src/m_disort.cc
+++ b/src/m_disort.cc
@@ -5,13 +5,6 @@
 
 #include <algorithm>
 #include <format>
-#include <numeric>
-#include <vector>
-
-#include "arts_constants.h"
-#include "configtypes.h"
-#include "debug.h"
-#include "path_point.h"
 
 ////////////////////////////////////////////////////////////////////////
 // Core Disort
@@ -21,7 +14,7 @@ void disort_spectral_radiance_fieldCalc(Tensor4& disort_spectral_radiance_field,
                                         Vector& disort_quadrature_angles,
                                         Vector& disort_quadrature_weights,
                                         const DisortSettings& disort_settings,
-                                        const Vector& phis) {
+                                        const AzimuthGrid& phis) {
   ARTS_TIME_REPORT
 
   using Conversion::acosd;

--- a/src/python_interface/py_disort.cpp
+++ b/src/python_interface/py_disort.cpp
@@ -231,8 +231,12 @@ void py_disort(py::module_& m) try {
   disort_settings.def_rw("fourier_mode_dimension",
                          &DisortSettings::fourier_mode_dimension,
                          ".. :class:`Index`");
-  disort_settings.def_rw("nfreq", &DisortSettings::nfreq, ".. :class:`Index`");
-  disort_settings.def_rw("nlay", &DisortSettings::nlay, ".. :class:`Index`");
+  disort_settings.def_rw("frequency_grid",
+                         &DisortSettings::frequency_grid,
+                         ".. :class:`AscendingGrid`");
+  disort_settings.def_rw("altitude_grid",
+                         &DisortSettings::altitude_grid,
+                         ".. :class:`DescendingGrid`");
   disort_settings.def_rw("solar_azimuth_angle",
                          &DisortSettings::solar_azimuth_angle,
                          ".. :class:`Vector`");
@@ -266,6 +270,25 @@ void py_disort(py::module_& m) try {
   disort_settings.def_rw("negative_boundary_condition",
                          &DisortSettings::negative_boundary_condition,
                          ".. :class:`Tensor3`");
+
+  py::class_<DisortFlux> df(m, "DisortFlux");
+  generic_interface(df);
+  df.def_rw("frequency_grid",
+            &DisortFlux::frequency_grid,
+            "Frequency grid of the fluxes\n\n.. :class:`AscendingGrid`");
+  df.def_rw(
+      "altitude_grid",
+      &DisortFlux::altitude_grid,
+      "Altitude grid of the fluxes (level values)\n\n.. :class:`DescendingGrid`");
+  df.def_rw("up",
+            &DisortFlux::up,
+            "Upwelling flux (layer values)\n\n.. :class:`Matrix`");
+  df.def_rw("down_diffuse",
+            &DisortFlux::down_diffuse,
+            "Downward diffuse flux (layer values)\n\n.. :class:`Matrix`");
+  df.def_rw("down_direct",
+            &DisortFlux::down_direct,
+            "Downward direct flux (layer values)\n\n.. :class:`Matrix`");
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format("DEV ERROR:\nCannot initialize disort\n{}", e.what()));

--- a/src/python_interface/py_disort.cpp
+++ b/src/python_interface/py_disort.cpp
@@ -289,6 +289,25 @@ void py_disort(py::module_& m) try {
   df.def_rw("down_direct",
             &DisortFlux::down_direct,
             "Downward direct flux (layer values)\n\n.. :class:`Matrix`");
+
+  py::class_<DisortRadiance> dr(m, "DisortRadiance");
+  generic_interface(dr);
+  dr.def_rw("frequency_grid",
+            &DisortRadiance::frequency_grid,
+            "Frequency grid of the fluxes\n\n.. :class:`AscendingGrid`");
+  dr.def_rw(
+      "altitude_grid",
+      &DisortRadiance::altitude_grid,
+      "Altitude grid of the fluxes (level values)\n\n.. :class:`DescendingGrid`");
+  dr.def_rw("zenith_grid",
+            &DisortRadiance::zenith_grid,
+            "Zenith grid\n\n.. :class:`ZenithGrid`");
+  dr.def_rw("azimuth_grid",
+            &DisortRadiance::azimuth_grid,
+            "Azimuth grid\n\n.. :class:`AzimuthGrid`");
+  dr.def_rw("data",
+            &DisortRadiance::data,
+            "Radiance field (layer values)\n\n.. :class:`Matrix`");
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format("DEV ERROR:\nCannot initialize disort\n{}", e.what()));

--- a/src/python_interface/py_griddedfield.cpp
+++ b/src/python_interface/py_griddedfield.cpp
@@ -58,6 +58,10 @@ void py_griddedfield(py::module_& m) try {
   gridded_data_interface(ngf3);
   generic_interface(ngf3);
 
+  py::class_<ZenithGriddedField1> zgf1n(m, "ZenithGriddedField1");
+  gridded_data_interface(zgf1n);
+  generic_interface(zgf1n);
+
   py::class_<GriddedField1Named> gf1n(m, "GriddedField1Named");
   gridded_data_interface(gf1n);
   generic_interface(gf1n);

--- a/src/workspace_group_friends.cpp
+++ b/src/workspace_group_friends.cpp
@@ -91,6 +91,11 @@ and interpolate the cross-section to other temperatures and pressures
 )",
   };
 
+  wsg_data["Tensor3"] = {
+      .file = "matpack.h",
+      .desc = "A 3 dimensional array of *Numeric*\n",
+  };
+
   wsg_data["Tensor5"] = {
       .file = "matpack.h",
       .desc = "A 5 dimensional array of *Numeric*\n",

--- a/src/workspace_group_friends.cpp
+++ b/src/workspace_group_friends.cpp
@@ -96,6 +96,11 @@ and interpolate the cross-section to other temperatures and pressures
       .desc = "A 3 dimensional array of *Numeric*\n",
   };
 
+  wsg_data["Tensor4"] = {
+      .file = "matpack.h",
+      .desc = "A 4 dimensional array of *Numeric*\n",
+  };
+
   wsg_data["Tensor5"] = {
       .file = "matpack.h",
       .desc = "A 5 dimensional array of *Numeric*\n",

--- a/src/workspace_groups.cpp
+++ b/src/workspace_groups.cpp
@@ -367,11 +367,6 @@ A sub-surface field effectively holds two things:
 )--",
   };
 
-  wsg_data["Tensor4"] = {
-      .file = "matpack.h",
-      .desc = "A 4 dimensional array of *Numeric*\n",
-  };
-
   wsg_data["Time"] = {
       .file = "artstime.h",
       .desc = R"(Represents a time stamp
@@ -692,6 +687,18 @@ line-of-sight to get the corresponding spectral radiance.
 )",
   };
 
+  wsg_data["DisortRadiance"] = {
+      .file = "disort.h",
+      .desc = R"(The radiance result variable for Disort.
+
+#. *AscendingGrid* frequency grid
+#. *DescendingGrid* level altitude grid
+#. *AzimuthGrid* azimuth grid
+#. *ZenithGrid* zenith grid
+#. *Tensor4* radiance data
+)",
+  };
+
   wsg_data["DisortSettings"] = {
       .file = "disort.h",
       .desc = R"(The settings required to run Disort.
@@ -721,8 +728,16 @@ line-of-sight to get the corresponding spectral radiance.
       .map_type = true,
   };
 
+  wsg_data["ZenithGriddedField1"] = {
+      .file = "matpack.h",
+      .desc = R"--(A 1-dimensional gridof *Numeric*.
+
+The grids are 1 *ZenithGrid*.
+)--",
+  };
+
   wsg_data["SortedGriddedField1"] = {
-      .file = "rtepack.h",
+      .file = "matpack.h",
       .desc = R"--(A 1-dimensional gridof *Numeric*.
 
 The grids are 1 *AscendingGrid*.
@@ -730,7 +745,7 @@ The grids are 1 *AscendingGrid*.
   };
 
   wsg_data["SortedGriddedField2"] = {
-      .file = "rtepack.h",
+      .file = "matpack.h",
       .desc = R"--(A 2-dimensional gridof *Numeric*.
 
 The grids are 2 *AscendingGrid*.
@@ -738,7 +753,7 @@ The grids are 2 *AscendingGrid*.
   };
 
   wsg_data["GeodeticField2"] = {
-      .file = "rtepack.h",
+      .file = "matpack.h",
       .desc = R"--(A 2-dimensional gridof *Numeric*.
 
 The grids are *latitude_grid* x *longitude_grid*.
@@ -747,7 +762,7 @@ The types are *LatGrid* x *LonGrid*.
   };
 
   wsg_data["SortedGriddedField3"] = {
-      .file = "rtepack.h",
+      .file = "matpack.h",
       .desc = R"--(A 3-dimensional gridof *Numeric*.
 
 The grids are 3 *AscendingGrid*.
@@ -755,7 +770,7 @@ The grids are 3 *AscendingGrid*.
   };
 
   wsg_data["SortedGriddedField4"] = {
-      .file = "rtepack.h",
+      .file = "matpack.h",
       .desc = R"--(A 4-dimensional gridof *Numeric*.
 
 The grids are 4 *AscendingGrid*.
@@ -763,7 +778,7 @@ The grids are 4 *AscendingGrid*.
   };
 
   wsg_data["SortedGriddedField5"] = {
-      .file = "rtepack.h",
+      .file = "matpack.h",
       .desc = R"--(A 5-dimensional gridof *Numeric*.
 
 The grids are 5 *AscendingGrid*.
@@ -771,7 +786,7 @@ The grids are 5 *AscendingGrid*.
   };
 
   wsg_data["SortedGriddedField6"] = {
-      .file = "rtepack.h",
+      .file = "matpack.h",
       .desc = R"--(A 6-dimensional gridof *Numeric*.
 
 The grids are 6 *AscendingGrid*.

--- a/src/workspace_groups.cpp
+++ b/src/workspace_groups.cpp
@@ -367,11 +367,6 @@ A sub-surface field effectively holds two things:
 )--",
   };
 
-  wsg_data["Tensor3"] = {
-      .file = "matpack.h",
-      .desc = "A 3 dimensional array of *Numeric*\n",
-  };
-
   wsg_data["Tensor4"] = {
       .file = "matpack.h",
       .desc = "A 4 dimensional array of *Numeric*\n",
@@ -685,6 +680,18 @@ line-of-sight to get the corresponding spectral radiance.
       .desc = "List of *SensorObsel*.\n",
   };
 
+  wsg_data["DisortFlux"] = {
+      .file = "disort.h",
+      .desc = R"(The flux result variable for Disort.
+
+#. *AscendingGrid* frequency grid
+#. *DescendingGrid* level altitude grid
+#. *Matrix* upwelling flux
+#. *Matrix* diffuse downwelling flux
+#. *Matrix* direct downwelling flux
+)",
+  };
+
   wsg_data["DisortSettings"] = {
       .file = "disort.h",
       .desc = R"(The settings required to run Disort.
@@ -692,8 +699,8 @@ line-of-sight to get the corresponding spectral radiance.
 #. *Index* Quadrature dimension
 #. *Index* Legendre order
 #. *Index* Fourier order
-#. *Index* Number of frequency points
-#. *Index* Number of layers
+#. *Index* The frequency grid
+#. *Index* The level altitude grid
 #. *Vector* Solar azimuth angles
 #. *Vector* Solar zenith angles
 #. *Vector* Solar source

--- a/src/workspace_meta_methods.cpp
+++ b/src/workspace_meta_methods.cpp
@@ -64,9 +64,7 @@ std::vector<WorkspaceMethodInternalMetaRecord> internal_meta_methods_creator() {
       .author = {"Richard Larsson"},
       .methods = {"disort_settings_agendaExecute",
                   "disort_spectral_radiance_fieldCalc"},
-      .out     = {"disort_spectral_radiance_field",
-                  "disort_quadrature_angles",
-                  "disort_quadrature_weights"},
+      .out     = {"disort_spectral_radiance_field", "disort_quadrature"},
   });
 
   wsm_meta.push_back(WorkspaceMethodInternalMetaRecord{
@@ -77,8 +75,7 @@ std::vector<WorkspaceMethodInternalMetaRecord> internal_meta_methods_creator() {
       .methods = {"ray_pathGeometricDownlooking",
                   "disort_spectral_radiance_fieldFromAgenda"},
       .out     = {"disort_spectral_radiance_field",
-                  "disort_quadrature_angles",
-                  "disort_quadrature_weights",
+                  "disort_quadrature",
                   "ray_path"},
   });
 
@@ -91,9 +88,7 @@ std::vector<WorkspaceMethodInternalMetaRecord> internal_meta_methods_creator() {
                   "ray_path_atmospheric_pointFromPath",
                   "ray_path_frequency_gridFromPath",
                   "disort_spectral_radiance_fieldCalcCdisort"},
-      .out     = {"disort_spectral_radiance_field",
-                  "disort_quadrature_angles",
-                  "disort_quadrature_weights"},
+      .out     = {"disort_spectral_radiance_field", "disort_quadrature"},
   });
 
   wsm_meta.push_back(WorkspaceMethodInternalMetaRecord{
@@ -104,8 +99,7 @@ std::vector<WorkspaceMethodInternalMetaRecord> internal_meta_methods_creator() {
       .methods = {"ray_pathGeometricDownlooking",
                   "disort_spectral_radiance_fieldFromAgendaCdisort"},
       .out     = {"disort_spectral_radiance_field",
-                  "disort_quadrature_angles",
-                  "disort_quadrature_weights",
+                  "disort_quadrature",
                   "ray_path"},
   });
 #endif

--- a/src/workspace_methods.cpp
+++ b/src/workspace_methods.cpp
@@ -5300,8 +5300,8 @@ This is WIP and should not be used.
                     "disort_quadrature_weights"},
       .in        = {"disort_settings"},
       .gin       = {"phis"},
-      .gin_type  = {"Vector"},
-      .gin_value = {Vector{0.0}},
+      .gin_type  = {"AzimuthGrid"},
+      .gin_value = {AzimuthGrid{{0.0}}},
       .gin_desc  = {"The azimuthal angles"},
   };
 
@@ -5321,8 +5321,8 @@ CDisort is only included for testing and comparisons with our own disort impleme
                     "ray_path",
                     "surface_field"},
       .gin       = {"phis"},
-      .gin_type  = {"Vector"},
-      .gin_value = {Vector{0.0}},
+      .gin_type  = {"AzimuthGrid"},
+      .gin_value = {AzimuthGrid{{0.0}}},
       .gin_desc  = {"The azimuthal angles"},
   };
 #endif

--- a/src/workspace_methods.cpp
+++ b/src/workspace_methods.cpp
@@ -5296,8 +5296,7 @@ This is WIP and should not be used.
 )",
       .author    = {"Richard Larsson"},
       .out       = {"disort_spectral_radiance_field",
-                    "disort_quadrature_angles",
-                    "disort_quadrature_weights"},
+                    "disort_quadrature"},
       .in        = {"disort_settings"},
       .gin       = {"phis"},
       .gin_type  = {"AzimuthGrid"},
@@ -5313,8 +5312,7 @@ CDisort is only included for testing and comparisons with our own disort impleme
 )",
       .author    = {"Oliver Lemke"},
       .out       = {"disort_spectral_radiance_field",
-                    "disort_quadrature_angles",
-                    "disort_quadrature_weights"},
+                    "disort_quadrature"},
       .in        = {"disort_settings",
                     "ray_path_atmospheric_point",
                     "ray_path_frequency_grid",
@@ -5352,8 +5350,7 @@ CDisort is only included for testing and comparisons with our own disort impleme
       .author = {"Richard Larsson"},
       .out    = {"spectral_radiance"},
       .in     = {"disort_spectral_radiance_field",
-                 "disort_quadrature_angles",
-                 "disort_quadrature_weights"},
+                 "disort_quadrature"},
   };
 
   wsm_data["RetrievalInit"] = {

--- a/src/workspace_variables.cpp
+++ b/src/workspace_variables.cpp
@@ -1025,11 +1025,9 @@ times *disort_quadrature_dimension*.
   wsv_data["disort_spectral_flux_field"] = {
       .desc = R"(The spectral flux field from Disort.
 
-Size is *frequency_grid* times 3 times *ray_path* - 1.
-
 The inner "3" is in order: upwelling, diffuse downwelling, and direct downwelling.
 )",
-      .type = "Tensor3",
+      .type = "DisortFlux",
   };
 
   wsv_data["covariance_matrix_diagonal_blocks"] = {

--- a/src/workspace_variables.cpp
+++ b/src/workspace_variables.cpp
@@ -915,33 +915,30 @@ Dimensions: *ray_path* x *suns* x *sun_path*
       .type = "ArrayOfArrayOfArrayOfPropagationPathPoint",
   };
 
+  wsv_data["disort_spectral_radiance_field"] = {
+      .desc = R"(The spectral radiance field from Disort.
+)",
+      .type = "DisortRadiance",
+  };
+
+  wsv_data["disort_spectral_flux_field"] = {
+      .desc = R"(The spectral flux field from Disort.
+)",
+      .type = "DisortFlux",
+  };
+
   wsv_data["disort_settings"] = {
       .desc = R"(Contains the full settings of spectral Disort calculations.
 )",
       .type = "DisortSettings",
   };
 
-  wsv_data["disort_quadrature_angles"] = {
-      .desc = R"(The quadrature angles for Disort.
+  wsv_data["disort_quadrature"] = {
+      .desc = R"(The quadrature angles for Disort with accompying weights.
 
-Unit is in degrees.
-
-Size is *disort_quadrature_dimension*.
+Size is *disort_quadrature_dimension* or zenith angle grid of *disort_spectral_radiance_field*.
 )",
-      .type = "Vector",
-  };
-
-  wsv_data["disort_quadrature_weights"] = {
-      .desc = R"(The quadrature weights for Disort.
-
-These weights are symmetric for uplooking and downlooking.
-
-In essence, the matching *disort_quadrature_angles* for the weights can
-be found as [*disort_quadrature_weights*, *disort_quadrature_weights*].
-
-Size is *disort_quadrature_dimension* / 2
-)",
-      .type = "Vector",
+      .type = "ZenithGriddedField1",
   };
 
   wsv_data["disort_quadrature_dimension"] = {
@@ -1011,23 +1008,6 @@ Units: degrees
       .desc = R"(The degree of a Legendre polynimial.
 )",
       .type = "Index",
-  };
-
-  wsv_data["disort_spectral_radiance_field"] = {
-      .desc = R"(The spectral radiance field from Disort.
-
-Size is *frequency_grid* times *ray_path* - 1 times azimuthal angles
-times *disort_quadrature_dimension*.
-)",
-      .type = "Tensor4",
-  };
-
-  wsv_data["disort_spectral_flux_field"] = {
-      .desc = R"(The spectral flux field from Disort.
-
-The inner "3" is in order: upwelling, diffuse downwelling, and direct downwelling.
-)",
-      .type = "DisortFlux",
   };
 
   wsv_data["covariance_matrix_diagonal_blocks"] = {

--- a/tests/core/cdisort/disort-comparison.py
+++ b/tests/core/cdisort/disort-comparison.py
@@ -18,7 +18,7 @@ if not pyarts.arts.globals.data.has_cdisort:
 # paths/constants
 # =============================================================================
 
-PLOT = False
+PLOT = True
 toa = 100e3
 lat = 0
 lon = 0

--- a/tests/core/cdisort/disort-comparison.py
+++ b/tests/core/cdisort/disort-comparison.py
@@ -18,7 +18,7 @@ if not pyarts.arts.globals.data.has_cdisort:
 # paths/constants
 # =============================================================================
 
-PLOT = True
+PLOT = False
 toa = 100e3
 lat = 0
 lon = 0
@@ -78,7 +78,7 @@ ws.disort_spectral_radiance_fieldProfileCdisort(
 )
 print("cdisort:   ", datetime.now() - dt)
 
-cdisort_spectral_radiance_field = ws.disort_spectral_radiance_field * 1.0
+cdisort_spectral_radiance_field = ws.disort_spectral_radiance_field.data * 1.0
 
 # cppdisort calculation
 dt = datetime.now()
@@ -92,12 +92,12 @@ ws.disort_spectral_radiance_fieldProfile(
 print("cppdisort: ", datetime.now() - dt)
 
 radiance_field_absdiff = (
-    cdisort_spectral_radiance_field - ws.disort_spectral_radiance_field
+    cdisort_spectral_radiance_field - ws.disort_spectral_radiance_field.data
 )
 
 radiance_field_reldiff = (
-    (cdisort_spectral_radiance_field - ws.disort_spectral_radiance_field)
-    / ws.disort_spectral_radiance_field
+    (cdisort_spectral_radiance_field - ws.disort_spectral_radiance_field.data)
+    / ws.disort_spectral_radiance_field.data
     * 100
 )
 
@@ -108,7 +108,7 @@ imax = np.unravel_index(
 print(
     f"max location: {ws.ray_path[imax[1]].pos[0] / 1000:.1f} km, "
     f"{ws.frequency_grid[imax[0]] / 1e9:.1f} GHz, "
-    f"{ws.disort_quadrature_angles[imax[-1]]:.2f}°"
+    f"{ws.disort_quadrature.grids[0][imax[-1]]:.2f}°"
 )
 
 
@@ -128,7 +128,7 @@ def plot_field(fig, I, ax, title, reldiff=False):
     # =============================================================================
     cmap = cm["managua"]
     colors = cmap(np.linspace(0, 1, N_quad))
-    angles = ws.disort_quadrature_angles[:]
+    angles = ws.disort_quadrature.grids[0][:]
     idx = np.argsort(angles)
     angles = angles[idx]
     I = I[:, :, idx] * 1.0
@@ -163,7 +163,7 @@ def plot_field(fig, I, ax, title, reldiff=False):
 if PLOT:
     plot_field(fig, cdisort_spectral_radiance_field[:, :, 0, :], ax[0:2, 0], "cdisort")
     plot_field(
-        fig, ws.disort_spectral_radiance_field[:, :, 0, :], ax[0:2, 1], "cppdisort"
+        fig, ws.disort_spectral_radiance_field.data[:, :, 0, :], ax[0:2, 1], "cppdisort"
     )
 
     plot_field(
@@ -181,4 +181,4 @@ if PLOT:
     # fig.savefig(f"disort-toa{toa / 1e3:.0f}km.pdf")
     plt.show()
 
-assert np.allclose(cdisort_spectral_radiance_field, ws.disort_spectral_radiance_field)
+assert np.allclose(cdisort_spectral_radiance_field, ws.disort_spectral_radiance_field.data)

--- a/tests/core/scat/henyey-simple.py
+++ b/tests/core/scat/henyey-simple.py
@@ -67,13 +67,13 @@ plt.figure()
 plt.semilogy(f, ws.spectral_radiance[:, 0], "k--", lw=3)
 plt.semilogy(
     f,
-    ws.disort_spectral_radiance_field[:, 0, 0, 0],
+    ws.disort_spectral_radiance_field.data[:, 0, 0, (NQuad // 2) - 1],
     "g:",
     lw=3,
 )
 plt.semilogy(
     f,
-    ws.disort_spectral_radiance_field[:, 0, 0, (NQuad // 2) - 1],
+    ws.disort_spectral_radiance_field.data[:, 0, 0, 0],
     "m:",
     lw=3,
 )
@@ -124,13 +124,13 @@ for manual in [False, True]:
                 plt.semilogy(f, ws.spectral_radiance[:, 0], "k--", lw=3)
                 plt.semilogy(
                     f,
-                    ws.disort_spectral_radiance_field[:, 0, 0, 0],
+                    ws.disort_spectral_radiance_field.data[:, 0, 0, (NQuad // 2) - 1],
                     "g:",
                     lw=3,
                 )
                 plt.semilogy(
                     f,
-                    ws.disort_spectral_radiance_field[:, 0, 0, (NQuad // 2) - 1],
+                    ws.disort_spectral_radiance_field.data[:, 0, 0, 0],
                     "m:",
                     lw=3,
                 )

--- a/tests/python/wsgs/diagnostics-wsg-vs-wsv.py
+++ b/tests/python/wsgs/diagnostics-wsg-vs-wsv.py
@@ -21,7 +21,7 @@ wsgs = pyarts.arts.globals.workspace_groups()
 wsms = pyarts.arts.globals.workspace_methods()
 
 wsgs = {}.fromkeys(wsgs, 0)
-wsgs["CallbackOperator"] = 1
+wsgs["CallbackOperator"] = 1  # Exception since pure user-agenda-method
 
 for wsv in wsvs:
     wsgs[wsvs[wsv].type] += 1
@@ -48,3 +48,5 @@ errors = [f"\n{wsg} should not be a workspace group"
           for wsg in keys if wsgs[wsg] == 0]
 
 assert len(errors) == 0, ", and".join(errors) + '\n' + reason
+
+print("All workspace groups are used in workspace variables or methods")


### PR DESCRIPTION
This returns the disort variables in a more manageable manner.  For flux, a type ``DisortFlux`` is created that names the flux parameters - it contains a frequency grid, an altitude grid, a matrix of upwards flux, a matrix of downward diffuse flux, and a matrix of downwards direct flux.  For radiance, a type ``DisortRadiance`` is created that has a frequency grid, an altitude grid, an azimuth grid and a zenith grid.  Likewise, a ``ZenithGriddedField1`` is now how the quadrature angles are returned.

In these cases, the altitude grid is always the level grid, so the data is one smaller.

It's not trivial to reverse the internal angles it turns out, so I am doing the sorting after-the-fact.