### PR TITLE
Use full package name in stubgen

### DIFF
--- a/cmake/modules/ArtsNanobindStubs.cmake
+++ b/cmake/modules/ArtsNanobindStubs.cmake
@@ -3,9 +3,9 @@ function (ARTS_ADD_CPP_STUBS)
   foreach (MODULENAME IN LISTS ARGN)
     nanobind_add_stub(
       pyarts_${MODULENAME}_cpp_stub
-      MODULE arts.${MODULENAME}
+      MODULE pyarts3.arts.${MODULENAME}
       OUTPUT ${ARTS_BINARY_DIR}/python/src/pyarts3/arts/${MODULENAME}.pyi
-      PYTHON_PATH ${ARTS_BINARY_DIR}/python/src/pyarts3
+      PYTHON_PATH ${ARTS_BINARY_DIR}/python/src
       DEPENDS pyarts_cpp
     )
     list(APPEND deplist "pyarts_${MODULENAME}_cpp_stub")
@@ -13,9 +13,9 @@ function (ARTS_ADD_CPP_STUBS)
 
   nanobind_add_stub(
     pyarts_cpp_stub
-    MODULE arts
+    MODULE pyarts3.arts
     OUTPUT ${ARTS_BINARY_DIR}/python/src/pyarts3/arts/__init__.pyi
-    PYTHON_PATH ${ARTS_BINARY_DIR}/python/src/pyarts3
+    PYTHON_PATH ${ARTS_BINARY_DIR}/python/src
     DEPENDS pyarts_cpp "${deplist}"
   )
   set_property(


### PR DESCRIPTION
Generate full typenames in stubs.
Resolves stubgen error with Python != 3.12. nanobind's stubgen throws error `AttributeError: module 'math' has no attribute 'floor'` when importing `numpy`. Likely an import naming confusion between the `math` module inside `arts` and the global Python `math` module.I don't know why the error does not occur with Python 3.12 but consistently with 3.10, 3.11 and 3.13.