### PR TITLE
Help string

### DIFF
--- a/examples/1-getting-started/2-clearsky-radiative-transfer/1.zeeman.py
+++ b/examples/1-getting-started/2-clearsky-radiative-transfer/1.zeeman.py
@@ -68,4 +68,5 @@ assert np.allclose(
         ]
     ),
 ), "Values have drifted from expected results in spectral radiance"
+
 print (f"{ws.absorption_bands[list(ws.absorption_bands.keys())[0]].lines[-1]:h}")

--- a/examples/1-getting-started/2-clearsky-radiative-transfer/1.zeeman.py
+++ b/examples/1-getting-started/2-clearsky-radiative-transfer/1.zeeman.py
@@ -68,7 +68,3 @@ assert np.allclose(
         ]
     ),
 ), "Values have drifted from expected results in spectral radiance"
-
-print (f"{ws.absorption_bands[list(ws.absorption_bands.keys())[0]].lines[-1]:h}")
-print (f"{ws.absorption_bands[list(ws.absorption_bands.keys())[0]].lines[-1]:IO}")
-print (f"{ws.absorption_bands[list(ws.absorption_bands.keys())[0]].lines[-1]}")

--- a/examples/1-getting-started/2-clearsky-radiative-transfer/1.zeeman.py
+++ b/examples/1-getting-started/2-clearsky-radiative-transfer/1.zeeman.py
@@ -68,3 +68,4 @@ assert np.allclose(
         ]
     ),
 ), "Values have drifted from expected results in spectral radiance"
+print (f"{ws.absorption_bands[list(ws.absorption_bands.keys())[0]].lines[-1]:h}")

--- a/examples/1-getting-started/2-clearsky-radiative-transfer/1.zeeman.py
+++ b/examples/1-getting-started/2-clearsky-radiative-transfer/1.zeeman.py
@@ -70,3 +70,5 @@ assert np.allclose(
 ), "Values have drifted from expected results in spectral radiance"
 
 print (f"{ws.absorption_bands[list(ws.absorption_bands.keys())[0]].lines[-1]:h}")
+print (f"{ws.absorption_bands[list(ws.absorption_bands.keys())[0]].lines[-1]:IO}")
+print (f"{ws.absorption_bands[list(ws.absorption_bands.keys())[0]].lines[-1]}")

--- a/src/core/lbl/lbl_data.cpp
+++ b/src/core/lbl/lbl_data.cpp
@@ -471,3 +471,16 @@ void xml_io_stream<LblLineKey>::read(std::istream& is,
   throw std::runtime_error(
       std::format("Error reading LblLineKey:\n{}", e.what()));
 }
+
+template <>
+std::optional<std::string> to_helper_string<AbsorptionBands>(
+    const AbsorptionBands& bands) {
+  std::string out{};
+
+  std::string_view x = ""sv;
+  for (auto& [qid, data] : bands) {
+    out += std::format("{}{:h}: {:h}", std::exchange(x, "\n"sv), qid, data);
+  }
+
+  return out;
+}

--- a/src/core/lbl/lbl_data.h
+++ b/src/core/lbl/lbl_data.h
@@ -397,3 +397,5 @@ struct xml_io_stream<LblLineKey> {
 
   static void read(std::istream& is, LblLineKey& x, bifstream* pbifs = nullptr);
 };
+
+std::string to_educational_string_frequency(Numeric);

--- a/src/core/lbl/lbl_data.h
+++ b/src/core/lbl/lbl_data.h
@@ -397,5 +397,3 @@ struct xml_io_stream<LblLineKey> {
 
   static void read(std::istream& is, LblLineKey& x, bifstream* pbifs = nullptr);
 };
-
-std::string to_educational_string_frequency(Numeric);

--- a/src/core/lbl/lbl_data.h
+++ b/src/core/lbl/lbl_data.h
@@ -397,3 +397,7 @@ struct xml_io_stream<LblLineKey> {
 
   static void read(std::istream& is, LblLineKey& x, bifstream* pbifs = nullptr);
 };
+
+template <>
+std::optional<std::string> to_helper_string<AbsorptionBands>(
+    const AbsorptionBands&);

--- a/src/core/lbl/lbl_hitran.cpp
+++ b/src/core/lbl/lbl_hitran.cpp
@@ -182,22 +182,18 @@ line hitran_record::from(HitranLineStrengthOption ls,
   l.ls.single_models.resize(2);
 
   l.ls.single_models[0].species = qid.isot.spec;
-  l.ls.single_models[0].data.emplace_back(
-      LineShapeModelVariable::G0,
-      lbl::temperature::data{LineShapeModelType::T1, Vector{gamma_self, n}});
+  l.ls.single_models[0].data[LineShapeModelVariable::G0] =
+      lbl::temperature::data{LineShapeModelType::T1, Vector{gamma_self, n}};
 
   l.ls.single_models[1].species = SpeciesEnum::Bath;
-  l.ls.single_models[1].data.emplace_back(
-      LineShapeModelVariable::G0,
-      lbl::temperature::data{LineShapeModelType::T1, Vector{gamma_air, n}});
+  l.ls.single_models[1].data[LineShapeModelVariable::G0] =
+      lbl::temperature::data{LineShapeModelType::T1, Vector{gamma_air, n}};
 
   if (delta != 0) {
-    l.ls.single_models[0].data.emplace_back(
-        LineShapeModelVariable::D0,
-        lbl::temperature::data{LineShapeModelType::T0, Vector{delta}});
-    l.ls.single_models[1].data.emplace_back(
-        LineShapeModelVariable::D0,
-        lbl::temperature::data{LineShapeModelType::T0, Vector{delta}});
+    l.ls.single_models[0].data[LineShapeModelVariable::D0] =
+        lbl::temperature::data{LineShapeModelType::T0, Vector{delta}};
+    l.ls.single_models[1].data[LineShapeModelVariable::D0] =
+        lbl::temperature::data{LineShapeModelType::T0, Vector{delta}};
   }
 
   l.qn = std::move(local);

--- a/src/core/lbl/lbl_lineshape_model.cpp
+++ b/src/core/lbl/lbl_lineshape_model.cpp
@@ -5,6 +5,8 @@
 
 #include <ranges>
 
+#include "lbl_temperature_model.h"
+
 std::istream& operator>>(std::istream& is,
                          lbl::line_shape::species_model::map_t& x) {
   Size n;
@@ -319,3 +321,20 @@ void model::clear_zeroes() {
   }
 }
 }  // namespace lbl::line_shape
+
+template <>
+std::optional<std::string>
+to_helper_string<lbl::line_shape::species_model::map_t>(
+    const lbl::line_shape::species_model::map_t& map) {
+  std::string out{};
+
+  std::string_view x = ""sv;
+  for (const auto& [key, value] : map) {
+    out += std::format("{}{}: {}",
+                       std::exchange(x, "; "sv),
+                       key,
+                       to_educational_string(value, key));
+  }
+
+  return out;
+}

--- a/src/core/lbl/lbl_lineshape_model.cpp
+++ b/src/core/lbl/lbl_lineshape_model.cpp
@@ -5,26 +5,19 @@
 
 #include <ranges>
 
