### PR TITLE
Make some second tier methods' names explicit

### DIFF
--- a/doc/arts/dev.workspace.methods.rst
+++ b/doc/arts/dev.workspace.methods.rst
@@ -415,7 +415,7 @@ This is the extraction of the text in the ``workspace_meta_methods.cpp`` file:
       .author           = {"Richard Larsson"},
       .methods          = {"atmospheric_fieldInit",
                            "atmospheric_fieldAppendBaseData",
-                           "atmospheric_fieldAppendAbsorptionData"},
+                           "atmospheric_fieldAppendDataToTheAtmosphericFieldBasedOnAvailableAbsorptionData"},
       .out              = {"atmospheric_field"},
       .preset_gin       = {"replace_existing"},
       .preset_gin_value = {Index{0}},

--- a/src/m_atm.cc
+++ b/src/m_atm.cc
@@ -328,7 +328,7 @@ void atmospheric_fieldAppendBaseData(AtmField &atmospheric_field,
   }
 }
 
-void atmospheric_fieldAppendLineSpeciesData(
+void atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnLineData(
     AtmField &atmospheric_field,
     const AbsorptionBands &absorption_bands,
     const String &basename,
@@ -350,7 +350,7 @@ void atmospheric_fieldAppendLineSpeciesData(
               [](const SpeciesEnum &x) { return String{toString<1>(x)}; });
 }
 
-void atmospheric_fieldAppendLineIsotopologueData(
+void atmospheric_fieldAppendIsotopologueRatioDataToTheAtmosphericFieldBasedOnLineData(
     AtmField &atmospheric_field,
     const AbsorptionBands &absorption_bands,
     const String &basename,
@@ -376,7 +376,7 @@ void atmospheric_fieldAppendLineIsotopologueData(
               [](const SpeciesIsotope &x) { return x.FullName(); });
 }
 
-void atmospheric_fieldAppendLineLevelData(
+void atmospheric_fieldAppendNLTEDataToTheAtmosphericFieldBasedOnLineData(
     AtmField &atmospheric_field,
     const AbsorptionBands &absorption_bands,
     const String &basename,
@@ -404,7 +404,7 @@ void atmospheric_fieldAppendLineLevelData(
       [](const QuantumLevelIdentifier &x) { return std::format("{}", x); });
 }
 
-void atmospheric_fieldAppendTagsSpeciesData(
+void atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionSpecies(
     AtmField &atmospheric_field,
     const ArrayOfArrayOfSpeciesTag &absorption_species,
     const String &basename,
@@ -426,7 +426,7 @@ void atmospheric_fieldAppendTagsSpeciesData(
               [](const SpeciesEnum &x) { return String{toString<1>(x)}; });
 }
 
-void atmospheric_fieldAppendCIASpeciesData(
+void atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnCollisionInducedAbsorptionData(
     AtmField &atmospheric_field,
     const ArrayOfCIARecord &absorption_cia_data,
     const String &basename,
@@ -448,7 +448,7 @@ void atmospheric_fieldAppendCIASpeciesData(
               [](const SpeciesEnum &x) { return String{toString<1>(x)}; });
 }
 
-void atmospheric_fieldAppendLookupTableSpeciesData(
+void atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionLookupTableData(
     AtmField &atmospheric_field,
     const AbsorptionLookupTables &absorption_lookup_table,
     const String &basename,
@@ -470,7 +470,7 @@ void atmospheric_fieldAppendLookupTableSpeciesData(
               [](const SpeciesEnum &x) { return String{toString<1>(x)}; });
 }
 
-void atmospheric_fieldAppendXsecSpeciesData(
+void atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionCrossSectionFitData(
     AtmField &atmospheric_field,
     const ArrayOfXsecRecord &absorption_xsec_fit_data,
     const String &basename,
@@ -492,7 +492,7 @@ void atmospheric_fieldAppendXsecSpeciesData(
               [](const SpeciesEnum &x) { return String{toString<1>(x)}; });
 }
 
-void atmospheric_fieldAppendPredefSpeciesData(
+void atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionPredefinedModelData(
     AtmField &atmospheric_field,
     const PredefinedModelData &absorption_predefined_model_data,
     const String &basename,
@@ -535,7 +535,7 @@ void atmospheric_fieldAppendPredefSpeciesData(
   }
 }
 
-void atmospheric_fieldAppendAbsorptionData(const Workspace &ws,
+void atmospheric_fieldAppendDataToTheAtmosphericFieldBasedOnAvailableAbsorptionData(const Workspace &ws,
                                            AtmField &atmospheric_field,
                                            const String &basename,
                                            const String &extrapolation,
@@ -550,7 +550,7 @@ void atmospheric_fieldAppendAbsorptionData(const Workspace &ws,
     using lines_t                = AbsorptionBands;
     const auto &absorption_bands = ws.get<lines_t>(lines_str);
 
-    atmospheric_fieldAppendLineSpeciesData(atmospheric_field,
+    atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnLineData(atmospheric_field,
                                            absorption_bands,
                                            basename,
                                            extrapolation,
@@ -558,7 +558,7 @@ void atmospheric_fieldAppendAbsorptionData(const Workspace &ws,
                                            replace_existing);
 
     if (static_cast<bool>(load_isot)) {
-      atmospheric_fieldAppendLineIsotopologueData(atmospheric_field,
+      atmospheric_fieldAppendIsotopologueRatioDataToTheAtmosphericFieldBasedOnLineData(atmospheric_field,
                                                   absorption_bands,
                                                   basename,
                                                   extrapolation,
@@ -567,7 +567,7 @@ void atmospheric_fieldAppendAbsorptionData(const Workspace &ws,
     }
 
     if (static_cast<bool>(load_nlte)) {
-      atmospheric_fieldAppendLineLevelData(atmospheric_field,
+      atmospheric_fieldAppendNLTEDataToTheAtmosphericFieldBasedOnLineData(atmospheric_field,
                                            absorption_bands,
                                            basename,
                                            extrapolation,
@@ -580,7 +580,7 @@ void atmospheric_fieldAppendAbsorptionData(const Workspace &ws,
       ws.wsv_and_contains(cia_str)) {
     using cia_t                     = ArrayOfCIARecord;
     const auto &absorption_cia_data = ws.get<cia_t>(cia_str);
-    atmospheric_fieldAppendCIASpeciesData(atmospheric_field,
+    atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnCollisionInducedAbsorptionData(atmospheric_field,
                                           absorption_cia_data,
                                           basename,
                                           extrapolation,
@@ -592,7 +592,7 @@ void atmospheric_fieldAppendAbsorptionData(const Workspace &ws,
       ws.wsv_and_contains(lookup_str)) {
     using lookup_t                      = AbsorptionLookupTables;
     const auto &absorption_lookup_table = ws.get<lookup_t>(lookup_str);
-    atmospheric_fieldAppendLookupTableSpeciesData(atmospheric_field,
+    atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionLookupTableData(atmospheric_field,
                                                   absorption_lookup_table,
                                                   basename,
                                                   extrapolation,
@@ -604,7 +604,7 @@ void atmospheric_fieldAppendAbsorptionData(const Workspace &ws,
       ws.wsv_and_contains(xsec_str)) {
     using xsec_t                         = ArrayOfXsecRecord;
     const auto &absorption_xsec_fit_data = ws.get<xsec_t>(xsec_str);
-    atmospheric_fieldAppendXsecSpeciesData(atmospheric_field,
+    atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionCrossSectionFitData(atmospheric_field,
                                            absorption_xsec_fit_data,
                                            basename,
                                            extrapolation,
@@ -616,7 +616,7 @@ void atmospheric_fieldAppendAbsorptionData(const Workspace &ws,
       ws.wsv_and_contains(predef_str)) {
     using predef_t                               = PredefinedModelData;
     const auto &absorption_predefined_model_data = ws.get<predef_t>(predef_str);
-    atmospheric_fieldAppendPredefSpeciesData(atmospheric_field,
+    atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionPredefinedModelData(atmospheric_field,
                                              absorption_predefined_model_data,
                                              basename,
                                              extrapolation,
@@ -628,7 +628,7 @@ void atmospheric_fieldAppendAbsorptionData(const Workspace &ws,
       ws.wsv_and_contains(species_str)) {
     using aospec_t                 = ArrayOfArrayOfSpeciesTag;
     const auto &absorption_species = ws.get<aospec_t>(species_str);
-    atmospheric_fieldAppendTagsSpeciesData(atmospheric_field,
+    atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionSpecies(atmospheric_field,
                                            absorption_species,
                                            basename,
                                            extrapolation,

--- a/src/workspace_meta_methods.cpp
+++ b/src/workspace_meta_methods.cpp
@@ -222,7 +222,7 @@ This method simply is a convenience wrapper for that use case.
       .author           = {"Richard Larsson"},
       .methods          = {"atmospheric_fieldInit",
                            "atmospheric_fieldAppendBaseData",
-                           "atmospheric_fieldAppendAbsorptionData"},
+                           "atmospheric_fieldAppendDataToTheAtmosphericFieldBasedOnAvailableAbsorptionData"},
       .out              = {"atmospheric_field"},
       .preset_gin       = {"replace_existing"},
       .preset_gin_value = {Index{0}},

--- a/src/workspace_methods.cpp
+++ b/src/workspace_methods.cpp
@@ -3940,7 +3940,7 @@ if the method should throw if the pressure or temperature is missing.
                     "Whether or not to allow missing temperature data"},
   };
 
-  wsm_data["atmospheric_fieldAppendLineSpeciesData"] = {
+  wsm_data["atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnLineData"] = {
       .desc =
           R"--(Append species data to the atmospheric field based on line data
 
@@ -3970,9 +3970,9 @@ exists in the atmospheric field.
                     "Whether or not to replace existing data"},
   };
 
-  wsm_data["atmospheric_fieldAppendLineIsotopologueData"] = {
+  wsm_data["atmospheric_fieldAppendIsotopologueRatioDataToTheAtmosphericFieldBasedOnLineData"] = {
       .desc =
-          R"--(Append isotopologue data to the atmospheric field based on line data
+          R"--(Append isotopologue ratio data to the atmospheric field based on line data
 
 This will look at the valid ``basename`` for files matching base
 data.  The base data file names are of the form: "species-n.xml" (e.g., "H2O-161.xml").
@@ -4000,7 +4000,7 @@ exists in the atmospheric field.
                     "Whether or not to replace existing data"},
   };
 
-  wsm_data["atmospheric_fieldAppendLineLevelData"] = {
+  wsm_data["atmospheric_fieldAppendNLTEDataToTheAtmosphericFieldBasedOnLineData"] = {
       .desc =
           R"--(Append NLTE data to the atmospheric field based on line data
 
@@ -4031,9 +4031,9 @@ exists in the atmospheric field.
                     "Whether or not to replace existing data"},
   };
 
-  wsm_data["atmospheric_fieldAppendTagsSpeciesData"] = {
+  wsm_data["atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionSpecies"] = {
       .desc =
-          R"--(Append species data to the atmospheric field based on species data
+          R"--(Append species data to the atmospheric field based on *absorption_species*
 
 This will look at the valid ``basename`` for files matching base
 data.  The base data file names are of the short-name form: "species.xml" (e.g., "H2O.xml").
@@ -4061,9 +4061,9 @@ exists in the atmospheric field.
                     "Whether or not to replace existing data"},
   };
 
-  wsm_data["atmospheric_fieldAppendCIASpeciesData"] = {
+  wsm_data["atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnCollisionInducedAbsorptionData"] = {
       .desc =
-          R"--(Append species data to the atmospheric field based on collision-induced data data
+          R"--(Append species data to the atmospheric field based on collision-induced absorption data
 
 This will look at the valid ``basename`` for files matching base
 data.  The base data file names are of the short-name form: "species1.xml" "species2.xml" (e.g., "H2O.xml" "CO2.xml").
@@ -4091,9 +4091,9 @@ exists in the atmospheric field.
                     "Whether or not to replace existing data"},
   };
 
-  wsm_data["atmospheric_fieldAppendXsecSpeciesData"] = {
+  wsm_data["atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionCrossSectionFitData"] = {
       .desc =
-          R"--(Append species data to the atmospheric field based on cross-section data
+          R"--(Append species data to the atmospheric field based on absorption cross-section fit data
 
 This will look at the valid ``basename`` for files matching base
 data.  The base data file names are of the short-name form: "species.xml" (e.g., "H2O.xml").
@@ -4121,9 +4121,9 @@ exists in the atmospheric field.
                     "Whether or not to replace existing data"},
   };
 
-  wsm_data["atmospheric_fieldAppendLookupTableSpeciesData"] = {
+  wsm_data["atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionLookupTableData"] = {
       .desc =
-          R"--(Append species data to the atmospheric field based on lookup data
+          R"--(Append species data to the atmospheric field based on absorption lookup table data
 
 This will look at the valid ``basename`` for files matching base
 data.  The base data file names are of the short-name form: "species.xml" (e.g., "H2O.xml").
@@ -4151,9 +4151,9 @@ exists in the atmospheric field.
                     "Whether or not to replace existing data"},
   };
 
-  wsm_data["atmospheric_fieldAppendPredefSpeciesData"] = {
+  wsm_data["atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionPredefinedModelData"] = {
       .desc =
-          R"--(Append species data to the atmospheric field based on predefined model data
+          R"--(Append species data to the atmospheric field based on absorption predefined model data
 
 This will look at the valid ``basename`` for files matching base
 data.  The base data file names are of the short-name form: "species-MODEL.xml" (e.g., "H2O-ForeignContCKDMT400.xml").
@@ -4181,22 +4181,24 @@ exists in the atmospheric field.
                     "Whether or not to replace existing data"},
   };
 
-  wsm_data["atmospheric_fieldAppendAbsorptionData"] = {
+  wsm_data["atmospheric_fieldAppendDataToTheAtmosphericFieldBasedOnAvailableAbsorptionData"] = {
       .desc =
           R"--(Append data to the atmospheric field based on available absorption data.
 
 Wraps:
 
-- *atmospheric_fieldAppendLineSpeciesData* if the workspace contains *absorption_bands*
-- *atmospheric_fieldAppendLineIsotopologueData* if ``load_isot`` is true and if the workspace contains *absorption_bands*
-- *atmospheric_fieldAppendLineLevelData* if ``load_nlte`` is true and if the workspace contains *absorption_bands*
-- *atmospheric_fieldAppendTagsSpeciesData* if the workspace contains *absorption_species*
-- *atmospheric_fieldAppendLookupTableSpeciesData* if the workspace contains *absorption_lookup_table*
-- *atmospheric_fieldAppendCIASpeciesData* if the workspace contains *absorption_cia_data*
-- *atmospheric_fieldAppendXsecSpeciesData* if the workspace contains *absorption_xsec_fit_data*
-- *atmospheric_fieldAppendPredefSpeciesData* if the workspace contains *absorption_predefined_model_data*
+- *atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnLineData* if the workspace contains *absorption_bands*
+- *atmospheric_fieldAppendIsotopologueRatioDataToTheAtmosphericFieldBasedOnLineData* if ``load_isot`` is true and if the workspace contains *absorption_bands*
+- *atmospheric_fieldAppendNLTEDataToTheAtmosphericFieldBasedOnLineData* if ``load_nlte`` is true and if the workspace contains *absorption_bands*
+- *atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionSpecies* if the workspace contains *absorption_species*
+- *atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionLookupTableData* if the workspace contains *absorption_lookup_table*
+- *atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnCollisionInducedAbsorptionData* if the workspace contains *absorption_cia_data*
+- *atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionCrossSectionFitData* if the workspace contains *absorption_xsec_fit_data*
+- *atmospheric_fieldAppendSpeciesDataToTheAtmosphericFieldBasedOnAbsorptionPredefinedModelData* if the workspace contains *absorption_predefined_model_data*
 
-See these individually for more details.
+See these individually for more details.  Not that unlike the individual methods, this method will still
+work if some of the absorption data types are missing in the workspace.  It operates directly on the
+workspace rather than taking the data as input arguments.
 )--",
       .author    = {"Richard Larsson"},
       .out       = {"atmospheric_field"},

--- a/tests/core/mars/cat.py
+++ b/tests/core/mars/cat.py
@@ -36,7 +36,7 @@ for abs_scenario in ["FullMars", "IsotEarth", "FullEarth"]:
             missing_is_zero=True,
             extrapolation="Nearest",
         )
-        ws.atmospheric_fieldAppendLineIsotopologueData(
+        ws.atmospheric_fieldAppendIsotopologueRatioDataToTheAtmosphericFieldBasedOnLineData(
             basename="planets/Mars/isotopologue_ratios/", replace_existing=True
         )
         assert 6 == len(


### PR DESCRIPTION
This addresses #1008 .  The builtin documentation was not reachable for some methods that the user should probably never use directly.  To make clear what the methods do, the first line of the documentation is appended to the names of these methods.