### PR TITLE
Fix ASAN error in lag=0 code.

### DIFF
--- a/src/core/matpack/lagrange_interp.h
+++ b/src/core/matpack/lagrange_interp.h
@@ -225,11 +225,11 @@ constexpr void update_pos(std::span<Index, X> indx,
 
   if (N == 0) {
     if constexpr (cyclic<transform>) {
-      const auto xn = (xp + 1) == xe ? xf : (xp + 1);
+      const auto xn = ((xp + 1) == xi.end()) ? xf : (xp + 1);
       xp            = (std::abs(x - *xn) < std::abs(x - *xp)) ? xn : xp;
     } else {
       const auto xn = xp + 1;
-      xp = ((xn != xe) or (std::abs(x - *xn) >= std::abs(x - *xp))) ? xp : xn;
+      xp = (xn == xi.end() or std::abs(x - *xn) > std::abs(x - *xp)) ? xp : xn;
     }
   }
 


### PR DESCRIPTION
Fixes problem in #1016 for interpolations with nearest-neighbor order.  There was an overflow by one, dereferencing an end-pointer.  This adds an additional check making nearest neighbor interpolation a bit more expensive (still faster than linear - and still at no additional cost for a 1-long grid, to keep the appearance of 1D/2D in 3D alive).