-namespace {
-std::istream& operator>>(
-    std::istream& is,
-    std::pair<LineShapeModelVariable, lbl::temperature::data>& x) {
-  String name;
-  is >> name >> x.second;
-
-  x.first = to<LineShapeModelVariable>(name);
-
-  return is;
-}
-}  // namespace
-
-std::istream& operator>>(
-    std::istream& is,
-    std::vector<std::pair<LineShapeModelVariable, lbl::temperature::data>>& x) {
+std::istream& operator>>(std::istream& is,
+                         lbl::line_shape::species_model::map_t& x) {
   Size n;
   is >> n;
-  x.resize(n);
-  for (auto& y : x) is >> y;
+
+  x.clear();
+  x.reserve(n);
+
+  for (Size i = 0; i < n; i++) {
+    LineShapeModelVariable var;
+    lbl::temperature::data temp_data;
+    is >> var >> x[var];
+  }
   return is;
 }
 

--- a/src/core/lbl/lbl_lineshape_model.h
+++ b/src/core/lbl/lbl_lineshape_model.h
@@ -23,8 +23,8 @@ struct species_model {
   template <LineShapeModelVariable... V>
   std::vector<std::pair<LineShapeModelVariable, temperature::data>>::size_type
   remove_variables() {
-    return (... +
-        std::erase_if(data, [v = V](const auto& x) { return x.first == v; }));
+    return (... + std::erase_if(
+                      data, [v = V](const auto& x) { return x.first == v; }));
   }
 
 #define VARIABLE(name) \
@@ -245,7 +245,9 @@ struct std::formatter<lbl::line_shape::species_model> {
   template <class FmtContext>
   FmtContext::iterator format(const lbl::line_shape::species_model& v,
                               FmtContext& ctx) const {
-    if (tags.io) {
+    if (tags.help) {
+      tags.format(ctx, "Species: "sv, v.species, "; Data: "sv, v.data);
+    } else if (tags.io) {
       tags.format(ctx, v.species, ' ', v.data.size(), ' ', v.data);
     } else {
       tags.add_if_bracket(ctx, '[');

--- a/src/core/lbl/lbl_lineshape_model.h
+++ b/src/core/lbl/lbl_lineshape_model.h
@@ -17,12 +17,12 @@ namespace lbl::line_shape {
 struct species_model {
   SpeciesEnum species{};
 
-  std::vector<std::pair<LineShapeModelVariable, temperature::data>> data{};
+  using map_t = std::unordered_map<LineShapeModelVariable, temperature::data>;
+  map_t data{};
 
   //! Removes the variables from the model.
   template <LineShapeModelVariable... V>
-  std::vector<std::pair<LineShapeModelVariable, temperature::data>>::size_type
-  remove_variables() {
+  map_t::size_type remove_variables() {
     return (... + std::erase_if(
                       data, [v = V](const auto& x) { return x.first == v; }));
   }
@@ -274,21 +274,31 @@ struct std::formatter<lbl::line_shape::model> {
   template <class FmtContext>
   FmtContext::iterator format(const lbl::line_shape::model& v,
                               FmtContext& ctx) const {
-    if (tags.io) {
-      tags.format(ctx,
-                  v.T0,
-                  ' ',
-                  Index{v.one_by_one},
-                  ' ',
-                  v.single_models.size(),
-                  ' ',
-                  v.single_models);
-    } else {
-      const auto sep = tags.sep();
-      tags.add_if_bracket(ctx, '[');
-      tags.format(ctx, v.one_by_one, sep, v.T0, sep, v.single_models);
-      tags.add_if_bracket(ctx, ']');
+    if (tags.help) {
+      return tags.format(ctx,
+                         "Reference temperature: "sv,
+                         v.T0,
+                         " K; One-by-one: "sv,
+                         v.one_by_one ? "<on>"sv : "<off>"sv,
+                         "; Single models: "sv,
+                         v.single_models);
     }
+
+    if (tags.io) {
+      return tags.format(ctx,
+                         v.T0,
+                         ' ',
+                         Index{v.one_by_one},
+                         ' ',
+                         v.single_models.size(),
+                         ' ',
+                         v.single_models);
+    }
+
+    const auto sep = tags.sep();
+    tags.add_if_bracket(ctx, '[');
+    tags.format(ctx, v.one_by_one, sep, v.T0, sep, v.single_models);
+    tags.add_if_bracket(ctx, ']');
 
     return ctx.out();
   }

--- a/src/core/lbl/lbl_lineshape_model.h
+++ b/src/core/lbl/lbl_lineshape_model.h
@@ -303,3 +303,7 @@ struct std::formatter<lbl::line_shape::model> {
     return ctx.out();
   }
 };
+
+template <>
+std::optional<std::string> to_helper_string<lbl::line_shape::species_model::map_t>(
+    const lbl::line_shape::species_model::map_t&);

--- a/src/core/lbl/lbl_temperature_model.cpp
+++ b/src/core/lbl/lbl_temperature_model.cpp
@@ -7,6 +7,8 @@
 #include <limits>
 #include <utility>
 
+#include "arts_conversions.h"
+
 namespace lbl::temperature {
 static_assert(LineShapeModelTypeSize == enumsize::LineShapeModelTypeSize,
               "Invalid number of models");
@@ -326,35 +328,149 @@ void xml_io_stream<lbl::temperature::data>::read(std::istream& is,
       std::format("Error reading {}:\n{}", type_name, e.what()));
 }
 
-std::string to_educational_string(const lbl::temperature::data& data) {
+namespace {
+std::string metric_unit_x0(const Numeric x,
+                           const std::optional<LineShapeModelVariable>& type) {
+  using enum LineShapeModelVariable;
+  using enum LineShapeModelType;
+
+  if (type) {
+    const auto [c, v] = Conversion::metric_prefix(x);
+    switch (*type) {
+      case G0:
+      case D0:
+      case G2:
+      case D2:
+      case FVC:
+        return std::format("{:.2f}{}{}Hz/Pa", v, c == ' ' ? ""sv : " "sv, c);
+      case ETA: return std::format("{}", x);
+      case DV:
+        return std::format("{:.2f}{}{}Hz/Pa^2", v, c == ' ' ? ""sv : " "sv, c);
+      case G:
+        return std::format("{:.2f}{}{}/Pa^2", v, c == ' ' ? ""sv : " "sv, c);
+      case Y:
+        return std::format("{:.2f}{}{}/Pa", v, c == ' ' ? ""sv : " "sv, c);
+    }
+  }
+
+  return std::format("{}", x);
+}
+
+std::string metric_unit_x1(const Numeric x,
+                           LineShapeModelType t,
+                           const std::optional<LineShapeModelVariable>& type) {
+  using enum LineShapeModelVariable;
+  using enum LineShapeModelType;
+
+  if (type) {
+    const auto [c, v] = Conversion::metric_prefix(x);
+    switch (*type) {
+      case G0:
+      case D0:
+      case G2:
+      case D2:
+      case FVC:
+        switch (t) {
+          case T0:
+          case T1:
+          case T2:
+          case T5:
+          case DPL:
+          case POLY: return std::format("{}", x);
+          case T3:
+          case T4:
+          case AER:
+            return std::format(
+                "{:.2f}{}{}Hz/Pa", v, c == ' ' ? ""sv : " "sv, c);
+        }
+      case ETA: return std::format("{}", x);
+      case DV:
+        switch (t) {
+          case T0:
+          case T1:
+          case T2:
+          case T5:
+          case DPL:
+          case POLY: return std::format("{}", x);
+          case T3:
+            return std::format(
+                "{:.2f}{}{}Hz/Pa^2/K", v, c == ' ' ? ""sv : " "sv, c);
+          case T4:
+          case AER:
+            return std::format(
+                "{:.2f}{}{}Hz/Pa^2", v, c == ' ' ? ""sv : " "sv, c);
+        }
+      case G:
+        switch (t) {
+          case T0:
+          case T1:
+          case T2:
+          case T5:
+          case DPL:
+          case POLY: return std::format("{}", x);
+          case T3:
+            return std::format(
+                "{:.2f}{}{}/Pa^2/K", v, c == ' ' ? ""sv : " "sv, c);
+          case T4:
+          case AER:
+            return std::format(
+                "{:.2f}{}{}/Pa^2", v, c == ' ' ? ""sv : " "sv, c);
+        }
+      case Y:
+        switch (t) {
+          case T0:
+          case T1:
+          case T2:
+          case T5:
+          case DPL:
+          case POLY: return std::format("{}", x);
+          case T3:
+            return std::format(
+                "{:.2f}{}{}/Pa/K", v, c == ' ' ? ""sv : " "sv, c);
+          case T4:
+          case AER:
+            return std::format("{:.2f}{}{}/Pa", v, c == ' ' ? ""sv : " "sv, c);
+        }
+    }
+  }
+
+  return std::format("{}", x);
+}
+}  // namespace
+
+std::string to_educational_string(const lbl::temperature::data& data,
+                                  std::optional<LineShapeModelVariable> type) {
   switch (data.Type()) {
     using enum LineShapeModelType;
     using enum LineShapeModelCoefficient;
-    case T0: return std::format("LineShapeModelType::T0: {}", data.X(X0));
+    case T0:
+      return std::format("LineShapeModelType::T0: {}",
+                         metric_unit_x0(data.X(X0), type));
     case T1:
       return std::format("LineShapeModelType::T1: {} * pow(T0 / T, {})",
-                         data.X(X0),
-                         data.X(X1));
+                         metric_unit_x0(data.X(X0), type),
+                         metric_unit_x1(data.X(X1), data.Type(), type));
     case T2:
       return std::format(
           "LineShapeModelType::T2: {} * pow(T0 / T, {}) * (1 + {} * log(T / T0))",
-          data.X(X0),
-          data.X(X1),
+          metric_unit_x0(data.X(X0), type),
+          metric_unit_x1(data.X(X1), data.Type(), type),
           data.X(X2));
     case T3:
-      return std::format(
-          "LineShapeModelType::T3: {} + {} * (T - T0)", data.X(X0), data.X(X1));
+      return std::format("LineShapeModelType::T3: {} + {} * (T - T0)",
+                         metric_unit_x0(data.X(X0), type),
+                         metric_unit_x1(data.X(X1), data.Type(), type));
     case T4:
       return std::format(
           "LineShapeModelType::T4: ({0} + {1} * (T0 / T - 1)) * pow(T0 / T, {2})",
-          data.X(X0),
-          data.X(X1),
+          metric_unit_x0(data.X(X0), type),
+          metric_unit_x1(data.X(X1), data.Type(), type),
           data.X(X2));
     case T5:
       return std::format(
           "LineShapeModelType::T5: {} * pow(T0 / T, 0.25 + 1.5 * {})",
-          data.X(X0),
-          data.X(X1));
+          metric_unit_x0(data.X(X0), type),
+          metric_unit_x1(data.X(X1), data.Type(), type));
     case AER:
       return std::format(
           "LineShapeModelType::AER: (T < 250.0) ? "
@@ -362,23 +478,32 @@ std::string to_educational_string(const lbl::temperature::data& data) {
           "(T > 296.0) ? "
           "{2} + (T - 296.0) * ({3} - {2}) / (340.0 - 296.0) : "
           "{1} + (T - 250.0) * ({2} - {1}) / (296.0 - 250.0)",
-          data.X(X0),
-          data.X(X1),
-          data.X(X2),
-          data.X(X3));
+          metric_unit_x0(data.X(X0), type),
+          metric_unit_x0(data.X(X1), type),
+          metric_unit_x0(data.X(X2), type),
+          metric_unit_x0(data.X(X3), type));
     case DPL:
       return std::format(
           "LineShapeModelType::DPL: {} * pow(T0 / T, {}) + {} * pow(T0 / T, {})",
-          data.X(X0),
-          data.X(X1),
-          data.X(X2),
-          data.X(X3));
+          metric_unit_x0(data.X(X0), type),
+          metric_unit_x1(data.X(X1), data.Type(), type),
+          metric_unit_x0(data.X(X2), type),
+          metric_unit_x1(data.X(X3), data.Type(), type));
     case POLY: {
       std::string s{};
+      Size i{};
       std::string res{"LineShapeModelType::POLY: "};
+      std::string_view x = ""sv;
       for (auto& v : data.X()) {
-        res += std::format("{}{}", v, s);
+        res += std::format("{}{}{}{}",
+                           std::exchange(x, " + "sv),
+                           metric_unit_x0(v, type),
+                           i == 0   ? ""s
+                           : i == 1 ? "/K"s
+                                    : std::format("/K^{}", i),
+                           s);
         s   += " * T";
+        i++;
       }
       return res;
     }

--- a/src/core/lbl/lbl_temperature_model.h
+++ b/src/core/lbl/lbl_temperature_model.h
@@ -244,6 +244,8 @@ class data {
 };
 }  // namespace lbl::temperature
 
+std::string to_educational_string(const lbl::temperature::data&);
+
 template <>
 struct std::formatter<lbl::temperature::data> {
   format_tags tags;
@@ -259,7 +261,9 @@ struct std::formatter<lbl::temperature::data> {
   template <class FmtContext>
   FmtContext::iterator format(const lbl::temperature::data& v,
                               FmtContext& ctx) const {
-    if (tags.io) {
+if (tags.help) {
+  tags.format(ctx, "Equation: "sv, to_educational_string(v));
+} else if (tags.io) {
       tags.format(ctx, v.Type(), ' ');
       if (lbl::temperature::model_size(v.Type()) ==
           std::numeric_limits<Size>::max())

--- a/src/core/lbl/lbl_temperature_model.h
+++ b/src/core/lbl/lbl_temperature_model.h
@@ -6,6 +6,7 @@
 #include <xml.h>
 
 #include <limits>
+#include <optional>
 
 namespace lbl::temperature {
 inline constexpr std::size_t LineShapeModelTypeSize = 9;
@@ -244,7 +245,9 @@ class data {
 };
 }  // namespace lbl::temperature
 
-std::string to_educational_string(const lbl::temperature::data&);
+std::string to_educational_string(
+    const lbl::temperature::data&,
+    std::optional<LineShapeModelVariable> = std::nullopt);
 
 template <>
 struct std::formatter<lbl::temperature::data> {
@@ -261,9 +264,9 @@ struct std::formatter<lbl::temperature::data> {
   template <class FmtContext>
   FmtContext::iterator format(const lbl::temperature::data& v,
                               FmtContext& ctx) const {
-if (tags.help) {
-  tags.format(ctx, "Equation: "sv, to_educational_string(v));
-} else if (tags.io) {
+    if (tags.help) {
+      tags.format(ctx, "Equation: "sv, to_educational_string(v));
+    } else if (tags.io) {
       tags.format(ctx, v.Type(), ' ');
       if (lbl::temperature::model_size(v.Type()) ==
           std::numeric_limits<Size>::max())

--- a/src/core/lbl/lbl_zeeman.h
+++ b/src/core/lbl/lbl_zeeman.h
@@ -464,7 +464,14 @@ struct std::formatter<lbl::zeeman::model> {
   template <class FmtContext>
   FmtContext::iterator format(const lbl::zeeman::model &v,
                               FmtContext &ctx) const {
-    if (tags.io) {
+    if (tags.help) {
+      if (v.on) {
+        tags.format(
+            ctx, "<on>; Upper state: "sv, v.gu(), "; Lower state: "sv, v.gl());
+      } else {
+        tags.format(ctx, "<off>"sv);
+      }
+    } else if (tags.io) {
       tags.format(ctx, Index{v.on}, ' ', v.gu(), ' ', v.gl());
     } else {
       const auto sep = tags.sep();

--- a/src/core/quantum/quantum.cc
+++ b/src/core/quantum/quantum.cc
@@ -16,6 +16,8 @@
 #include <utility>
 #include <variant>
 
+#include "quantum_term_symbol.h"
+
 namespace Quantum {
 using enum QuantumNumberType;
 
@@ -911,4 +913,9 @@ void xml_io_stream<QuantumLevelIdentifier>::read(std::istream& is_xml,
   tag.check_end_name(type_name);
 } catch (const std::exception& e) {
   ARTS_USER_ERROR("Error reading QuantumLevelIdentifier:\n{}", e.what())
+}
+
+
+std::string to_educational_string(const QuantumIdentifier& q) {
+  return Quantum::Helpers::molecular_term_symbol(q);
 }

--- a/src/core/quantum/quantum.h
+++ b/src/core/quantum/quantum.h
@@ -346,6 +346,8 @@ struct std::formatter<QuantumState> {
   }
 };
 
+std::string to_educational_string(const QuantumIdentifier&);
+
 template <>
 struct std::formatter<QuantumIdentifier> {
   format_tags tags;
@@ -362,6 +364,14 @@ struct std::formatter<QuantumIdentifier> {
   template <class FmtContext>
   FmtContext::iterator format(const QuantumIdentifier& q,
                               FmtContext& ctx) const {
+    if (tags.help) {
+      return tags.format(ctx,
+                         "QuantumIdentifier: Species: "sv,
+                         q.isot,
+                         "; Symbol: ",
+                         to_educational_string(q));
+    }
+
     tags.format(ctx, q.isot);
 
     for (auto& v : q.state) tags.format(ctx, " "sv, v.first, " "sv, v.second);

--- a/src/core/util/CMakeLists.txt
+++ b/src/core/util/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(util STATIC
   arts_omp.cc
+  arts_conversions.cpp
   debug.cpp
   format_tags.cpp
   planet_data.cpp

--- a/src/core/util/arts_conversions.cpp
+++ b/src/core/util/arts_conversions.cpp
@@ -2,6 +2,8 @@
 
 #include <array>
 
+#include "nonstd.h"
+
 /** Namespace containing several practical unit conversions, physical and mathematical **/
 namespace Conversion {
 std::pair<char, Numeric> metric_prefix(Numeric x) {
@@ -21,7 +23,7 @@ std::pair<char, Numeric> metric_prefix(Numeric x) {
        {'h', 1e2}}};
 
   for (const auto& [unit, factor] : high_units) {
-    if (x > factor) return {unit, x / factor};
+    if (nonstd::abs(x) > factor) return {unit, x / factor};
   }
 
   constexpr std::array<std::pair<char, Numeric>, 12> low_units = {
@@ -39,7 +41,7 @@ std::pair<char, Numeric> metric_prefix(Numeric x) {
        {'d', 1e-1 * 1000}}};
 
   for (const auto& [unit, factor] : low_units) {
-    if (x < factor) return {unit, 1000 * x / factor};
+    if (nonstd::abs(x) < factor) return {unit, 1000.0 * x / factor};
   }
 
   return {' ', 0.0};

--- a/src/core/util/arts_conversions.cpp
+++ b/src/core/util/arts_conversions.cpp
@@ -1,0 +1,47 @@
+#include "arts_conversions.h"
+
+#include <array>
+
+/** Namespace containing several practical unit conversions, physical and mathematical **/
+namespace Conversion {
+std::pair<char, Numeric> metric_prefix(Numeric x) {
+  if (x == 0.0) return {' ', 0.0};
+
+  constexpr std::array<std::pair<char, Numeric>, 11> high_units = {
+      {{'Q', 1e30},
+       {'R', 1e27},
+       {'Y', 1e24},
+       {'Z', 1e21},
+       {'E', 1e18},
+       {'P', 1e15},
+       {'T', 1e12},
+       {'G', 1e9},
+       {'M', 1e6},
+       {'k', 1e3},
+       {'h', 1e2}}};
+
+  for (const auto& [unit, factor] : high_units) {
+    if (x > factor) return {unit, x / factor};
+  }
+
+  constexpr std::array<std::pair<char, Numeric>, 12> low_units = {
+      {{'q', 1e-30 * 1000},
+       {'r', 1e-27 * 1000},
+       {'y', 1e-24 * 1000},
+       {'z', 1e-21 * 1000},
+       {'a', 1e-18 * 1000},
+       {'f', 1e-15 * 1000},
+       {'p', 1e-12 * 1000},
+       {'n', 1e-9 * 1000},
+       {'u', 1e-6 * 1000},
+       {'m', 1e-3 * 1000},
+       {'c', 1e-2 * 1000},
+       {'d', 1e-1 * 1000}}};
+
+  for (const auto& [unit, factor] : low_units) {
+    if (x < factor) return {unit, 1000 * x / factor};
+  }
+
+  return {' ', 0.0};
+}
+};  // namespace Conversion

--- a/src/core/util/arts_conversions.h
+++ b/src/core/util/arts_conversions.h
@@ -12,6 +12,7 @@
 #define CONVERSIONS_IN_ARTS_H
 
 #include <cmath>
+#include <utility>
 
 #include "arts_constants.h"
 
@@ -164,6 +165,11 @@ constexpr auto angstrom2meter(auto x) noexcept { return x * 1e-10; }
 
 /** Conversion from meter to Å **/
 constexpr auto meter2angstrom(auto x) noexcept { return x * 1e10; }
+
+//! Converts the number to a metric prefix (kilo:=k, Mega:=M, nano:=n, etc)
+// And empty char (' ') is used when no conversion happens.  The function returns a pair
+// containing the prefix character and the scaled value.
+std::pair<char, Numeric> metric_prefix(Numeric);
 };  // namespace Conversion
 
 #endif

--- a/src/core/util/format_tags.cpp
+++ b/src/core/util/format_tags.cpp
@@ -10,6 +10,7 @@ std::string format_tags::get_format_args() const {
   if (short_str) buf.push_back('s');
   if (comma) buf.push_back(',');
   if (newline) buf.push_back('n');
+  if (help) buf.push_back('h');
   if (io) buf += "IO"sv;
 
   buf.push_back('}');

--- a/src/core/util/format_tags.h
+++ b/src/core/util/format_tags.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <iterator>
 #include <map>
+#include <optional>
 #include <print>
 #include <set>
 #include <span>
@@ -17,6 +18,11 @@
 #include <variant>
 
 using namespace std::literals;
+
+template <typename T>
+std::optional<std::string> to_helper_string(const T&) {
+  return std::nullopt;
+}
 
 struct format_tags;
 template <typename T>
@@ -279,6 +285,10 @@ struct std::formatter<std::variant<WTs...>> {
   template <class FmtContext>
   FmtContext::iterator format(const std::variant<WTs...>& v,
                               FmtContext& ctx) const {
+    if (tags.help) {
+      if (auto x = to_helper_string(v); x) return tags.format(ctx, *x);
+    }
+
     const auto call = []<typename T>(const format_tags& tags,
                                      FmtContext& ctx,
                                      const T* const e) -> bool {
@@ -308,6 +318,10 @@ struct std::formatter<std::unordered_map<Key, Value>> {
   template <class FmtContext>
   FmtContext::iterator format(const std::unordered_map<Key, Value>& v,
                               FmtContext& ctx) const {
+    if (tags.help) {
+      if (auto x = to_helper_string(v); x) return tags.format(ctx, *x);
+    }
+
     tags.add_if_bracket(ctx, '{');
     format_map_iterable(ctx, inner_fmt().tags, v);
     tags.add_if_bracket(ctx, '}');
@@ -330,8 +344,12 @@ struct std::formatter<std::map<Key, Value>> {
   }
 
   template <class FmtContext>
-  FmtContext::iterator format(const std::unordered_map<Key, Value>& v,
+  FmtContext::iterator format(const std::map<Key, Value>& v,
                               FmtContext& ctx) const {
+    if (tags.help) {
+      if (auto x = to_helper_string(v); x) return tags.format(ctx, *x);
+    }
+
     tags.add_if_bracket(ctx, '{');
     format_map_iterable(ctx, inner_fmt().tags, v);
     tags.add_if_bracket(ctx, '}');
@@ -356,6 +374,11 @@ struct std::formatter<std::span<T>> {
 
   template <class FmtContext>
   FmtContext::iterator format(const std::span<T>& v, FmtContext& ctx) const {
+    if (inner_fmt().tags.help) {
+      if (auto x = to_helper_string(v); x)
+        return inner_fmt().tags.format(ctx, *x);
+    }
+
     inner_fmt().tags.add_if_bracket(ctx, '[');
     format_value_iterable(ctx, inner_fmt().tags, v);
     inner_fmt().tags.add_if_bracket(ctx, ']');
@@ -380,6 +403,11 @@ struct std::formatter<std::set<T>> {
 
   template <class FmtContext>
   FmtContext::iterator format(const std::set<T>& v, FmtContext& ctx) const {
+    if (inner_fmt().tags.help) {
+      if (auto x = to_helper_string(v); x)
+        return inner_fmt().tags.format(ctx, *x);
+    }
+
     inner_fmt().tags.add_if_bracket(ctx, '[');
     format_value_iterable(ctx, inner_fmt().tags, v);
     inner_fmt().tags.add_if_bracket(ctx, ']');
@@ -405,6 +433,11 @@ struct std::formatter<std::unordered_set<T>> {
   template <class FmtContext>
   FmtContext::iterator format(const std::unordered_set<T>& v,
                               FmtContext& ctx) const {
+    if (inner_fmt().tags.help) {
+      if (auto x = to_helper_string(v); x)
+        return inner_fmt().tags.format(ctx, *x);
+    }
+
     inner_fmt().tags.add_if_bracket(ctx, '[');
     format_value_iterable(ctx, inner_fmt().tags, v);
     inner_fmt().tags.add_if_bracket(ctx, ']');
@@ -430,6 +463,11 @@ struct std::formatter<std::vector<T, Allocator>> {
   template <class FmtContext>
   FmtContext::iterator format(const std::vector<T, Allocator>& v,
                               FmtContext& ctx) const {
+    if (inner_fmt().tags.help) {
+      if (auto x = to_helper_string(v); x)
+        return inner_fmt().tags.format(ctx, *x);
+    }
+
     inner_fmt().tags.add_if_bracket(ctx, '[');
     format_value_iterable(ctx, inner_fmt().tags, v);
     inner_fmt().tags.add_if_bracket(ctx, ']');
@@ -455,6 +493,11 @@ struct std::formatter<std::array<T, N>> {
   template <class FmtContext>
   FmtContext::iterator format(const std::array<T, N>& v,
                               FmtContext& ctx) const {
+    if (inner_fmt().tags.help) {
+      if (auto x = to_helper_string(v); x)
+        return inner_fmt().tags.format(ctx, *x);
+    }
+
     inner_fmt().tags.add_if_bracket(ctx, '[');
     format_value_iterable(ctx, inner_fmt().tags, v);
     inner_fmt().tags.add_if_bracket(ctx, ']');
@@ -476,6 +519,11 @@ struct std::formatter<std::pair<A, B>> {
 
   template <class FmtContext>
   FmtContext::iterator format(const std::pair<A, B>& v, FmtContext& ctx) const {
+    if (inner_fmt().tags.help) {
+      if (auto x = to_helper_string(v); x)
+        return inner_fmt().tags.format(ctx, *x);
+    }
+
     tags.add_if_bracket(ctx, '(');
     tags.format(ctx, v.first, tags.sep(), v.second);
     tags.add_if_bracket(ctx, ')');
@@ -509,6 +557,11 @@ struct std::formatter<std::tuple<WT...>> {
   template <class FmtContext>
   FmtContext::iterator format(const std::tuple<WT...>& v,
                               FmtContext& ctx) const {
+    if (inner_fmt().tags.help) {
+      if (auto x = to_helper_string(v); x)
+        return inner_fmt().tags.format(ctx, *x);
+    }
+
     tags.add_if_bracket(ctx, '(');
     format(ctx, std::index_sequence_for<WT...>{}, v);
     tags.add_if_bracket(ctx, ')');

--- a/src/core/util/format_tags.h
+++ b/src/core/util/format_tags.h
@@ -30,7 +30,7 @@ template <typename T>
 concept arts_formattable =
     std::formattable<T, char> and arts_inner_fmt<T> and requires(T x) {
       std::format("{}", x);
-      std::format("{:nsqNBIO,}", x);
+      std::format("{:hnsqNBIO,}", x);
     };
 
 template <typename T>
@@ -46,6 +46,7 @@ struct format_tags {
   bool short_str = false;
   bool io        = false;
   bool newline   = false;
+  bool help      = false;
   Size depth     = 0;
 
   [[nodiscard]] std::string get_format_args() const;
@@ -160,6 +161,12 @@ constexpr std::format_parse_context::iterator parse_format_tags(
 
     if (*it == 'n') {
       fmt.newline = true;
+      ++it;
+      continue;
+    }
+
+    if (*it == 'h') {
+      fmt.help = true;
       ++it;
       continue;
     }

--- a/src/m_lbl.cc
+++ b/src/m_lbl.cc
@@ -587,9 +587,8 @@ void absorption_bandsLineMixingAdaptation(
             temperatures, eqv_str[joker, j, k].imag(), polynomial_fit_degree);
         ARTS_USER_ERROR_IF(
             not yfit, "Cannot fit y for line {} of band {}", k, band_key)
-        band.lines[k].ls.single_models[j].data.emplace_back(
-            LineShapeModelVariable::Y,
-            lbl::temperature::data{LineShapeModelType::POLY, *yfit});
+        band.lines[k].ls.single_models[j].data[LineShapeModelVariable::Y] =
+            lbl::temperature::data{LineShapeModelType::POLY, *yfit};
       }
 
       if (rosenkranz_fit_order >= 2) {
@@ -597,17 +596,15 @@ void absorption_bandsLineMixingAdaptation(
             temperatures, eqv_str[joker, j, k].real(), polynomial_fit_degree);
         ARTS_USER_ERROR_IF(
             not gfit, "Cannot fit g for line {} of band {}", k, band_key)
-        band.lines[k].ls.single_models[j].data.emplace_back(
-            LineShapeModelVariable::G,
-            lbl::temperature::data{LineShapeModelType::POLY, *gfit});
+        band.lines[k].ls.single_models[j].data[LineShapeModelVariable::G] =
+            lbl::temperature::data{LineShapeModelType::POLY, *gfit};
 
         auto dfit = polyfit(
             temperatures, eqv_val[joker, j, k].real(), polynomial_fit_degree);
         ARTS_USER_ERROR_IF(
             not dfit, "Cannot fit dv for line {} of band {}", k, band_key)
-        band.lines[k].ls.single_models[j].data.emplace_back(
-            LineShapeModelVariable::DV,
-            lbl::temperature::data{LineShapeModelType::POLY, *dfit});
+        band.lines[k].ls.single_models[j].data[LineShapeModelVariable::DV] =
+            lbl::temperature::data{LineShapeModelType::POLY, *dfit};
       }
     }
   }

--- a/src/python_interface/py_disort.cpp
+++ b/src/python_interface/py_disort.cpp
@@ -40,6 +40,7 @@ void py_disort(py::module_& m) try {
           "y"_a);
   generic_interface(bdrfop);  // FIXME OLE
   py::implicitly_convertible<DisortBDRFOperator::func_t, DisortBDRFOperator>();
+
   py::class_<DisortBDRF> disbdrf(m, "DisortBDRF");
   disbdrf
       .def(
@@ -219,6 +220,7 @@ void py_disort(py::module_& m) try {
           },
           "tau"_a,
           "Compute the downward flux");
+  generic_interface(x);
 
   py::class_<DisortSettings> disort_settings(m, "DisortSettings");
   generic_interface(disort_settings);

--- a/src/python_interface/py_jac.cpp
+++ b/src/python_interface/py_jac.cpp
@@ -18,6 +18,7 @@ NB_MAKE_OPAQUE(std::vector<Jacobian::ErrorTarget>)
 namespace Python {
 void py_jac(py::module_& m) try {
   py::class_<ErrorKey> errkey(m, "ErrorKey");
+  generic_interface(errkey);
   errkey.doc() = "Error key";
   errkey.def_rw(
       "y_start",
@@ -28,6 +29,7 @@ void py_jac(py::module_& m) try {
                 "Size of target in measurement vector\n\n.. :class:`Index`");
 
   py::class_<Jacobian::AtmTarget> atm(m, "JacobianAtmTarget");
+  generic_interface(atm);
   atm.doc() = "Atmospheric target";
   atm.def_ro("type",
              &Jacobian::AtmTarget::type,
@@ -44,9 +46,9 @@ void py_jac(py::module_& m) try {
   atm.def_ro("x_size",
              &Jacobian::AtmTarget::x_size,
              "Size of target in state vector\n\n.. :class:`Index`");
-  str_interface(atm);
 
   py::class_<Jacobian::SurfaceTarget> surf(m, "JacobianSurfaceTarget");
+  generic_interface(surf);
   surf.doc() = "Surface target";
   surf.def_ro("type",
               &Jacobian::SurfaceTarget::type,
@@ -63,9 +65,9 @@ void py_jac(py::module_& m) try {
   surf.def_ro("x_size",
               &Jacobian::SurfaceTarget::x_size,
               "Size of target in state vector\n\n.. :class:`Index`");
-  str_interface(surf);
 
   py::class_<Jacobian::LineTarget> line(m, "JacobianLineTarget");
+  generic_interface(line);
   line.doc() = "Line target";
   line.def_ro("type",
               &Jacobian::LineTarget::type,
@@ -82,9 +84,9 @@ void py_jac(py::module_& m) try {
   line.def_ro("x_size",
               &Jacobian::LineTarget::x_size,
               "Size of target in state vector\n\n.. :class:`Index`");
-  str_interface(line);
 
   py::class_<Jacobian::SensorTarget> sensor(m, "JacobianSensorTarget");
+  generic_interface(sensor);
   sensor.doc() = "Sensor target";
   sensor.def_ro("type",
                 &Jacobian::SensorTarget::type,
@@ -101,9 +103,9 @@ void py_jac(py::module_& m) try {
   sensor.def_ro("x_size",
                 &Jacobian::SensorTarget::x_size,
                 "Size of target in state vector\n\n.. :class:`Index`");
-  str_interface(sensor);
 
   py::class_<Jacobian::ErrorTarget> error(m, "JacobianErrorTarget");
+  generic_interface(error);
   error.doc() = "Error target";
   error.def_ro("type",
                &Jacobian::ErrorTarget::type,
@@ -117,19 +119,28 @@ void py_jac(py::module_& m) try {
   error.def_ro("x_size",
                &Jacobian::ErrorTarget::x_size,
                "Size of target in state vector\n\n.. :class:`Index`");
-  str_interface(error);
 
-  py::bind_vector<std::vector<Jacobian::AtmTarget>>(m, "ArrayOfAtmTargets")
-      .doc() = "List of atmospheric targets";
-  py::bind_vector<std::vector<Jacobian::SurfaceTarget>>(m,
-                                                        "ArrayOfSurfaceTarget")
-      .doc() = "List of surface targets";
-  py::bind_vector<std::vector<Jacobian::LineTarget>>(m, "ArrayOfLineTarget")
-      .doc() = "List of line targets";
-  py::bind_vector<std::vector<Jacobian::SensorTarget>>(m, "ArrayOfSensorTarget")
-      .doc() = "List of sensor targets";
-  py::bind_vector<std::vector<Jacobian::ErrorTarget>>(m, "ArrayOfErrorTarget")
-      .doc() = "List of error targets";
+  auto atm_targets =
+      py::bind_vector<std::vector<Jacobian::AtmTarget>>(m, "ArrayOfAtmTargets");
+  atm_targets.doc() = "List of atmospheric targets";
+  auto surf_targets = py::bind_vector<std::vector<Jacobian::SurfaceTarget>>(
+      m, "ArrayOfSurfaceTarget");
+  surf_targets.doc() = "List of surface targets";
+  auto line_targets  = py::bind_vector<std::vector<Jacobian::LineTarget>>(
+      m, "ArrayOfLineTarget");
+  line_targets.doc()  = "List of line targets";
+  auto sensor_targets = py::bind_vector<std::vector<Jacobian::SensorTarget>>(
+      m, "ArrayOfSensorTarget");
+  sensor_targets.doc() = "List of sensor targets";
+  auto error_targets   = py::bind_vector<std::vector<Jacobian::ErrorTarget>>(
+      m, "ArrayOfErrorTarget");
+  error_targets.doc() = "List of error targets";
+
+  generic_interface(atm_targets);
+  generic_interface(surf_targets);
+  generic_interface(line_targets);
+  generic_interface(sensor_targets);
+  generic_interface(error_targets);
 
   py::class_<JacobianTargets> jacs(m, "JacobianTargets");
   generic_interface(jacs);

--- a/src/python_interface/py_lbl.cpp
+++ b/src/python_interface/py_lbl.cpp
@@ -28,6 +28,7 @@ void py_lbl(py::module_& m) try {
   auto lbl = m.def_submodule("lbl", "Line-by-line helper functions");
 
   py::class_<lbl::line_key> line_key(lbl, "line_key");
+  generic_interface(line_key);
   line_key.def_rw("band",
                   &lbl::line_key::band,
                   "The band\n\n.. :class:`QuantumIdentifier`");
@@ -46,12 +47,12 @@ void py_lbl(py::module_& m) try {
                   &lbl::line_key::var,
                   "The variable\n\n.. :class:`LineByLineVariable`");
   line_key.doc() = "A key for a line";
-  str_interface(line_key);
 
-  py::class_<lbl::temperature::data>(m, "TemperatureModel")
-      .def(py::init<LineShapeModelType, Vector>(),
-           "type"_a,
-           "data"_a = Vector{0.0})
+  py::class_<lbl::temperature::data> tm(m, "TemperatureModel");
+  generic_interface(tm);
+  tm.def(py::init<LineShapeModelType, Vector>(),
+         "type"_a,
+         "data"_a = Vector{0.0})
       .def_prop_rw(
           "type",
           &lbl::temperature::data::Type,
@@ -106,9 +107,11 @@ void py_lbl(py::module_& m) try {
                });
   lsvtml.doc() = "A list of line shape models with temperature coefficients";
   vector_interface(lsvtml);
+  generic_interface(lsvtml);
 
-  py::class_<lbl::line_shape::species_model>(m, "LineShapeSpeciesModel")
-      .def_rw("species",
+  py::class_<lbl::line_shape::species_model> lssm(m, "LineShapeSpeciesModel");
+  generic_interface(lssm);
+  lssm.def_rw("species",
               &lbl::line_shape::species_model::species,
               "The species\n\n.. :class:`SpeciesEnum`")
       .def_rw(
@@ -185,11 +188,13 @@ void py_lbl(py::module_& m) try {
           m, "LineShapeModelList");
   lsml.doc() = "A list of line shape models";
   vector_interface(lsml);
+  generic_interface(lsml);
 
-  py::class_<lbl::line_shape::model>(m, "LineShapeModel")
-      .def_rw("one_by_one",
-              &lbl::line_shape::model::one_by_one,
-              "If true, the lines are treated one by one\n\n.. :class:`bool`")
+  py::class_<lbl::line_shape::model> lsm(m, "LineShapeModel");
+  generic_interface(lsm);
+  lsm.def_rw("one_by_one",
+             &lbl::line_shape::model::one_by_one,
+             "If true, the lines are treated one by one\n\n.. :class:`bool`")
       .def_rw("T0",
               &lbl::line_shape::model::T0,
               "The reference temperature\n\n.. :class:`Numeric`")
@@ -217,8 +222,9 @@ void py_lbl(py::module_& m) try {
           "Remove zero coefficients")
       .doc() = "Line shape model";
 
-  py::class_<lbl::zeeman::model>(m, "ZeemanLineModel")
-      .def_rw("on",
+  py::class_<lbl::zeeman::model> zlm(m, "ZeemanLineModel");
+  generic_interface(zlm);
+  zlm.def_rw("on",
               &lbl::zeeman::model::on,
               "If True, the Zeeman effect is included\n\n.. :class:`bool`")
       .def_prop_rw(
@@ -256,27 +262,23 @@ void py_lbl(py::module_& m) try {
           "The number of Zeeman lines")
       .doc() = "Zeeman model";
 
-  py::class_<lbl::line>(m, "AbsorptionLine")
-      .def_rw(
-          "a",
-          &lbl::line::a,
-          "The Einstein coefficient [1 / s]\n\n.. :class:`Numeric`")
-      .def_rw(
-          "f0",
-          &lbl::line::f0,
-          "The line center frequency [Hz]\n\n.. :class:`Numeric`")
-      .def_rw(
-          "e0",
-          &lbl::line::e0,
-          "The lower level energy [J]\n\n.. :class:`Numeric`")
-      .def_rw(
-          "gu",
-          &lbl::line::gu,
-          "The upper level statistical weight [-]\n\n.. :class:`Numeric`")
-      .def_rw(
-          "gl",
-          &lbl::line::gl,
-          "The lower level statistical weight [-]\n\n.. :class:`Numeric`")
+  py::class_<lbl::line> al(m, "AbsorptionLine");
+  generic_interface(al);
+  al.def_rw("a",
+             &lbl::line::a,
+             "The Einstein coefficient [1 / s]\n\n.. :class:`Numeric`")
+      .def_rw("f0",
+              &lbl::line::f0,
+              "The line center frequency [Hz]\n\n.. :class:`Numeric`")
+      .def_rw("e0",
+              &lbl::line::e0,
+              "The lower level energy [J]\n\n.. :class:`Numeric`")
+      .def_rw("gu",
+              &lbl::line::gu,
+              "The upper level statistical weight [-]\n\n.. :class:`Numeric`")
+      .def_rw("gl",
+              &lbl::line::gl,
+              "The lower level statistical weight [-]\n\n.. :class:`Numeric`")
       .def_rw("z",
               &lbl::line::z,
               "The Zeeman model\n\n.. :class:`~pyarts3.arts.ZeemanLineModel`")
@@ -311,8 +313,10 @@ void py_lbl(py::module_& m) try {
                              py::rv_policy::reference_internal>(m, "LineList");
   ll.doc() = "A list of :class:`AbsorptionLine`";
   vector_interface(ll);
+  generic_interface(ll);
 
   py::class_<AbsorptionBand> ab(m, "AbsorptionBand");
+  generic_interface(ab);
   ab.def_rw("lines",
             &AbsorptionBand::lines,
             "The lines in the band\n\n.. :class:`LineList`")
@@ -349,7 +353,6 @@ void py_lbl(py::module_& m) try {
           "isot"_a,
           "T0"_a = 296.0,
           "Keep only the lines with a stronger HITRAN-like line strength");
-  generic_interface(ab);
 
   auto aoab = py::bind_map<AbsorptionBands, py::rv_policy::reference_internal>(
       m, "AbsorptionBands");
@@ -504,6 +507,7 @@ T0 : float
       "T0"_a = 296.0);
 
   py::class_<LinemixingSingleEcsData> ed(m, "LinemixingSingleEcsData");
+  generic_interface(ed);
   ed.def_rw("scaling",
             &LinemixingSingleEcsData::scaling,
             ".. :class:`~pyarts3.arts.TemperatureModel`");
@@ -532,7 +536,6 @@ T0 : float
          "energy_x"_a,
          "energy_xm2"_a,
          R"(The Omega coefficient for the ECS model)");
-  generic_interface(ed);
 
   auto lsed =
       py::bind_map<LinemixingSpeciesEcsData>(m, "LinemixingSpeciesEcsData");

--- a/src/python_interface/py_math.cpp
+++ b/src/python_interface/py_math.cpp
@@ -3,6 +3,7 @@
 #include <matpack.h>
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/pair.h>
+#include <hpy_arts.h>
 #include <wigner_functions.h>
 
 #include <utility>
@@ -239,8 +240,9 @@ w : list[float]
     The weights
 )");
 
-  py::class_<Legendre::SchmidtMatrix>(math, "SchmidtMatrix")
-      .def(py::init<Size>(), "N"_a, "Default Schmidt matrix")
+  py::class_<Legendre::SchmidtMatrix> sm(math, "SchmidtMatrix");
+  generic_interface(sm);
+  sm.def(py::init<Size>(), "N"_a, "Default Schmidt matrix")
       .def(
           "__getitem__",
           [](const Legendre::SchmidtMatrix& self, std::pair<Index, Index> idx) {

--- a/src/python_interface/py_matpack.cpp
+++ b/src/python_interface/py_matpack.cpp
@@ -214,6 +214,10 @@ void py_matpack(py::module_& m) try {
   matpack_interface(comv2);
   matpack_interface(comv3);
   matpack_interface(comv4);
+  generic_interface(comv1);
+  generic_interface(comv2);
+  generic_interface(comv3);
+  generic_interface(comv4);
 
   py::class_<AscendingGrid> g1(m, "AscendingGrid");
   matpack_grid_interface(g1);

--- a/src/python_interface/py_operators.cpp
+++ b/src/python_interface/py_operators.cpp
@@ -3,8 +3,8 @@
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/function.h>
 #include <nanobind/stl/pair.h>
-#include <nanobind/stl/string_view.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/string_view.h>
 #include <nanobind/stl/vector.h>
 #include <operators.h>
 
@@ -49,6 +49,7 @@ void py_operators(py::module_& m) {
           "atm_point"_a)
       .doc() =
       "A callback to get [extinction, ssa] from a single scattering albedo and extinction field.";
+  generic_interface(esop);
   py::implicitly_convertible<ExtSSACallback::func_t, ExtSSACallback>();
 
   py::class_<NumericBinaryOperator> nbop(m, "NumericBinaryOperator");
@@ -117,13 +118,13 @@ void py_operators(py::module_& m) {
           "z"_a);
   sgstro.doc() =
       "A callback to get the bulk scattering properties of a species.";
+  generic_interface(sgstro);
   py::implicitly_convertible<ScatteringGeneralSpectralTROFunc::func_t,
                              ScatteringGeneralSpectralTROFunc>();
 
   py::class_<SpectralRadianceTransformOperator> srtop(
       m, "SpectralRadianceTransformOperator");
-  srtop
-      .def(py::init_implicit<const std::string_view&>())
+  srtop.def(py::init_implicit<const std::string_view&>())
       .def("__init__",
            [](SpectralRadianceTransformOperator* op,
               SpectralRadianceTransformOperator::Op::func_t f) {

--- a/src/python_interface/py_path.cpp
+++ b/src/python_interface/py_path.cpp
@@ -10,7 +10,6 @@
 namespace Python {
 void py_path(py::module_& m) try {
   py::class_<PropagationPathPoint> pppp(m, "PropagationPathPoint");
-
   generic_interface(pppp);
 
   pppp.def_rw("pos_type",

--- a/src/python_interface/py_predefined.cpp
+++ b/src/python_interface/py_predefined.cpp
@@ -16,9 +16,10 @@
 
 namespace Python {
 void internalCKDMT400(py::module_& m) {
-  py::class_<Absorption::PredefinedModel::MT_CKD400::WaterData>(
-      m, "MTCKD400WaterData")
-      .def(py::init<Absorption::PredefinedModel::MT_CKD400::WaterData>())
+  py::class_<Absorption::PredefinedModel::MT_CKD400::WaterData> mm(
+      m, "MTCKD400WaterData");
+  generic_interface(mm);
+  mm.def(py::init<Absorption::PredefinedModel::MT_CKD400::WaterData>())
       .def_rw("ref_temp",
               &Absorption::PredefinedModel::MT_CKD400::WaterData::ref_temp,
               "Reference temperature\n\n.. :class:`Numeric`")
@@ -915,8 +916,9 @@ abs_coef : ~pyarts3.arts.Vector
 )--");
 }
 void internalNamedModel(py::module_& m) {
-  py::class_<Absorption::PredefinedModel::ModelName>(m, "ModelName")
-      .def(py::init<Absorption::PredefinedModel::ModelName>())
+  py::class_<Absorption::PredefinedModel::ModelName> mm(m, "ModelName");
+  generic_interface(mm);
+  mm.def(py::init<Absorption::PredefinedModel::ModelName>())
       .def("__getstate__",
            [](const Absorption::PredefinedModel::ModelName&) {
              return py::make_tuple();

--- a/src/python_interface/py_rtepack.cpp
+++ b/src/python_interface/py_rtepack.cpp
@@ -160,8 +160,10 @@ void py_rtepack(py::module_ &m) try {
   py::implicitly_convertible<PolarizationChoice, Stokvec>();
   py::implicitly_convertible<String, Stokvec>();
 
-  py::bind_vector<std::vector<Stokvec>>(m, "ArrayOfStokvec").doc() =
-      "A list of :class:`~pyarts3.arts.Stokvec`";
+  auto asv = py::bind_vector<std::vector<Stokvec>>(m, "ArrayOfStokvec");
+  generic_interface(asv);
+  vector_interface(asv);
+  asv.doc() = "A list of :class:`~pyarts3.arts.Stokvec`";
 
   py::class_<StokvecVector> vsv(m, "StokvecVector");
   vsv.def(py::init_implicit<std::vector<Numeric>>())
@@ -227,8 +229,10 @@ void py_rtepack(py::module_ &m) try {
   common_ndarray(pm);
   generic_interface(pm);
 
-  py::bind_vector<std::vector<Propmat>>(m, "ArrayOfPropmat").doc() =
-      "A list of :class:`~pyarts3.arts.Propmat`";
+  auto apm = py::bind_vector<std::vector<Propmat>>(m, "ArrayOfPropmat");
+  generic_interface(apm);
+  vector_interface(apm);
+  apm.doc() = "A list of :class:`~pyarts3.arts.Propmat`";
 
   py::class_<PropmatVector> vpm(m, "PropmatVector");
   vpm.def(py::init_implicit<std::vector<Numeric>>())
@@ -277,8 +281,10 @@ void py_rtepack(py::module_ &m) try {
   common_ndarray(mm);
   generic_interface(mm);
 
-  py::bind_vector<std::vector<Muelmat>>(m, "ArrayOfMuelmat").doc() =
-      "A list of :class:`~pyarts3.arts.Muelmat`";
+  auto amm = py::bind_vector<std::vector<Muelmat>>(m, "ArrayOfMuelmat");
+  generic_interface(amm);
+  vector_interface(amm);
+  amm.doc() = "A list of :class:`~pyarts3.arts.Muelmat`";
 
   py::class_<MuelmatVector> vmm(m, "MuelmatVector");
   vmm.def(py::init_implicit<std::vector<Numeric>>())
@@ -336,13 +342,14 @@ void py_rtepack(py::module_ &m) try {
           m, "ArrayOfSpecmat");
   asp.doc() = "A list of :class:`~pyarts3.arts.Specmat`";
   vector_interface(asp);
+  generic_interface(asp);
 
   py::class_<SpecmatVector> vcmm(m, "SpecmatVector");
   vcmm.def(py::init_implicit<std::vector<Complex>>())
       .def(py::init_implicit<std::vector<Specmat>>());
   rtepack_array<Specmat, 1, 4, 4>(vcmm);
   vcmm.doc() = "A vector of :class:`~pyarts3.arts.Specmat`";
-  //generic_interface(vcmm);
+  generic_interface(vcmm);
 
   py::class_<SpecmatMatrix> mcmm(m, "SpecmatMatrix");
   rtepack_array<Specmat, 2, 4, 4>(mcmm);
@@ -351,6 +358,7 @@ void py_rtepack(py::module_ &m) try {
   py::class_<SpecmatTensor3> cmt3(m, "SpecmatTensor3");
   rtepack_array<Specmat, 3, 4, 4>(cmt3);
   cmt3.doc() = "A 3-tensor of :class:`~pyarts3.arts.Specmat`";
+  generic_interface(cmt3);
 
   auto a1 =
       py::bind_vector<ArrayOfPropmatVector, py::rv_policy::reference_internal>(
@@ -425,31 +433,11 @@ void py_rtepack(py::module_ &m) try {
   generic_interface(c5);
   vector_interface(c5);
 
-  //   auto d1 =
-  //       py::bind_vector<ArrayOfSpecmatVector, py::rv_policy::reference_internal>(
-  //           m, "ArrayOfSpecmatVector");
-  //   generic_interface(d1);
-  //   vector_interface(d1);
-  //   auto d2 = py::bind_vector<ArrayOfArrayOfSpecmatVector,
-  //                             py::rv_policy::reference_internal>(
-  //       m, "ArrayOfArrayOfSpecmatVector");
-  //   generic_interface(d2);
-  //   vector_interface(d2);
   auto d3 =
       py::bind_vector<ArrayOfSpecmatMatrix, py::rv_policy::reference_internal>(
           m, "ArrayOfSpecmatMatrix");
   generic_interface(d3);
   vector_interface(d3);
-  //   auto d4 = py::bind_vector<ArrayOfArrayOfSpecmatMatrix,
-  //                             py::rv_policy::reference_internal>(
-  //       m, "ArrayOfArrayOfSpecmatMatrix");
-  //   generic_interface(d4);
-  //   vector_interface(d4);
-  //   auto d5 =
-  //       py::bind_vector<ArrayOfSpecmatTensor3, py::rv_policy::reference_internal>(
-  //           m, "ArrayOfSpecmatTensor3");
-  //   generic_interface(d5);
-  //   vector_interface(d5);
 
   auto rtepack  = m.def_submodule("rtepack");
   rtepack.doc() = "Interface to some of the core RTE functionality";

--- a/src/python_interface/py_sensor.cpp
+++ b/src/python_interface/py_sensor.cpp
@@ -146,6 +146,8 @@ void py_sensor(py::module_& m) try {
                             py::rv_policy::reference_internal>(
       m, "ArrayOfSensorPosLosVector");
   a0.doc() = "Array of SensorPosLosVector";
+  generic_interface(a0);
+  vector_interface(a0);
 
   auto a1 =
       py::bind_vector<ArrayOfSensorObsel, py::rv_policy::reference_internal>(

--- a/src/python_interface/py_sparse.cpp
+++ b/src/python_interface/py_sparse.cpp
@@ -415,7 +415,9 @@ arr : :class:`scipy.sparse.csr_matrix`
   generic_interface(a1);
   vector_interface(a1);
 
-  py::class_<Block>(m, "Block")
+  py::class_<Block> block(m, "Block");
+  generic_interface(block);
+  block
       .def(py::init<Range, Range, IndexPair, std::shared_ptr<Matrix>>(),
            "By value, dense")
       .def(py::init<Range, Range, IndexPair, std::shared_ptr<Sparse>>(),

--- a/src/python_interface/py_species.cpp
+++ b/src/python_interface/py_species.cpp
@@ -61,6 +61,7 @@ std::string docs_isotopes() {
 namespace Python {
 void py_species(py::module_& m) try {
   py::class_<SpeciesIsotopologueRatios> sirs(m, "SpeciesIsotopologueRatios");
+  generic_interface(sirs);
   sirs.doc() = "Isotopologue ratios for a species";
   sirs.def(
           "__init__",
@@ -240,6 +241,7 @@ Returns
       py::bind_vector<Array<SpeciesTag>, py::rv_policy::reference_internal>(
           m, "_ArrayOfSpeciesTag");
   vector_interface(tmp1_);
+  generic_interface(tmp1_);
 
   //////////////////////////////////////////////////////////////////////
 
@@ -308,6 +310,7 @@ Returns
                                py::rv_policy::reference_internal>(
       m, "_ArrayOfArrayOfSpeciesTag");
   vector_interface(tmp2_);
+  generic_interface(tmp2_);
 
   //////////////////////////////////////////////////////////////////////
 

--- a/src/python_interface/py_star.cpp
+++ b/src/python_interface/py_star.cpp
@@ -38,12 +38,12 @@ void py_star(py::module_& m) try {
               const std::
                   tuple<String, Matrix, Numeric, Numeric, Numeric, Numeric>&
                       state) {
-             new (self) Sun{std::get<0>(state),
-                            std::get<1>(state),
-                            std::get<2>(state),
-                            std::get<3>(state),
-                            std::get<4>(state),
-                            std::get<5>(state)};
+             new (self) Sun{.description = std::get<0>(state),
+                            .spectrum    = std::get<1>(state),
+                            .radius      = std::get<2>(state),
+                            .distance    = std::get<3>(state),
+                            .latitude    = std::get<4>(state),
+                            .longitude   = std::get<5>(state)};
            });
 
   auto a1 = py::bind_vector<ArrayOfSun, py::rv_policy::reference_internal>(

--- a/src/python_interface/py_surf.cpp
+++ b/src/python_interface/py_surf.cpp
@@ -116,6 +116,7 @@ void py_surf(py::module_ &m) try {
   surfdata.doc() = "Surface data";
   py::implicitly_convertible<Surf::FunctionalData::func_t, Surf::Data>();
   py::implicitly_convertible<GriddedField2, Surf::Data>();
+  generic_interface(surfdata);
 
   py::class_<SurfacePropertyTag> spt =
       py::class_<SurfacePropertyTag>(m, "SurfacePropertyTag");
@@ -132,6 +133,8 @@ void py_surf(py::module_ &m) try {
       py::bind_vector<ArrayOfSurfacePoint, py::rv_policy::reference_internal>(
           m, "ArrayOfSurfacePoint");
   asp.doc() = "Array of SurfacePoint";
+  generic_interface(asp);
+  vector_interface(asp);
 
   auto fld = py::class_<SurfaceField>(m, "SurfaceField");
   fld.def(

--- a/src/python_interface/py_workspace.cpp
+++ b/src/python_interface/py_workspace.cpp
@@ -77,6 +77,7 @@ void py_auto_wsv(py::class_<Workspace>& ws);
 void py_auto_wsm(py::class_<Workspace>& ws);
 
 void py_workspace(py::class_<Workspace>& ws) try {
+  generic_interface(ws);
   ws.def(
         "__init__",
         [](Workspace* w, bool with_defaults) {
@@ -158,8 +159,6 @@ void py_workspace(py::class_<Workspace>& ws) try {
           "other"_a,
           "Swap the workspace for andother.");
 
-  str_interface(ws);
-  xml_interface(ws);
   ws.def(
         "__iter__",
         [](const Workspace& w) {

--- a/src/python_interface/py_zeeman.cpp
+++ b/src/python_interface/py_zeeman.cpp
@@ -5,6 +5,7 @@
 
 #include <sstream>
 
+#include "hpy_arts.h"
 #include "lbl_zeeman.h"
 #include "python_interface.h"
 
@@ -32,14 +33,15 @@ void py_zeeman(py::module_& m) try {
   auto zee  = m.def_submodule("zeeman");
   zee.doc() = "Zeeman effect calculations";
 
-  py::class_<lbl::zeeman::pol>(zee, "PolarizationState")
-      .def(
-          "__init__",
-          [](lbl::zeeman::pol* out, const std::string& val) {
-            auto x = to(val);
-            new (out) lbl::zeeman::pol{x};
-          },
-          "val"_a = std::string{"no"})
+  py::class_<lbl::zeeman::pol> zze(zee, "PolarizationState");
+  generic_interface(zze);
+  zze.def(
+         "__init__",
+         [](lbl::zeeman::pol* out, const std::string& val) {
+           auto x = to(val);
+           new (out) lbl::zeeman::pol{x};
+         },
+         "val"_a = std::string{"no"})
       .def_static(
           "get_options",
           []() {
@@ -102,8 +104,9 @@ void py_zeeman(py::module_& m) try {
       .doc() = "Polarization state of Zeeman calculations";
   py::implicitly_convertible<const std::string&, lbl::zeeman::pol>();
 
-  py::class_<lbl::zeeman::magnetic_angles>(zee, "MagneticAngles")
-      .def(py::init<Vector3, Vector2>())
+  py::class_<lbl::zeeman::magnetic_angles> zzma(zee, "MagneticAngles");
+  generic_interface(zzma);
+  zzma.def(py::init<Vector3, Vector2>())
       .def_ro("u",
               &lbl::zeeman::magnetic_angles::u,
               "Magnetic u\n\n.. :class:`Numeric`")

--- a/src/tests/test_vformat.cc
+++ b/src/tests/test_vformat.cc
@@ -29,12 +29,10 @@ lbl::line get_lbl_line() {
   l.ls.T0         = 300.0;
   auto& mod       = l.ls.single_models.emplace_back("H2O"_spec);
 
-  mod.data.emplace_back(
-      LineShapeModelVariable::G0,
-      lbl::temperature::data{LineShapeModelType::T0, Vector{6.0}});
-  mod.data.emplace_back(
-      LineShapeModelVariable::D0,
-      lbl::temperature::data{LineShapeModelType::T1, Vector{7.0, 8.0}});
+  mod.data[LineShapeModelVariable::G0] =
+      lbl::temperature::data{LineShapeModelType::T0, Vector{6.0}};
+  mod.data[LineShapeModelVariable::D0] =
+      lbl::temperature::data{LineShapeModelType::T1, Vector{7.0, 8.0}};
 
   l.z.gu(6.0);
   l.z.gl(7.0);

--- a/src/xml_io_old.cc
+++ b/src/xml_io_old.cc
@@ -134,19 +134,15 @@ ArtscatMeta ReadFromArtscat3Stream(std::istream& is) {
 
       // Set line shape computer
       output.data.ls.single_models[0].species = isotopologue.spec;
-      output.data.ls.single_models[0].data.emplace_back(
-          LineShapeModelVariable::G0,
-          lbl::temperature::data{LineShapeModelType::T1, Vector{sgam, nair}});
-      output.data.ls.single_models[0].data.emplace_back(
-          LineShapeModelVariable::D0,
-          lbl::temperature::data{LineShapeModelType::T5, Vector{psf, nair}});
+      output.data.ls.single_models[0].data[LineShapeModelVariable::G0] =
+          lbl::temperature::data{LineShapeModelType::T1, Vector{sgam, nair}};
+      output.data.ls.single_models[0].data[LineShapeModelVariable::D0] =
+          lbl::temperature::data{LineShapeModelType::T5, Vector{psf, nair}};
       output.data.ls.single_models[1].species = SpeciesEnum::Bath;
-      output.data.ls.single_models[1].data.emplace_back(
-          LineShapeModelVariable::G0,
-          lbl::temperature::data{LineShapeModelType::T1, Vector{agam, nair}});
-      output.data.ls.single_models[1].data.emplace_back(
-          LineShapeModelVariable::D0,
-          lbl::temperature::data{LineShapeModelType::T5, Vector{psf, nair}});
+      output.data.ls.single_models[1].data[LineShapeModelVariable::G0] =
+          lbl::temperature::data{LineShapeModelType::T1, Vector{agam, nair}};
+      output.data.ls.single_models[1].data[LineShapeModelVariable::D0] =
+          lbl::temperature::data{LineShapeModelType::T5, Vector{psf, nair}};
 
       if (not(output.data.gu > 0.0)) output.data.gu = 1.;
       if (not(output.data.gl > 0.0)) output.data.gl = 1.;
@@ -188,31 +184,32 @@ lbl::line_shape::model from_artscat4(std::istream& is,
   out.single_models[6].species = to<SpeciesEnum>("He");
 
   for (auto& v : out.single_models) {
-    v.data.emplace_back(
-        LineShapeModelVariable::G0,
-        lbl::temperature::data{LineShapeModelType::T1, Vector{0, 0}});
-    v.data.emplace_back(
-        LineShapeModelVariable::D0,
-        lbl::temperature::data{LineShapeModelType::T5, Vector{0, 0}});
+    v.data[LineShapeModelVariable::G0] =
+        lbl::temperature::data{LineShapeModelType::T1, Vector{0, 0}};
+    v.data[LineShapeModelVariable::D0] =
+        lbl::temperature::data{LineShapeModelType::T5, Vector{0, 0}};
   }
 
   // G0 main coefficient
   for (auto& v : out.single_models) {
-    is >> double_imanip() >> v.data[0].second.X(LineShapeModelCoefficient::X0);
+    is >> double_imanip() >>
+        v.data[LineShapeModelVariable::G0].X(LineShapeModelCoefficient::X0);
   };
 
   // G0 exponent is same as D0 exponent
   for (auto& v : out.single_models) {
-    is >> double_imanip() >> v.data[0].second.X(LineShapeModelCoefficient::X1);
-    v.data[1].second.X(LineShapeModelCoefficient::X1) =
-        v.data[0].second.X(LineShapeModelCoefficient::X1);
+    is >> double_imanip() >>
+        v.data[LineShapeModelVariable::G0].X(LineShapeModelCoefficient::X1);
+    v.data[LineShapeModelVariable::D0].X(LineShapeModelCoefficient::X1) =
+        v.data[LineShapeModelVariable::G0].X(LineShapeModelCoefficient::X1);
   };
 
   // D0 coefficient
-  out.single_models.front().data.back().second.X(
+  out.single_models.front().data[LineShapeModelVariable::D0].X(
       LineShapeModelCoefficient::X0) = 0;
   for (auto& v : out.single_models | stdv::drop(1)) {
-    is >> double_imanip() >> v.data[1].second.X(LineShapeModelCoefficient::X0);
+    is >> double_imanip() >>
+        v.data[LineShapeModelVariable::D0].X(LineShapeModelCoefficient::X0);
   }
 
   // Remove duplicate species


### PR DESCRIPTION
This adds "h" as a formatting option.  It does pretty much nothing except for absorption-bands and lines, where it prints information similar to how the old <comment> blocks used to work.

To use, simply ``print(f"{ws.absorption_bands:h}")`` and the formatter will deal with it.  Inside ARTS, using ``tags.help`` as an early return tag in a formatter is how you would access this if you wish to extend it to other types.   To help with containers a ``template <typename T> std::optional<std::string> to_helper_string(const T&)`` overload exist that returns nothing by default.  Overload this if you need formatting helper methods for standard containers.