### PR TITLE
Reserve was used inside a resize command

### DIFF
--- a/src/core/sensor/obsel.cpp
+++ b/src/core/sensor/obsel.cpp
@@ -83,11 +83,11 @@ const std::vector<SparseStokvec>& SparseStokvecMatrix::vector() const {
   return sparse_data;
 }
 
-void SparseStokvecMatrix::resize(Size nrows, Size ncols, Size reserve) {
+void SparseStokvecMatrix::resize(Size nrows, Size ncols, Size size) {
   rows = nrows;
   cols = ncols;
   sparse_data.clear();
-  sparse_data.reserve(reserve);
+  sparse_data.resize(size);
 }
 
 std::array<Index, 2> SparseStokvecMatrix::shape() const {

--- a/src/core/sensor/obsel.h
+++ b/src/core/sensor/obsel.h
@@ -68,7 +68,7 @@ class SparseStokvecMatrix {
   [[nodiscard]] std::array<Index, 2> shape() const;
   const std::vector<SparseStokvec>& vector() const;
 
-  void resize(Size rows, Size cols, Size reserve);
+  void resize(Size rows, Size cols, Size size);
 
   Stokvec& operator[](Size i, Size j);
   Stokvec operator[](Size i, Size j) const;


### PR DESCRIPTION
Fixes the #1016 ASAN error sensor_count.py.  This bug is odd that it was not caught.  There was a call to reserve but not a call to push_back, instead just writing the data to the allocated memory.  This should have been caught by the size-checker, but it wasn't.

Anyways, now there is a proper resize instead.  This might lead to some more copying of data but it should be OK.