### PR TITLE
Map species data

### DIFF
--- a/src/core/jacobian/jacobian.h
+++ b/src/core/jacobian/jacobian.h
@@ -22,6 +22,8 @@
 #include "jacobian_names.h"
 #include "xml_io_stream_functional.h"
 
+#include <boost/container_hash/hash.hpp>
+
 struct ErrorKey {
   Size y_start;
 
@@ -35,7 +37,10 @@ struct ErrorKey {
 template <>
 struct std::hash<ErrorKey> {
   std::size_t operator()(const ErrorKey& g) const {
-    return std::hash<Size>{}(g.y_start) ^ (std::hash<Size>{}(g.y_size) << 32);
+    std::size_t seed = 0;
+    boost::hash_combine(seed, g.y_start);
+    boost::hash_combine(seed, g.y_size);
+    return seed;
   }
 };
 

--- a/src/core/lbl/lbl_data.cpp
+++ b/src/core/lbl/lbl_data.cpp
@@ -120,22 +120,28 @@ auto local_get_value(T& absorption_bands, const line_key& type)
 
   if (good_enum(type.ls_var)) {
     auto& line_ls_data = line.ls.single_models;
-    ARTS_USER_ERROR_IF(type.spec >= line_ls_data.size(),
-                       "Not enough line data for line: {}"
-                       " for quantum identifier: {}",
+    const auto ptr     = line_ls_data.find(type.spec);
+    ARTS_USER_ERROR_IF(ptr == line_ls_data.end(),
+                       R"(Missing data.
+Species: {}
+Line:    {}
+Band:    {}
+)",
+                       type.spec,
                        line,
                        type.band);
 
-    auto& ls_data = line_ls_data[type.spec].data;
-    auto ls_ptr   = std::ranges::find_if(
-        ls_data, [var = type.ls_var](auto& x) { return x.first == var; });
+    auto& ls_data = ptr->second.data;
+    auto ls_ptr   = ls_data.find(type.ls_var);
     ARTS_USER_ERROR_IF(ls_ptr == ls_data.end(),
-                       "No line shape parameter: \"{}"
-                       "\" for species: \"{}"
-                       "\" in line: {}"
-                       " for quantum identifier: {}",
+                       R"(Missing data.
+Line Shape Model Variable: {}
+Species:                   {}
+Line:                      {}
+Band:                      {}
+)",
                        type.ls_var,
-                       line_ls_data[type.spec].species,
+                       type.spec,
                        line,
                        type.band);
 
@@ -200,11 +206,7 @@ std::unordered_set<SpeciesEnum> species_in_bands(
     out.insert(key.isot.spec);
 
     for (auto& line : data.lines) {
-      for (auto spec :
-           line.ls.single_models |
-               std::views::transform([](auto& x) { return x.species; })) {
-        out.insert(spec);
-      }
+      out.insert_range(line.ls.single_models | stdv::keys);
     }
   }
   return out;

--- a/src/core/lbl/lbl_data.cpp
+++ b/src/core/lbl/lbl_data.cpp
@@ -321,7 +321,8 @@ std::string std::formatter<lbl::line>::to_string(const lbl::line& v) const {
                         "; Line shape: "sv,
                         v.ls,
                         "; Quantum state: "sv,
-                        v.qn);
+                        v.qn,
+                        ';');
   }
 
   if (tags.io) {
@@ -353,14 +354,18 @@ std::string std::formatter<lbl::line>::to_string(const lbl::line& v) const {
 std::string std::formatter<lbl::band_data>::to_string(
     const lbl::band_data& v) const {
   if (tags.help) {
-    return tags.vformat("Line shape: "sv,
-                        v.lineshape,
-                        "; Cutoff type: "sv,
-                        v.cutoff,
-                        "; Cutoff value: "sv,
-                        to_educational_string_frequency(v.cutoff_value),
-                        "; Lines: "sv,
-                        v.lines);
+    return tags.vformat(
+        "Line shape: "sv,
+        v.lineshape,
+        "; Cutoff: "sv,
+        v.cutoff == LineByLineCutoffType::None
+            ? "<off>"s
+            : std::format("{} at {}",
+                          v.cutoff,
+                          to_educational_string_frequency(v.cutoff_value)),
+        "; Lines: ["sv,
+        v.lines,
+        ']');
   }
 
   if (tags.io) {
@@ -481,7 +486,7 @@ std::optional<std::string> to_helper_string<AbsorptionBands>(
 
   std::string_view x = ""sv;
   for (auto& [qid, data] : bands) {
-    out += std::format("{}{:h}: {:h}", std::exchange(x, "\n"sv), qid, data);
+    out += std::format("{}{:h} --- {:h}", std::exchange(x, "\n"sv), qid, data);
   }
 
   return out;

--- a/src/core/lbl/lbl_data.h
+++ b/src/core/lbl/lbl_data.h
@@ -19,6 +19,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "enumsSpeciesEnum.h"
 #include "lbl_lineshape_model.h"
 #include "lbl_zeeman.h"
 
@@ -205,7 +206,7 @@ struct band_data {
 
 struct line_pos {
   Size line;
-  Size spec{std::numeric_limits<Size>::max()};
+  SpeciesEnum spec{SpeciesEnum::unused};
   Size iz{std::numeric_limits<Size>::max()};
 };
 
@@ -217,8 +218,8 @@ struct line_key {
   //! The line count within the band
   Size line{std::numeric_limits<Size>::max()};
 
-  //! The species index if (ls_var is not invalid)
-  Size spec{std::numeric_limits<Size>::max()};
+  //! The species (if ls_var is not invalid)
+  SpeciesEnum spec{SpeciesEnum::Bath};
 
   /* The variable to be used for the line shape derivative
 
@@ -300,7 +301,7 @@ template <>
 struct std::hash<lbl::line_key> {
   Size operator()(const lbl::line_key& x) const {
     return (std::hash<QuantumIdentifier>{}(x.band) << 32) ^
-           std::hash<Size>{}(x.line) ^ std::hash<Size>{}(x.spec);
+           std::hash<Size>{}(x.line) ^ std::hash<SpeciesEnum>{}(x.spec);
   }
 };
 

--- a/src/core/lbl/lbl_data.h
+++ b/src/core/lbl/lbl_data.h
@@ -219,7 +219,7 @@ struct line_key {
   Size line{std::numeric_limits<Size>::max()};
 
   //! The species (if ls_var is not invalid)
-  SpeciesEnum spec{SpeciesEnum::Bath};
+  SpeciesEnum spec{SpeciesEnum::unused};
 
   /* The variable to be used for the line shape derivative
 

--- a/src/core/lbl/lbl_data.h
+++ b/src/core/lbl/lbl_data.h
@@ -300,8 +300,13 @@ Size count_lines(const std::unordered_map<QuantumIdentifier, lbl::band_data>&);
 template <>
 struct std::hash<lbl::line_key> {
   Size operator()(const lbl::line_key& x) const {
-    return (std::hash<QuantumIdentifier>{}(x.band) << 32) ^
-           std::hash<Size>{}(x.line) ^ std::hash<SpeciesEnum>{}(x.spec);
+    std::size_t seed = 0;
+
+    boost::hash_combine(seed, std::hash<QuantumIdentifier>{}(x.band));
+    boost::hash_combine(seed, std::hash<Size>{}(x.line));
+    boost::hash_combine(seed, std::hash<SpeciesEnum>{}(x.spec));
+
+    return seed;
   }
 };
 

--- a/src/core/lbl/lbl_hitran.cpp
+++ b/src/core/lbl/lbl_hitran.cpp
@@ -179,20 +179,18 @@ line hitran_record::from(HitranLineStrengthOption ls,
   l.ls            = line_shape::model{};
   l.ls.T0         = 296.0;
   l.ls.one_by_one = false;
-  l.ls.single_models.resize(2);
+  l.ls.single_models.reserve(2);
 
-  l.ls.single_models[0].species = qid.isot.spec;
-  l.ls.single_models[0].data[LineShapeModelVariable::G0] =
+  l.ls.single_models[qid.isot.spec].data[LineShapeModelVariable::G0] =
       lbl::temperature::data{LineShapeModelType::T1, Vector{gamma_self, n}};
 
-  l.ls.single_models[1].species = SpeciesEnum::Bath;
-  l.ls.single_models[1].data[LineShapeModelVariable::G0] =
+  l.ls.single_models[SpeciesEnum::Bath].data[LineShapeModelVariable::G0] =
       lbl::temperature::data{LineShapeModelType::T1, Vector{gamma_air, n}};
 
   if (delta != 0) {
-    l.ls.single_models[0].data[LineShapeModelVariable::D0] =
+    l.ls.single_models[qid.isot.spec].data[LineShapeModelVariable::D0] =
         lbl::temperature::data{LineShapeModelType::T0, Vector{delta}};
-    l.ls.single_models[1].data[LineShapeModelVariable::D0] =
+    l.ls.single_models[SpeciesEnum::Bath].data[LineShapeModelVariable::D0] =
         lbl::temperature::data{LineShapeModelType::T0, Vector{delta}};
   }
 

--- a/src/core/lbl/lbl_hitran.cpp
+++ b/src/core/lbl/lbl_hitran.cpp
@@ -141,6 +141,9 @@ hitran_data read_hitran_par(std::istream&& file,
 line hitran_record::from(HitranLineStrengthOption ls,
                          QuantumState&& local,
                          bool do_zeeman) const {
+  using enum LineShapeModelVariable;
+  using enum LineShapeModelType;
+
   line l;
   l.a  = A;
   l.f0 = f0;
@@ -181,17 +184,14 @@ line hitran_record::from(HitranLineStrengthOption ls,
   l.ls.one_by_one = false;
   l.ls.single_models.reserve(2);
 
-  l.ls.single_models[qid.isot.spec].data[LineShapeModelVariable::G0] =
-      lbl::temperature::data{LineShapeModelType::T1, Vector{gamma_self, n}};
-
-  l.ls.single_models[SpeciesEnum::Bath].data[LineShapeModelVariable::G0] =
-      lbl::temperature::data{LineShapeModelType::T1, Vector{gamma_air, n}};
+  auto& self    = l.ls.single_models[qid.isot.spec];
+  auto& air     = l.ls.single_models[SpeciesEnum::Bath];
+  self.data[G0] = {T1, Vector{gamma_self, n}};
+  air.data[G0]  = {T1, Vector{gamma_air, n}};
 
   if (delta != 0) {
-    l.ls.single_models[qid.isot.spec].data[LineShapeModelVariable::D0] =
-        lbl::temperature::data{LineShapeModelType::T0, Vector{delta}};
-    l.ls.single_models[SpeciesEnum::Bath].data[LineShapeModelVariable::D0] =
-        lbl::temperature::data{LineShapeModelType::T0, Vector{delta}};
+    self.data[D0] = {T0, Vector{delta}};
+    air.data[D0]  = {T0, Vector{delta}};
   }
 
   l.qn = std::move(local);

--- a/src/core/lbl/lbl_lineshape_model.cpp
+++ b/src/core/lbl/lbl_lineshape_model.cpp
@@ -5,6 +5,7 @@
 
 #include <ranges>
 #include <unordered_map>
+#include <utility>
 
 #include "enumsSpeciesEnum.h"
 #include "lbl_temperature_model.h"
@@ -87,7 +88,7 @@ VARIABLE(X3);
   Numeric model::mod(const AtmPoint& atm) const {                         \
     Numeric vmr = 0.0;                                                    \
     Numeric res = 0.0;                                                    \
-    Numeric bth = -1.0;                                                   \
+    Numeric bth = NAN;                                                    \
                                                                           \
     for (auto& [s, m] : single_models) {                                  \
       const Numeric this_res = m.mod(T0, atm.temperature, atm.pressure);  \
@@ -100,7 +101,7 @@ VARIABLE(X3);
       }                                                                   \
     }                                                                     \
                                                                           \
-    if (bth >= 0) return res + (1.0 - vmr) * bth;                         \
+    if (not nonstd::isnan(bth)) return res + (1.0 - vmr) * bth;           \
                                                                           \
     return res / vmr;                                                     \
   }                                                                       \
@@ -144,7 +145,7 @@ VARIABLE(DV);
   Numeric model::d##mod##_d##deriv(const AtmPoint& atm) const {   \
     Numeric vmr = 0.0;                                            \
     Numeric res = 0.0;                                            \
-    Numeric bth = -1.0;                                           \
+    Numeric bth = NAN;                                            \
                                                                   \
     for (auto& [s, m] : single_models) {                          \
       const Numeric this_res =                                    \
@@ -158,7 +159,7 @@ VARIABLE(DV);
       }                                                           \
     }                                                             \
                                                                   \
-    if (bth >= 0.0) return res + (1.0 - vmr) * bth;               \
+    if (not nonstd::isnan(bth)) return res + (1.0 - vmr) * bth;   \
                                                                   \
     return res / vmr;                                             \
   }
@@ -245,7 +246,7 @@ VARIABLE(X3);
       case LineShapeModelCoefficient::X2: return d##name##_dX2(atm, spec); \
       case LineShapeModelCoefficient::X3: return d##name##_dX3(atm, spec); \
     }                                                                      \
-    return 0.0;                                                            \
+    std::unreachable();                                                    \
   }                                                                        \
   Numeric species_model::d##name##_dX(                                     \
       Numeric T0, Numeric T, Numeric P, LineShapeModelCoefficient coeff)   \
@@ -256,7 +257,7 @@ VARIABLE(X3);
       case LineShapeModelCoefficient::X2: return d##name##_dX2(T0, T, P);  \
       case LineShapeModelCoefficient::X3: return d##name##_dX3(T0, T, P);  \
     }                                                                      \
-    return 0.0;                                                            \
+    std::unreachable();                                                    \
   }
 
 VARIABLE(G0);

--- a/src/core/lbl/lbl_lineshape_model.cpp
+++ b/src/core/lbl/lbl_lineshape_model.cpp
@@ -191,8 +191,7 @@ VARIABLE(T0);
                                                                               \
     const Numeric x = m.d##mod##_d##deriv(T0, atm.temperature, atm.pressure); \
                                                                               \
-    const auto bth = single_models.find(SpeciesEnum::Bath);                   \
-    if (spec == SpeciesEnum::Bath and bth != single_models.end()) {           \
+    if (spec == SpeciesEnum::Bath) {                                          \
       const Numeric vmr = std::transform_reduce(                              \
           single_models.begin(),                                              \
           single_models.end(),                                                \
@@ -204,6 +203,7 @@ VARIABLE(T0);
       return (1 - vmr) * x;                                                   \
     }                                                                         \
                                                                               \
+    const auto bth = single_models.find(SpeciesEnum::Bath);                   \
     if (bth != single_models.end()) return atm[spec] * x;                     \
                                                                               \
     const Numeric vmr =                                                       \

--- a/src/core/lbl/lbl_lineshape_model.cpp
+++ b/src/core/lbl/lbl_lineshape_model.cpp
@@ -4,7 +4,9 @@
 #include <species.h>
 
 #include <ranges>
+#include <unordered_map>
 
+#include "enumsSpeciesEnum.h"
 #include "lbl_temperature_model.h"
 
 std::istream& operator>>(std::istream& is,
@@ -28,17 +30,13 @@ namespace lbl::line_shape {
 #define VARIABLE(name, PVAR, DPVAR)                              \
   Numeric species_model::name(                                   \
       Numeric T0, Numeric T, Numeric P [[maybe_unused]]) const { \
-    auto ptr = std::ranges::find_if(data, [](auto& x) {          \
-      return x.first == LineShapeModelVariable::name;            \
-    });                                                          \
+    auto ptr = data.find(LineShapeModelVariable::name);          \
     return ptr != data.end() ? PVAR * ptr->second(T0, T) : 0.0;  \
   }                                                              \
                                                                  \
   Numeric species_model::d##name##_dP(                           \
       Numeric T0, Numeric T, Numeric P [[maybe_unused]]) const { \
-    auto ptr = std::ranges::find_if(data, [](auto& x) {          \
-      return x.first == LineShapeModelVariable::name;            \
-    });                                                          \
+    auto ptr = data.find(LineShapeModelVariable::name);          \
     return ptr != data.end() ? DPVAR * ptr->second(T0, T) : 0.0; \
   }
 
@@ -57,9 +55,7 @@ VARIABLE(DV, P* P, 2 * P);
 #define DERIVATIVE(name, deriv, PVAR)                                    \
   Numeric species_model::d##name##_d##deriv(                             \
       Numeric T0, Numeric T, Numeric P [[maybe_unused]]) const {         \
-    auto ptr = std::ranges::find_if(data, [](auto& x) {                  \
-      return x.first == LineShapeModelVariable::name;                    \
-    });                                                                  \
+    auto ptr = data.find(LineShapeModelVariable::name);                  \
     return ptr != data.end() ? PVAR * ptr->second.d##deriv(T0, T) : 0.0; \
   }
 
@@ -87,54 +83,49 @@ VARIABLE(X3);
 
 /////////////////////////////////////////////////////////////////////////////
 
-#define VARIABLE(mod)                                                         \
-  Numeric model::mod(const AtmPoint& atm) const {                             \
-    Numeric vmr = 0.0;                                                        \
-    Numeric out = 0.0;                                                        \
-                                                                              \
-    const auto compute = [&](const species_model& m) {                        \
-      const Numeric this_vmr  = atm[m.species];                               \
-      vmr                    += this_vmr;                                     \
-      out += this_vmr * m.mod(T0, atm.temperature, atm.pressure);             \
-    };                                                                        \
-                                                                              \
-    for (auto& m :                                                            \
-         std::ranges::take_view(single_models, single_models.size() - 1)) {   \
-      compute(m);                                                             \
-    }                                                                         \
-                                                                              \
-    if (const auto& m = single_models.back();                                 \
-        m.species == SpeciesEnum::Bath) {                                     \
-      out += (1.0 - vmr) * m.mod(T0, atm.temperature, atm.pressure);          \
-    } else {                                                                  \
-      compute(m);                                                             \
-      out /= vmr;                                                             \
-    }                                                                         \
-                                                                              \
-    return out;                                                               \
-  }                                                                           \
-                                                                              \
-  [[nodiscard]] Numeric model::d##mod##_dVMR(const AtmPoint& atm,             \
-                                             SpeciesEnum species) const {     \
-    auto ptr = std::ranges::find_if(                                          \
-        single_models, [&](auto& m) { return m.species == species; });        \
-                                                                              \
-    if (ptr == single_models.end()) {                                         \
-      return 0.0;                                                             \
-    }                                                                         \
-                                                                              \
-    const Numeric x = ptr->mod(T0, atm.temperature, atm.pressure);            \
-                                                                              \
-    if (species == SpeciesEnum::Bath) return -x;                              \
-    if (single_models.back().species == SpeciesEnum::Bath)                    \
-      return x - single_models.back().mod(T0, atm.temperature, atm.pressure); \
-    const Numeric t =                                                         \
-        std::transform_reduce(single_models.begin(),                          \
-                              single_models.end(),                            \
-                              0.0,                                            \
-                              std::plus<>{},                                  \
-                              [&atm](auto& m) { return atm[m.species]; });    \
-    return (t - x) / t * t;                                                   \
+#define VARIABLE(mod)                                                     \
+  Numeric model::mod(const AtmPoint& atm) const {                         \
+    Numeric vmr = 0.0;                                                    \
+    Numeric res = 0.0;                                                    \
+    Numeric bth = -1.0;                                                   \
+                                                                          \
+    for (auto& [s, m] : single_models) {                                  \
+      const Numeric this_res = m.mod(T0, atm.temperature, atm.pressure);  \
+      if (s != SpeciesEnum::Bath) {                                       \
+        const Numeric this_vmr  = atm[s];                                 \
+        vmr                    += this_vmr;                               \
+        res                    += this_vmr * this_res;                    \
+      } else {                                                            \
+        bth = this_res;                                                   \
+      }                                                                   \
+    }                                                                     \
+                                                                          \
+    if (bth >= 0) return res + (1.0 - vmr) * bth;                         \
+                                                                          \
+    return res / vmr;                                                     \
+  }                                                                       \
+                                                                          \
+  [[nodiscard]] Numeric model::d##mod##_dVMR(const AtmPoint& atm,         \
+                                             SpeciesEnum species) const { \
+    auto ptr = single_models.find(species);                               \
+                                                                          \
+    if (ptr == single_models.end()) return 0.0;                           \
+                                                                          \
+    const Numeric x = ptr->second.mod(T0, atm.temperature, atm.pressure); \
+                                                                          \
+    if (species == SpeciesEnum::Bath) return -x;                          \
+                                                                          \
+    const auto bth = single_models.find(SpeciesEnum::Bath);               \
+    if (bth != single_models.end())                                       \
+      return x - bth->second.mod(T0, atm.temperature, atm.pressure);      \
+                                                                          \
+    const Numeric t =                                                     \
+        std::transform_reduce(single_models.begin(),                      \
+                              single_models.end(),                        \
+                              0.0,                                        \
+                              std::plus<>{},                              \
+                              [&atm](auto& m) { return atm[m.first]; });  \
+    return (t - x) / t * t;                                               \
   }
 
 VARIABLE(G0);
@@ -149,33 +140,27 @@ VARIABLE(DV);
 
 #undef VARIABLE
 
-#define DERIVATIVE(mod, deriv)                                               \
-  Numeric model::d##mod##_d##deriv(const AtmPoint& atm) const {              \
-    Numeric vmr = 0.0;                                                       \
-    Numeric out = 0.0;                                                       \
-                                                                             \
-    const auto compute = [&](const species_model& m) {                       \
-      const Numeric this_vmr  = atm[m.species];                              \
-      vmr                    += this_vmr;                                    \
-      out +=                                                                 \
-          this_vmr * m.d##mod##_d##deriv(T0, atm.temperature, atm.pressure); \
-    };                                                                       \
-                                                                             \
-    for (auto& m :                                                           \
-         std::ranges::take_view(single_models, single_models.size() - 1)) {  \
-      compute(m);                                                            \
-    }                                                                        \
-                                                                             \
-    if (const auto& m = single_models.back();                                \
-        m.species == SpeciesEnum::Bath) {                                    \
-      out += (1.0 - vmr) *                                                   \
-             m.d##mod##_d##deriv(T0, atm.temperature, atm.pressure);         \
-    } else {                                                                 \
-      compute(m);                                                            \
-      out /= vmr;                                                            \
-    }                                                                        \
-                                                                             \
-    return out;                                                              \
+#define DERIVATIVE(mod, deriv)                                    \
+  Numeric model::d##mod##_d##deriv(const AtmPoint& atm) const {   \
+    Numeric vmr = 0.0;                                            \
+    Numeric res = 0.0;                                            \
+    Numeric bth = -1.0;                                           \
+                                                                  \
+    for (auto& [s, m] : single_models) {                          \
+      const Numeric this_res =                                    \
+          m.d##mod##_d##deriv(T0, atm.temperature, atm.pressure); \
+      if (s != SpeciesEnum::Bath) {                               \
+        const Numeric this_vmr  = atm[s];                         \
+        vmr                    += this_vmr;                       \
+        res                    += this_vmr * this_res;            \
+      } else {                                                    \
+        bth = this_res;                                           \
+      }                                                           \
+    }                                                             \
+                                                                  \
+    if (bth >= 0.0) return res + (1.0 - vmr) * bth;               \
+                                                                  \
+    return res / vmr;                                             \
   }
 
 #define VARIABLE(deriv)   \
@@ -197,36 +182,37 @@ VARIABLE(T0);
 
 #undef DERIVATIVE
 
-#define DERIVATIVE(mod, deriv)                                                 \
-  Numeric model::d##mod##_d##deriv(const AtmPoint& atm, const Size spec)       \
-      const {                                                                  \
-    if (spec >= single_models.size()) return 0.0;                              \
-    const auto& m = single_models[spec];                                       \
-                                                                               \
-    const Numeric x = m.d##mod##_d##deriv(T0, atm.temperature, atm.pressure);  \
-                                                                               \
-    if (spec == single_models.size() - 1 and                                   \
-        single_models.back().species == SpeciesEnum::Bath) {                   \
-      const Numeric vmr =                                                      \
-          std::transform_reduce(single_models.begin(),                         \
-                                single_models.end() - 1,                       \
-                                0.0,                                           \
-                                std::plus<>{},                                 \
-                                [&atm](auto& ml) { return atm[ml.species]; }); \
-      return (1 - vmr) * x;                                                    \
-    }                                                                          \
-                                                                               \
-    if (single_models.back().species == SpeciesEnum::Bath) {                   \
-      return atm[m.species] * x;                                               \
-    }                                                                          \
-                                                                               \
-    const Numeric vmr =                                                        \
-        std::transform_reduce(single_models.begin(),                           \
-                              single_models.end(),                             \
-                              0.0,                                             \
-                              std::plus<>{},                                   \
-                              [&atm](auto& ml) { return atm[ml.species]; });   \
-    return x * atm[m.species] / vmr;                                           \
+#define DERIVATIVE(mod, deriv)                                                \
+  Numeric model::d##mod##_d##deriv(const AtmPoint& atm,                       \
+                                   const SpeciesEnum spec) const {            \
+    const auto ptr = single_models.find(spec);                                \
+    if (ptr == single_models.end()) return 0.0;                               \
+    const auto& m = ptr->second;                                              \
+                                                                              \
+    const Numeric x = m.d##mod##_d##deriv(T0, atm.temperature, atm.pressure); \
+                                                                              \
+    const auto bth = single_models.find(SpeciesEnum::Bath);                   \
+    if (spec == SpeciesEnum::Bath and bth != single_models.end()) {           \
+      const Numeric vmr = std::transform_reduce(                              \
+          single_models.begin(),                                              \
+          single_models.end(),                                                \
+          0.0,                                                                \
+          std::plus<>{},                                                      \
+          [&atm](auto& ml) {                                                  \
+            return ml.first == SpeciesEnum::Bath ? 0.0 : atm[ml.first];       \
+          });                                                                 \
+      return (1 - vmr) * x;                                                   \
+    }                                                                         \
+                                                                              \
+    if (bth != single_models.end()) return atm[spec] * x;                     \
+                                                                              \
+    const Numeric vmr =                                                       \
+        std::transform_reduce(single_models.begin(),                          \
+                              single_models.end(),                            \
+                              0.0,                                            \
+                              std::plus<>{},                                  \
+                              [&atm](auto& ml) { return atm[ml.first]; });    \
+    return x * atm[spec] / vmr;                                               \
   }
 
 #define VARIABLE(deriv)   \
@@ -249,28 +235,28 @@ VARIABLE(X3);
 
 #undef DERIVATIVE
 
-#define VARIABLE(name)                                                       \
-  Numeric model::d##name##_dX(                                               \
-      const AtmPoint& atm, const Size spec, LineShapeModelCoefficient coeff) \
-      const {                                                                \
-    switch (coeff) {                                                         \
-      case LineShapeModelCoefficient::X0: return d##name##_dX0(atm, spec);   \
-      case LineShapeModelCoefficient::X1: return d##name##_dX1(atm, spec);   \
-      case LineShapeModelCoefficient::X2: return d##name##_dX2(atm, spec);   \
-      case LineShapeModelCoefficient::X3: return d##name##_dX3(atm, spec);   \
-    }                                                                        \
-    return 0.0;                                                              \
-  }                                                                          \
-  Numeric species_model::d##name##_dX(                                       \
-      Numeric T0, Numeric T, Numeric P, LineShapeModelCoefficient coeff)     \
-      const {                                                                \
-    switch (coeff) {                                                         \
-      case LineShapeModelCoefficient::X0: return d##name##_dX0(T0, T, P);    \
-      case LineShapeModelCoefficient::X1: return d##name##_dX1(T0, T, P);    \
-      case LineShapeModelCoefficient::X2: return d##name##_dX2(T0, T, P);    \
-      case LineShapeModelCoefficient::X3: return d##name##_dX3(T0, T, P);    \
-    }                                                                        \
-    return 0.0;                                                              \
+#define VARIABLE(name)                                                     \
+  Numeric model::d##name##_dX(const AtmPoint& atm,                         \
+                              const SpeciesEnum spec,                      \
+                              LineShapeModelCoefficient coeff) const {     \
+    switch (coeff) {                                                       \
+      case LineShapeModelCoefficient::X0: return d##name##_dX0(atm, spec); \
+      case LineShapeModelCoefficient::X1: return d##name##_dX1(atm, spec); \
+      case LineShapeModelCoefficient::X2: return d##name##_dX2(atm, spec); \
+      case LineShapeModelCoefficient::X3: return d##name##_dX3(atm, spec); \
+    }                                                                      \
+    return 0.0;                                                            \
+  }                                                                        \
+  Numeric species_model::d##name##_dX(                                     \
+      Numeric T0, Numeric T, Numeric P, LineShapeModelCoefficient coeff)   \
+      const {                                                              \
+    switch (coeff) {                                                       \
+      case LineShapeModelCoefficient::X0: return d##name##_dX0(T0, T, P);  \
+      case LineShapeModelCoefficient::X1: return d##name##_dX1(T0, T, P);  \
+      case LineShapeModelCoefficient::X2: return d##name##_dX2(T0, T, P);  \
+      case LineShapeModelCoefficient::X3: return d##name##_dX3(T0, T, P);  \
+    }                                                                      \
+    return 0.0;                                                            \
   }
 
 VARIABLE(G0);
@@ -286,17 +272,20 @@ VARIABLE(DV);
 #undef VARIABLE
 
 std::istream& operator>>(std::istream& is, species_model& x) {
-  String name;
-  is >> name >> x.data;
-  x.species = to<SpeciesEnum>(name);
-  return is;
+  return is >> x.data;
 }
 
-std::istream& operator>>(std::istream& is, std::vector<species_model>& x) {
+std::istream& operator>>(std::istream& is,
+                         std::unordered_map<SpeciesEnum, species_model>& x) {
   Size n;
   is >> n;
-  x.resize(n);
-  for (auto& y : x) is >> y;
+  x.reserve(n);
+  for (Size i = 0; i < n; i++) {
+    SpeciesEnum spec;
+    is >> spec;
+    is >> x[spec];
+  }
+
   return is;
 }
 
@@ -313,7 +302,7 @@ std::istream& operator>>(std::istream& is, model& x) try {
 
 void model::clear_zeroes() {
   auto is_zero = [](auto& x) { return x.second.is_zero(); };
-  for (auto& m : single_models) {
+  for (auto& [s, m] : single_models) {
     auto ptr = std::ranges::find_if(m.data, is_zero);
     while (ptr != m.data.end()) {
       m.data.erase(ptr);

--- a/src/core/lbl/lbl_lineshape_voigt_lte.cpp
+++ b/src/core/lbl/lbl_lineshape_voigt_lte.cpp
@@ -11,6 +11,7 @@
 #include <limits>
 #include <numeric>
 
+#include "enumsSpeciesEnum.h"
 #include "lbl_data.h"
 #include "lbl_zeeman.h"
 
@@ -143,21 +144,24 @@ Complex line_strength_calc(const Numeric inv_gd,
                            const SpeciesIsotope& spec,
                            const line& line,
                            const AtmPoint& atm,
-                           const Size ispec) {
-  const auto& ls   = line.ls.single_models[ispec];
+                           const SpeciesEnum ispec) {
+  const auto& ls   = line.ls.single_models.at(ispec);
   const Numeric T0 = line.ls.T0;
   const Numeric T  = atm.temperature;
   const Numeric P  = atm.pressure;
   const Numeric x  = atm[spec.spec];
   const Numeric r  = atm[spec];
-  const Numeric v  = ls.species == SpeciesEnum::Bath
-                         ? 1 - std::transform_reduce(
-                                  line.ls.single_models.begin(),
-                                  line.ls.single_models.end() - 1,
-                                  0.0,
-                                  std::plus<>{},
-                                  [&atm](auto& s) { return atm[s.species]; })
-                         : atm[ls.species];
+  const Numeric v =
+      ispec == SpeciesEnum::Bath
+          ? 1 - std::transform_reduce(
+                    line.ls.single_models.begin(),
+                    line.ls.single_models.end(),
+                    0.0,
+                    std::plus<>{},
+                    [&atm](auto& s) {
+                      return s.first == SpeciesEnum::Bath ? 0.0 : atm[s.first];
+                    })
+          : atm[ispec];
 
   const auto s = line.s(T, PartitionFunctions::Q(T, spec));
 
@@ -173,19 +177,21 @@ Complex dline_strength_calc_dG(const Numeric dG,
                                const SpeciesIsotope& spec,
                                const line& line,
                                const AtmPoint& atm,
-                               const Size ispec) {
-  const auto& ls  = line.ls.single_models[ispec];
+                               const SpeciesEnum ispec) {
   const Numeric T = atm.temperature;
   const Numeric x = atm[spec.spec];
   const Numeric r = atm[spec];
-  const Numeric v = ls.species == SpeciesEnum::Bath
-                        ? 1 - std::transform_reduce(
-                                  line.ls.single_models.begin(),
-                                  line.ls.single_models.end() - 1,
-                                  0.0,
-                                  std::plus<>{},
-                                  [&atm](auto& s) { return atm[s.species]; })
-                        : atm[ls.species];
+  const Numeric v =
+      ispec == SpeciesEnum::Bath
+          ? 1 - std::transform_reduce(
+                    line.ls.single_models.begin(),
+                    line.ls.single_models.end(),
+                    0.0,
+                    std::plus<>{},
+                    [&atm](auto& s) {
+                      return s.first == SpeciesEnum::Bath ? 0.0 : atm[s.first];
+                    })
+          : atm[ispec];
 
   const auto s = line.s(T, PartitionFunctions::Q(T, spec));
 
@@ -199,19 +205,21 @@ Complex dline_strength_calc_dY(const Numeric dY,
                                const SpeciesIsotope& spec,
                                const line& line,
                                const AtmPoint& atm,
-                               const Size ispec) {
-  const auto& ls  = line.ls.single_models[ispec];
+                               const SpeciesEnum ispec) {
   const Numeric T = atm.temperature;
   const Numeric x = atm[spec.spec];
   const Numeric r = atm[spec];
-  const Numeric v = ls.species == SpeciesEnum::Bath
-                        ? 1 - std::transform_reduce(
-                                  line.ls.single_models.begin(),
-                                  line.ls.single_models.end() - 1,
-                                  0.0,
-                                  std::plus<>{},
-                                  [&atm](auto& s) { return atm[s.species]; })
-                        : atm[ls.species];
+  const Numeric v =
+      ispec == SpeciesEnum::Bath
+          ? 1 - std::transform_reduce(
+                    line.ls.single_models.begin(),
+                    line.ls.single_models.end(),
+                    0.0,
+                    std::plus<>{},
+                    [&atm](auto& s) {
+                      return s.first == SpeciesEnum::Bath ? 0.0 : atm[s.first];
+                    })
+          : atm[ispec];
 
   const auto s = line.s(T, PartitionFunctions::Q(T, spec));
 
@@ -225,21 +233,24 @@ Complex dline_strength_calc_df0(const Numeric f0,
                                 const SpeciesIsotope& spec,
                                 const line& line,
                                 const AtmPoint& atm,
-                                const Size ispec) {
-  const auto& ls   = line.ls.single_models[ispec];
+                                const SpeciesEnum ispec) {
+  const auto& ls   = line.ls.single_models.at(ispec);
   const Numeric T0 = line.ls.T0;
   const Numeric T  = atm.temperature;
   const Numeric P  = atm.pressure;
   const Numeric x  = atm[spec.spec];
   const Numeric r  = atm[spec];
-  const Numeric v  = ls.species == SpeciesEnum::Bath
-                         ? 1 - std::transform_reduce(
-                                  line.ls.single_models.begin(),
-                                  line.ls.single_models.end() - 1,
-                                  0.0,
-                                  std::plus<>{},
-                                  [&atm](auto& s) { return atm[s.species]; })
-                         : atm[ls.species];
+  const Numeric v =
+      ispec == SpeciesEnum::Bath
+          ? 1 - std::transform_reduce(
+                    line.ls.single_models.begin(),
+                    line.ls.single_models.end(),
+                    0.0,
+                    std::plus<>{},
+                    [&atm](auto& s) {
+                      return s.first == SpeciesEnum::Bath ? 0.0 : atm[s.first];
+                    })
+          : atm[ispec];
   const auto s =
       line.s(atm.temperature, PartitionFunctions::Q(atm.temperature, spec));
   const auto ds = line.ds_df0_s_ratio() * s;
@@ -256,21 +267,24 @@ Complex dline_strength_calc_dT(const Numeric f0,
                                const SpeciesIsotope& spec,
                                const line& line,
                                const AtmPoint& atm,
-                               const Size ispec) {
-  const auto& ls   = line.ls.single_models[ispec];
+                               const SpeciesEnum ispec) {
+  const auto& ls   = line.ls.single_models.at(ispec);
   const Numeric T0 = line.ls.T0;
   const Numeric T  = atm.temperature;
   const Numeric P  = atm.pressure;
   const Numeric x  = atm[spec.spec];
   const Numeric r  = atm[spec];
-  const Numeric v  = ls.species == SpeciesEnum::Bath
-                         ? 1 - std::transform_reduce(
-                                  line.ls.single_models.begin(),
-                                  line.ls.single_models.end() - 1,
-                                  0.0,
-                                  std::plus<>{},
-                                  [&atm](auto& s) { return atm[s.species]; })
-                         : atm[ls.species];
+  const Numeric v =
+      ispec == SpeciesEnum::Bath
+          ? 1 - std::transform_reduce(
+                    line.ls.single_models.begin(),
+                    line.ls.single_models.end(),
+                    0.0,
+                    std::plus<>{},
+                    [&atm](auto& s) {
+                      return s.first == SpeciesEnum::Bath ? 0.0 : atm[s.first];
+                    })
+          : atm[ispec];
 
   const auto s  = line.s(T, PartitionFunctions::Q(T, spec));
   const auto ds = line.ds_dT(
@@ -307,30 +321,13 @@ Numeric dline_center_calc_dVMR(const line& line,
   return line.ls.dD0_dVMR(atm, spec) + line.ls.dDV_dVMR(atm, spec);
 }
 
-Numeric line_center_calc(const line& line, const AtmPoint& atm, Size ispec) {
-  const auto& ls = line.ls.single_models[ispec];
+Numeric line_center_calc(const line& line,
+                         const AtmPoint& atm,
+                         SpeciesEnum ispec) {
+  const auto& ls = line.ls.single_models.at(ispec);
   return line.f0 + ls.D0(line.ls.T0, atm.temperature, atm.pressure) +
          ls.DV(line.ls.T0, atm.temperature, atm.pressure);
 }
-
-// Numeric dline_center_calc_dT(const line& line,
-//                              const AtmPoint& atm,
-//                              Size ispec) {
-//   const auto& ls = line.ls.single_models[ispec];
-//   return ls.dD0_dT(line.ls.T0, atm.temperature, atm.pressure) +
-//          ls.dDV_dT(line.ls.T0, atm.temperature, atm.pressure);
-// }
-
-// Numeric dline_center_calc_dVMR(const line& line,
-//                                const SpeciesEnum spec,
-//                                const AtmPoint& atm,
-//                                Size ispec) {
-//   const auto& ls = line.ls.single_models[ispec];
-//   return ls.species == spec
-//              ? ls.D0(line.ls.T0, atm.temperature, atm.pressure) +
-//                    ls.DV(line.ls.T0, atm.temperature, atm.pressure)
-//              : 0;
-// }
 
 Numeric scaled_gd(const Numeric T, const Numeric mass, const Numeric f0) {
   constexpr auto c = Constant::doppler_broadening_const_squared;
@@ -345,7 +342,7 @@ struct single_shape_builder {
   Numeric f0;
   Numeric scaled_gd_part;
   Numeric G0;
-  Size ispec{std::numeric_limits<Size>::max()};
+  SpeciesEnum ispec{SpeciesEnum::unused};
 
   single_shape_builder(const SpeciesIsotope& s,
                        const line& l,
@@ -361,14 +358,15 @@ struct single_shape_builder {
   single_shape_builder(const SpeciesIsotope& s,
                        const line& l,
                        const AtmPoint& a,
-                       const Size is)
+                       const SpeciesEnum is)
       : spec(s),
         ln(l),
         atm(a),
         f0(line_center_calc(ln, atm, is)),
         scaled_gd_part(std::sqrt(Constant::doppler_broadening_const_squared *
                                  atm.temperature / s.mass)),
-        G0(ln.ls.single_models[is].G0(ln.ls.T0, atm.temperature, atm.pressure)),
+        G0(ln.ls.single_models.at(is).G0(
+            ln.ls.T0, atm.temperature, atm.pressure)),
         ispec(is) {}
 
   [[nodiscard]] single_shape as_zeeman(const Numeric H,
@@ -379,7 +377,7 @@ struct single_shape_builder {
     s.inv_gd = 1.0 / (scaled_gd_part * f0);
     s.z_imag = G0 * s.inv_gd;
     s.s      = ln.z.Strength(ln.qn, pol, iz) *
-          (ispec == std::numeric_limits<Size>::max()
+          (ispec == SpeciesEnum::unused
                ? line_strength_calc(s.inv_gd, spec, ln, atm)
                : line_strength_calc(s.inv_gd, spec, ln, atm, ispec));
     return s;
@@ -390,7 +388,7 @@ struct single_shape_builder {
     s.f0     = f0;
     s.inv_gd = 1.0 / (scaled_gd_part * f0);
     s.z_imag = G0 * s.inv_gd;
-    s.s      = (ispec == std::numeric_limits<Size>::max()
+    s.s      = (ispec == SpeciesEnum::unused
                     ? line_strength_calc(s.inv_gd, spec, ln, atm)
                     : line_strength_calc(s.inv_gd, spec, ln, atm, ispec));
     return s;
@@ -416,12 +414,12 @@ single_shape::single_shape(const SpeciesIsotope& spec,
                            const AtmPoint& atm,
                            const zeeman::pol pol,
                            const Index iz,
-                           const Size ispec)
+                           const SpeciesEnum ispec)
     : f0(line_center_calc(line, atm, ispec) +
          std::hypot(atm.mag[0], atm.mag[1], atm.mag[2]) *
              line.z.Splitting(line.qn, pol, iz)),
       inv_gd(1.0 / scaled_gd(atm.temperature, spec.mass, f0)),
-      z_imag(line.ls.single_models[ispec].G0(
+      z_imag(line.ls.single_models.at(ispec).G0(
                  line.ls.T0, atm.temperature, atm.pressure) *
              inv_gd),
       s(line.z.Strength(line.qn, pol, iz) *
@@ -545,7 +543,7 @@ void zeeman_push_back(std::vector<single_shape>& lines,
                       const line& line,
                       const AtmPoint& atm,
                       const zeeman::pol pol,
-                      const Size ispec,
+                      const SpeciesEnum ispec,
                       const Size iline) {
   if (pol == zeeman::pol::no) {
     lines.emplace_back(s);
@@ -573,16 +571,16 @@ void lines_push_back(std::vector<single_shape>& lines,
                      const zeeman::pol pol,
                      const Size iline) {
   if (line.ls.one_by_one) {
-    for (Size i = 0; i < line.ls.single_models.size(); ++i) {
+    for (auto& ispec : line.ls.single_models | stdv::keys) {
       if ((line.z.on and pol != zeeman::pol::no) or
           (not line.z.on and pol == zeeman::pol::no)) {
         zeeman_push_back(lines,
                          pos,
-                         single_shape_builder{spec, line, atm, i},
+                         single_shape_builder{spec, line, atm, ispec},
                          line,
                          atm,
                          pol,
-                         i,
+                         ispec,
                          iline);
       }
     }
@@ -595,7 +593,7 @@ void lines_push_back(std::vector<single_shape>& lines,
                        line,
                        atm,
                        pol,
-                       std::numeric_limits<Size>::max(),
+                       SpeciesEnum::unused,
                        iline);
     }
   }
@@ -1219,7 +1217,7 @@ void ComputeData::dt_core_calc(const SpeciesIsotope& spec,
     const Numeric& inv_gd = lshp.inv_gd;
     const Numeric& f0     = lshp.f0;
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       dz_fac[i] =
           (-2 * T * line.ls.dD0_dT(atm) - 2 * T * line.ls.dDV_dT(atm) - f0) /
           (2 * T * f0);
@@ -1230,7 +1228,7 @@ void ComputeData::dt_core_calc(const SpeciesIsotope& spec,
       dz[i] = inv_gd *
               Complex{-dline_center_calc_dT(line, atm), line.ls.dG0_dT(atm)};
     } else {
-      const auto& ls = line.ls.single_models[pos[i].spec];
+      const auto& ls = line.ls.single_models.at(pos[i].spec);
 
       dz_fac[i] = (-2 * T * ls.dD0_dT(line.ls.T0, T, atm.pressure) -
                    2 * T * ls.dDV_dT(line.ls.T0, T, atm.pressure) - f0) /
@@ -1392,7 +1390,7 @@ void ComputeData::dVMR_core_calc(const SpeciesIsotope& spec,
     const Numeric& inv_gd = lshp.inv_gd;
     const Numeric& f0     = lshp.f0;
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       dz_fac[i] = -(line.ls.dD0_dVMR(atm, target_spec) +
                     line.ls.dDV_dVMR(atm, target_spec)) /
                   f0;
@@ -1404,19 +1402,23 @@ void ComputeData::dVMR_core_calc(const SpeciesIsotope& spec,
       dz[i] = inv_gd * Complex{-dline_center_calc_dVMR(line, target_spec, atm),
                                line.ls.dG0_dVMR(atm, target_spec)};
     } else {
-      const auto ls_spec = line.ls.single_models[pos[i].spec].species;
+      const auto ls_spec = pos[i].spec;
 
       dz_fac[i] = 0;
 
       if (target_spec == ls_spec) {
         ds[i] = lshp.s * (1 + (target_spec == spec.spec)) / x;
       } else if (ls_spec == SpeciesEnum::Bath) {
-        const Numeric v = 1.0 - std::transform_reduce(
-                                    line.ls.single_models.begin(),
-                                    line.ls.single_models.end() - 1,
-                                    0.0,
-                                    std::plus<>{},
-                                    [&atm](auto& s) { return atm[s.species]; });
+        const Numeric v =
+            1.0 - std::transform_reduce(line.ls.single_models.begin(),
+                                        line.ls.single_models.end(),
+                                        0.0,
+                                        std::plus<>{},
+                                        [&atm](auto& s) {
+                                          return s.first == SpeciesEnum::Bath
+                                                     ? 0.0
+                                                     : atm[s.first];
+                                        });
         ds[i] = lshp.s * (v - x) / (x * v);
       } else {
         ds[i] = 0;
@@ -1450,8 +1452,7 @@ void ComputeData::set_filter(const line_key& key) {
   if (not good_enum(key.var)) {
     for (Size i = 0; i < pos.size(); i++) {
       if (pos[i].line == key.line and
-          (pos[i].spec == key.spec or
-           pos[i].spec == std::numeric_limits<Size>::max()))
+          (pos[i].spec == key.spec or pos[i].spec == SpeciesEnum::unused))
         filter.push_back(i);
     }
   } else {
@@ -1478,7 +1479,7 @@ void ComputeData::df0_core_calc(const SpeciesIsotope& spec,
     const Numeric& inv_gd = lshp.inv_gd;
     const Numeric& f0     = lshp.f0;
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       dz_fac[i] = -1.0 / f0;
 
       ds[i] = line.z.Strength(line.qn, pol, pos[i].iz) *
@@ -1572,15 +1573,15 @@ void ComputeData::dG0_core_calc(const band_shape& shp,
   for (Size i : filter) {
     const auto& ls = bnd.lines[pos[i].line].ls;
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       dz[i] = Complex(
           0, shp.lines[i].inv_gd * ls.dG0_dX(atm, key.spec, key.ls_coeff));
     } else {
-      dz[i] =
-          Complex(0,
-                  shp.lines[i].inv_gd *
-                      ls.single_models[pos[i].spec].dG0_dX(
-                          ls.T0, atm.temperature, atm.pressure, key.ls_coeff));
+      dz[i] = Complex(
+          0,
+          shp.lines[i].inv_gd *
+              ls.single_models.at(pos[i].spec)
+                  .dG0_dX(ls.T0, atm.temperature, atm.pressure, key.ls_coeff));
     }
   }
 
@@ -1611,7 +1612,7 @@ void ComputeData::dD0_core_calc(const band_shape& shp,
     const Numeric& inv_gd = lshp.inv_gd;
     const Numeric& f0     = lshp.f0;
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       const Numeric d = ls.dD0_dX(atm, key.spec, key.ls_coeff);
 
       dz_fac[i] = -d / f0;
@@ -1620,8 +1621,9 @@ void ComputeData::dD0_core_calc(const band_shape& shp,
 
       dz[i] = -d * inv_gd;
     } else {
-      const Numeric d = ls.single_models[pos[i].spec].dD0_dX(
-          ls.T0, atm.temperature, atm.pressure, key.ls_coeff);
+      const Numeric d =
+          ls.single_models.at(pos[i].spec)
+              .dD0_dX(ls.T0, atm.temperature, atm.pressure, key.ls_coeff);
 
       dz_fac[i] = -d / f0;
 
@@ -1657,7 +1659,7 @@ void ComputeData::dY_core_calc(const SpeciesIsotope& spec,
     const auto& line = bnd.lines[pos[i].line];
     const auto& lshp = shp.lines[i];
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       ds[i] = line.z.Strength(line.qn, pol, pos[i].iz) *
               dline_strength_calc_dY(line.ls.dY_dX(atm, key.spec, key.ls_coeff),
                                      lshp.inv_gd,
@@ -1665,15 +1667,17 @@ void ComputeData::dY_core_calc(const SpeciesIsotope& spec,
                                      line,
                                      atm);
     } else {
-      ds[i] = line.z.Strength(line.qn, pol, pos[i].iz) *
-              dline_strength_calc_dY(
-                  line.ls.single_models[pos[i].spec].dY_dX(
+      ds[i] =
+          line.z.Strength(line.qn, pol, pos[i].iz) *
+          dline_strength_calc_dY(
+              line.ls.single_models.at(pos[i].spec)
+                  .dY_dX(
                       line.ls.T0, atm.temperature, atm.pressure, key.ls_coeff),
-                  lshp.inv_gd,
-                  spec,
-                  line,
-                  atm,
-                  pos[i].spec);
+              lshp.inv_gd,
+              spec,
+              line,
+              atm,
+              pos[i].spec);
     }
   }
 
@@ -1703,7 +1707,7 @@ void ComputeData::dG_core_calc(const SpeciesIsotope& spec,
     const auto& line = bnd.lines[pos[i].line];
     const auto& lshp = shp.lines[i];
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       ds[i] = line.z.Strength(line.qn, pol, pos[i].iz) *
               dline_strength_calc_dG(line.ls.dG_dX(atm, key.spec, key.ls_coeff),
                                      lshp.inv_gd,
@@ -1711,15 +1715,17 @@ void ComputeData::dG_core_calc(const SpeciesIsotope& spec,
                                      line,
                                      atm);
     } else {
-      ds[i] = line.z.Strength(line.qn, pol, pos[i].iz) *
-              dline_strength_calc_dG(
-                  line.ls.single_models[pos[i].spec].dG_dX(
+      ds[i] =
+          line.z.Strength(line.qn, pol, pos[i].iz) *
+          dline_strength_calc_dG(
+              line.ls.single_models.at(pos[i].spec)
+                  .dG_dX(
                       line.ls.T0, atm.temperature, atm.pressure, key.ls_coeff),
-                  lshp.inv_gd,
-                  spec,
-                  line,
-                  atm,
-                  pos[i].spec);
+              lshp.inv_gd,
+              spec,
+              line,
+              atm,
+              pos[i].spec);
     }
   }
 
@@ -1752,7 +1758,7 @@ void ComputeData::dDV_core_calc(const band_shape& shp,
     const Numeric& inv_gd = lshp.inv_gd;
     const Numeric& f0     = lshp.f0;
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       const Numeric d = ls.dDV_dX(atm, key.spec, key.ls_coeff);
 
       dz_fac[i] = -d / f0;
@@ -1761,8 +1767,9 @@ void ComputeData::dDV_core_calc(const band_shape& shp,
 
       dz[i] = -d * inv_gd;
     } else {
-      const Numeric d = ls.single_models[pos[i].spec].dDV_dX(
-          ls.T0, atm.temperature, atm.pressure, key.ls_coeff);
+      const Numeric d =
+          ls.single_models.at(pos[i].spec)
+              .dDV_dX(ls.T0, atm.temperature, atm.pressure, key.ls_coeff);
 
       dz_fac[i] = -d / f0;
 

--- a/src/core/lbl/lbl_lineshape_voigt_lte.cpp
+++ b/src/core/lbl/lbl_lineshape_voigt_lte.cpp
@@ -350,10 +350,10 @@ struct single_shape_builder {
       : spec(s),
         ln(l),
         atm(a),
-        f0(line_center_calc(ln, atm)),
+        f0(line_center_calc(l, atm)),
         scaled_gd_part(std::sqrt(Constant::doppler_broadening_const_squared *
                                  atm.temperature / s.mass)),
-        G0(ln.ls.G0(atm)) {}
+        G0(l.ls.G0(atm)) {}
 
   single_shape_builder(const SpeciesIsotope& s,
                        const line& l,
@@ -362,11 +362,11 @@ struct single_shape_builder {
       : spec(s),
         ln(l),
         atm(a),
-        f0(line_center_calc(ln, atm, is)),
+        f0(line_center_calc(l, atm, is)),
         scaled_gd_part(std::sqrt(Constant::doppler_broadening_const_squared *
                                  atm.temperature / s.mass)),
-        G0(ln.ls.single_models.at(is).G0(
-            ln.ls.T0, atm.temperature, atm.pressure)),
+        G0(l.ls.single_models.at(is).G0(
+            l.ls.T0, atm.temperature, atm.pressure)),
         ispec(is) {}
 
   [[nodiscard]] single_shape as_zeeman(const Numeric H,
@@ -1402,13 +1402,11 @@ void ComputeData::dVMR_core_calc(const SpeciesIsotope& spec,
       dz[i] = inv_gd * Complex{-dline_center_calc_dVMR(line, target_spec, atm),
                                line.ls.dG0_dVMR(atm, target_spec)};
     } else {
-      const auto ls_spec = pos[i].spec;
-
       dz_fac[i] = 0;
 
-      if (target_spec == ls_spec) {
+      if (target_spec == pos[i].spec) {
         ds[i] = lshp.s * (1 + (target_spec == spec.spec)) / x;
-      } else if (ls_spec == SpeciesEnum::Bath) {
+      } else if (pos[i].spec == SpeciesEnum::Bath) {
         const Numeric v =
             1.0 - std::transform_reduce(line.ls.single_models.begin(),
                                         line.ls.single_models.end(),

--- a/src/core/lbl/lbl_lineshape_voigt_lte.h
+++ b/src/core/lbl/lbl_lineshape_voigt_lte.h
@@ -43,7 +43,7 @@ struct single_shape {
                const AtmPoint&,
                const zeeman::pol,
                const Index,
-               const Size);
+               const SpeciesEnum);
 
   [[nodiscard]] constexpr Complex z(Numeric f) const {
     return Complex{inv_gd * (f - f0), z_imag};
@@ -254,8 +254,7 @@ struct band_shape {
                            const ConstComplexVectorView& dz_dH,
                            const Numeric f) const;
 
-  void dH(ComplexVectorView cut,
-          const ConstComplexVectorView& df0_dH) const;
+  void dH(ComplexVectorView cut, const ConstComplexVectorView& df0_dH) const;
 
   [[nodiscard]] Complex dT(const ConstComplexVectorView& cut,
                            const ConstComplexVectorView& ds_dT,
@@ -371,8 +370,8 @@ struct ComputeData {
 
   Size filtered_line{std::numeric_limits<
       Size>::max()};  //! filter is for this and filtered_spec
-  Size filtered_spec{std::numeric_limits<
-      Size>::max()};  //! filter is for this and filtered_spec
+  SpeciesEnum filtered_spec{
+      SpeciesEnum::unused};  //! filter is for this and filtered_spec
   std::vector<Size>
       filter;  //! Filter for line parameters; resized all the time but reserves size of line shapes
 

--- a/src/core/lbl/lbl_lineshape_voigt_lte_mirrored.cpp
+++ b/src/core/lbl/lbl_lineshape_voigt_lte_mirrored.cpp
@@ -11,6 +11,7 @@
 #include <limits>
 #include <numeric>
 
+#include "enumsSpeciesEnum.h"
 #include "lbl_data.h"
 #include "lbl_zeeman.h"
 
@@ -143,21 +144,25 @@ Complex line_strength_calc(const Numeric inv_gd,
                            const SpeciesIsotope& spec,
                            const line& line,
                            const AtmPoint& atm,
-                           const Size ispec) {
-  const auto& ls   = line.ls.single_models[ispec];
+                           const SpeciesEnum ispec) {
+  const auto& ls   = line.ls.single_models.at(ispec);
   const Numeric T0 = line.ls.T0;
   const Numeric T  = atm.temperature;
   const Numeric P  = atm.pressure;
   const Numeric x  = atm[spec.spec];
   const Numeric r  = atm[spec];
-  const Numeric v  = ls.species == SpeciesEnum::Bath
-                         ? 1 - std::transform_reduce(
-                                  line.ls.single_models.begin(),
-                                  line.ls.single_models.end() - 1,
-                                  0.0,
-                                  std::plus<>{},
-                                  [&atm](auto& s) { return atm[s.species]; })
-                         : atm[ls.species];
+  const Numeric v =
+      ispec == SpeciesEnum::Bath
+          ? 1.0 - std::transform_reduce(line.ls.single_models.begin(),
+                                        line.ls.single_models.end(),
+                                        0.0,
+                                        std::plus<>{},
+                                        [&atm](auto& s) {
+                                          return s.first == SpeciesEnum::Bath
+                                                     ? 0.0
+                                                     : atm[s.first];
+                                        })
+          : atm[ispec];
 
   const auto s = line.s(T, PartitionFunctions::Q(T, spec));
 
@@ -173,19 +178,21 @@ Complex dline_strength_calc_dG(const Numeric dG,
                                const SpeciesIsotope& spec,
                                const line& line,
                                const AtmPoint& atm,
-                               const Size ispec) {
-  const auto& ls  = line.ls.single_models[ispec];
+                               const SpeciesEnum ispec) {
   const Numeric T = atm.temperature;
   const Numeric x = atm[spec.spec];
   const Numeric r = atm[spec];
-  const Numeric v = ls.species == SpeciesEnum::Bath
-                        ? 1 - std::transform_reduce(
-                                  line.ls.single_models.begin(),
-                                  line.ls.single_models.end() - 1,
-                                  0.0,
-                                  std::plus<>{},
-                                  [&atm](auto& s) { return atm[s.species]; })
-                        : atm[ls.species];
+  const Numeric v =
+      ispec == SpeciesEnum::Bath
+          ? 1 - std::transform_reduce(
+                    line.ls.single_models.begin(),
+                    line.ls.single_models.end(),
+                    0.0,
+                    std::plus<>{},
+                    [&atm](auto& s) {
+                      return s.first == SpeciesEnum::Bath ? 0.0 : atm[s.first];
+                    })
+          : atm[ispec];
 
   const auto s = line.s(T, PartitionFunctions::Q(T, spec));
 
@@ -199,19 +206,21 @@ Complex dline_strength_calc_dY(const Numeric dY,
                                const SpeciesIsotope& spec,
                                const line& line,
                                const AtmPoint& atm,
-                               const Size ispec) {
-  const auto& ls  = line.ls.single_models[ispec];
+                               const SpeciesEnum ispec) {
   const Numeric T = atm.temperature;
   const Numeric x = atm[spec.spec];
   const Numeric r = atm[spec];
-  const Numeric v = ls.species == SpeciesEnum::Bath
-                        ? 1 - std::transform_reduce(
-                                  line.ls.single_models.begin(),
-                                  line.ls.single_models.end() - 1,
-                                  0.0,
-                                  std::plus<>{},
-                                  [&atm](auto& s) { return atm[s.species]; })
-                        : atm[ls.species];
+  const Numeric v =
+      ispec == SpeciesEnum::Bath
+          ? 1 - std::transform_reduce(
+                    line.ls.single_models.begin(),
+                    line.ls.single_models.end(),
+                    0.0,
+                    std::plus<>{},
+                    [&atm](auto& s) {
+                      return s.first == SpeciesEnum::Bath ? 0.0 : atm[s.first];
+                    })
+          : atm[ispec];
 
   const auto s = line.s(T, PartitionFunctions::Q(T, spec));
 
@@ -225,21 +234,24 @@ Complex dline_strength_calc_df0(const Numeric f0,
                                 const SpeciesIsotope& spec,
                                 const line& line,
                                 const AtmPoint& atm,
-                                const Size ispec) {
-  const auto& ls   = line.ls.single_models[ispec];
+                                const SpeciesEnum ispec) {
+  const auto& ls   = line.ls.single_models.at(ispec);
   const Numeric T0 = line.ls.T0;
   const Numeric T  = atm.temperature;
   const Numeric P  = atm.pressure;
   const Numeric x  = atm[spec.spec];
   const Numeric r  = atm[spec];
-  const Numeric v  = ls.species == SpeciesEnum::Bath
-                         ? 1 - std::transform_reduce(
-                                  line.ls.single_models.begin(),
-                                  line.ls.single_models.end() - 1,
-                                  0.0,
-                                  std::plus<>{},
-                                  [&atm](auto& s) { return atm[s.species]; })
-                         : atm[ls.species];
+  const Numeric v =
+      ispec == SpeciesEnum::Bath
+          ? 1 - std::transform_reduce(
+                    line.ls.single_models.begin(),
+                    line.ls.single_models.end(),
+                    0.0,
+                    std::plus<>{},
+                    [&atm](auto& s) {
+                      return s.first == SpeciesEnum::Bath ? 0.0 : atm[s.first];
+                    })
+          : atm[ispec];
   const auto s =
       line.s(atm.temperature, PartitionFunctions::Q(atm.temperature, spec));
   const auto ds = line.ds_df0_s_ratio() * s;
@@ -256,21 +268,24 @@ Complex dline_strength_calc_dT(const Numeric f0,
                                const SpeciesIsotope& spec,
                                const line& line,
                                const AtmPoint& atm,
-                               const Size ispec) {
-  const auto& ls   = line.ls.single_models[ispec];
+                               const SpeciesEnum ispec) {
+  const auto& ls   = line.ls.single_models.at(ispec);
   const Numeric T0 = line.ls.T0;
   const Numeric T  = atm.temperature;
   const Numeric P  = atm.pressure;
   const Numeric x  = atm[spec.spec];
   const Numeric r  = atm[spec];
-  const Numeric v  = ls.species == SpeciesEnum::Bath
-                         ? 1 - std::transform_reduce(
-                                  line.ls.single_models.begin(),
-                                  line.ls.single_models.end() - 1,
-                                  0.0,
-                                  std::plus<>{},
-                                  [&atm](auto& s) { return atm[s.species]; })
-                         : atm[ls.species];
+  const Numeric v =
+      ispec == SpeciesEnum::Bath
+          ? 1 - std::transform_reduce(
+                    line.ls.single_models.begin(),
+                    line.ls.single_models.end(),
+                    0.0,
+                    std::plus<>{},
+                    [&atm](auto& s) {
+                      return s.first == SpeciesEnum::Bath ? 0.0 : atm[s.first];
+                    })
+          : atm[ispec];
 
   const auto s  = line.s(T, PartitionFunctions::Q(T, spec));
   const auto ds = line.ds_dT(
@@ -307,30 +322,13 @@ Numeric dline_center_calc_dVMR(const line& line,
   return line.ls.dD0_dVMR(atm, spec) + line.ls.dDV_dVMR(atm, spec);
 }
 
-Numeric line_center_calc(const line& line, const AtmPoint& atm, Size ispec) {
-  const auto& ls = line.ls.single_models[ispec];
+Numeric line_center_calc(const line& line,
+                         const AtmPoint& atm,
+                         SpeciesEnum ispec) {
+  const auto& ls = line.ls.single_models.at(ispec);
   return line.f0 + ls.D0(line.ls.T0, atm.temperature, atm.pressure) +
          ls.DV(line.ls.T0, atm.temperature, atm.pressure);
 }
-
-// Numeric dline_center_calc_dT(const line& line,
-//                              const AtmPoint& atm,
-//                              Size ispec) {
-//   const auto& ls = line.ls.single_models[ispec];
-//   return ls.dD0_dT(line.ls.T0, atm.temperature, atm.pressure) +
-//          ls.dDV_dT(line.ls.T0, atm.temperature, atm.pressure);
-// }
-
-// Numeric dline_center_calc_dVMR(const line& line,
-//                                const SpeciesEnum spec,
-//                                const AtmPoint& atm,
-//                                Size ispec) {
-//   const auto& ls = line.ls.single_models[ispec];
-//   return ls.species == spec
-//              ? ls.D0(line.ls.T0, atm.temperature, atm.pressure) +
-//                    ls.DV(line.ls.T0, atm.temperature, atm.pressure)
-//              : 0;
-// }
 
 Numeric scaled_gd(const Numeric T, const Numeric mass, const Numeric f0) {
   constexpr auto c = Constant::doppler_broadening_const_squared;
@@ -345,7 +343,7 @@ struct single_shape_builder {
   Numeric f0;
   Numeric scaled_gd_part;
   Numeric G0;
-  Size ispec{std::numeric_limits<Size>::max()};
+  SpeciesEnum ispec{SpeciesEnum::unused};
 
   single_shape_builder(const SpeciesIsotope& s,
                        const line& l,
@@ -361,14 +359,15 @@ struct single_shape_builder {
   single_shape_builder(const SpeciesIsotope& s,
                        const line& l,
                        const AtmPoint& a,
-                       const Size is)
+                       const SpeciesEnum is)
       : spec(s),
         ln(l),
         atm(a),
         f0(line_center_calc(ln, atm, is)),
         scaled_gd_part(std::sqrt(Constant::doppler_broadening_const_squared *
                                  atm.temperature / s.mass)),
-        G0(ln.ls.single_models[is].G0(ln.ls.T0, atm.temperature, atm.pressure)),
+        G0(ln.ls.single_models.at(is).G0(
+            ln.ls.T0, atm.temperature, atm.pressure)),
         ispec(is) {}
 
   [[nodiscard]] single_shape as_zeeman(const Numeric H,
@@ -379,7 +378,7 @@ struct single_shape_builder {
     s.inv_gd = 1.0 / (scaled_gd_part * f0);
     s.z_imag = G0 * s.inv_gd;
     s.s      = ln.z.Strength(ln.qn, pol, iz) *
-          (ispec == std::numeric_limits<Size>::max()
+          (ispec == SpeciesEnum::unused  // unused value
                ? line_strength_calc(s.inv_gd, spec, ln, atm)
                : line_strength_calc(s.inv_gd, spec, ln, atm, ispec));
     return s;
@@ -390,7 +389,7 @@ struct single_shape_builder {
     s.f0     = f0;
     s.inv_gd = 1.0 / (scaled_gd_part * f0);
     s.z_imag = G0 * s.inv_gd;
-    s.s      = (ispec == std::numeric_limits<Size>::max()
+    s.s      = (ispec == SpeciesEnum::unused  // unused value
                     ? line_strength_calc(s.inv_gd, spec, ln, atm)
                     : line_strength_calc(s.inv_gd, spec, ln, atm, ispec));
     return s;
@@ -416,12 +415,12 @@ single_shape::single_shape(const SpeciesIsotope& spec,
                            const AtmPoint& atm,
                            const zeeman::pol pol,
                            const Index iz,
-                           const Size ispec)
+                           const SpeciesEnum ispec)
     : f0(line_center_calc(line, atm, ispec) +
          std::hypot(atm.mag[0], atm.mag[1], atm.mag[2]) *
              line.z.Splitting(line.qn, pol, iz)),
       inv_gd(1.0 / scaled_gd(atm.temperature, spec.mass, f0)),
-      z_imag(line.ls.single_models[ispec].G0(
+      z_imag(line.ls.single_models.at(ispec).G0(
                  line.ls.T0, atm.temperature, atm.pressure) *
              inv_gd),
       s(line.z.Strength(line.qn, pol, iz) *
@@ -568,7 +567,7 @@ void zeeman_push_back(std::vector<single_shape>& lines,
                       const line& line,
                       const AtmPoint& atm,
                       const zeeman::pol pol,
-                      const Size ispec,
+                      const SpeciesEnum ispec,
                       const Size iline) {
   if (pol == zeeman::pol::no) {
     lines.emplace_back(s);
@@ -596,16 +595,16 @@ void lines_push_back(std::vector<single_shape>& lines,
                      const zeeman::pol pol,
                      const Size iline) {
   if (line.ls.one_by_one) {
-    for (Size i = 0; i < line.ls.single_models.size(); ++i) {
+    for (auto& spec_key : line.ls.single_models | stdv::keys) {
       if ((line.z.on and pol != zeeman::pol::no) or
           (not line.z.on and pol == zeeman::pol::no)) {
         zeeman_push_back(lines,
                          pos,
-                         single_shape_builder{spec, line, atm, i},
+                         single_shape_builder{spec, line, atm, spec_key},
                          line,
                          atm,
                          pol,
-                         i,
+                         spec_key,
                          iline);
       }
     }
@@ -618,7 +617,7 @@ void lines_push_back(std::vector<single_shape>& lines,
                        line,
                        atm,
                        pol,
-                       std::numeric_limits<Size>::max(),
+                       SpeciesEnum::unused,  // unused value
                        iline);
     }
   }
@@ -1242,7 +1241,7 @@ void ComputeData::dt_core_calc(const SpeciesIsotope& spec,
     const Numeric& inv_gd = lshp.inv_gd;
     const Numeric& f0     = lshp.f0;
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       dz_fac[i] =
           (-2 * T * line.ls.dD0_dT(atm) - 2 * T * line.ls.dDV_dT(atm) - f0) /
           (2 * T * f0);
@@ -1253,7 +1252,7 @@ void ComputeData::dt_core_calc(const SpeciesIsotope& spec,
       dz[i] = inv_gd *
               Complex{-dline_center_calc_dT(line, atm), line.ls.dG0_dT(atm)};
     } else {
-      const auto& ls = line.ls.single_models[pos[i].spec];
+      const auto& ls = line.ls.single_models.at(pos[i].spec);
 
       dz_fac[i] = (-2 * T * ls.dD0_dT(line.ls.T0, T, atm.pressure) -
                    2 * T * ls.dDV_dT(line.ls.T0, T, atm.pressure) - f0) /
@@ -1415,7 +1414,7 @@ void ComputeData::dVMR_core_calc(const SpeciesIsotope& spec,
     const Numeric& inv_gd = lshp.inv_gd;
     const Numeric& f0     = lshp.f0;
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       dz_fac[i] = -(line.ls.dD0_dVMR(atm, target_spec) +
                     line.ls.dDV_dVMR(atm, target_spec)) /
                   f0;
@@ -1427,19 +1426,23 @@ void ComputeData::dVMR_core_calc(const SpeciesIsotope& spec,
       dz[i] = inv_gd * Complex{-dline_center_calc_dVMR(line, target_spec, atm),
                                line.ls.dG0_dVMR(atm, target_spec)};
     } else {
-      const auto ls_spec = line.ls.single_models[pos[i].spec].species;
+      const auto ls_spec = pos[i].spec;
 
       dz_fac[i] = 0;
 
       if (target_spec == ls_spec) {
         ds[i] = lshp.s * (1 + (target_spec == spec.spec)) / x;
       } else if (ls_spec == SpeciesEnum::Bath) {
-        const Numeric v = 1.0 - std::transform_reduce(
-                                    line.ls.single_models.begin(),
-                                    line.ls.single_models.end() - 1,
-                                    0.0,
-                                    std::plus<>{},
-                                    [&atm](auto& s) { return atm[s.species]; });
+        const Numeric v =
+            1.0 - std::transform_reduce(line.ls.single_models.begin(),
+                                        line.ls.single_models.end(),
+                                        0.0,
+                                        std::plus<>{},
+                                        [&atm](auto& s) {
+                                          return s.first == SpeciesEnum::Bath
+                                                     ? 0.0
+                                                     : atm[s.first];
+                                        });
         ds[i] = lshp.s * (v - x) / (x * v);
       } else {
         ds[i] = 0;
@@ -1473,8 +1476,7 @@ void ComputeData::set_filter(const line_key& key) {
   if (not good_enum(key.var)) {
     for (Size i = 0; i < pos.size(); i++) {
       if (pos[i].line == key.line and
-          (pos[i].spec == key.spec or
-           pos[i].spec == std::numeric_limits<Size>::max()))
+          (pos[i].spec == key.spec or pos[i].spec == SpeciesEnum::unused))
         filter.push_back(i);
     }
   } else {
@@ -1501,7 +1503,7 @@ void ComputeData::df0_core_calc(const SpeciesIsotope& spec,
     const Numeric& inv_gd = lshp.inv_gd;
     const Numeric& f0     = lshp.f0;
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       dz_fac[i] = -1.0 / f0;
 
       ds[i] = line.z.Strength(line.qn, pol, pos[i].iz) *
@@ -1595,15 +1597,15 @@ void ComputeData::dG0_core_calc(const band_shape& shp,
   for (Size i : filter) {
     const auto& ls = bnd.lines[pos[i].line].ls;
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       dz[i] = Complex(
           0, shp.lines[i].inv_gd * ls.dG0_dX(atm, key.spec, key.ls_coeff));
     } else {
-      dz[i] =
-          Complex(0,
-                  shp.lines[i].inv_gd *
-                      ls.single_models[pos[i].spec].dG0_dX(
-                          ls.T0, atm.temperature, atm.pressure, key.ls_coeff));
+      dz[i] = Complex(
+          0,
+          shp.lines[i].inv_gd *
+              ls.single_models.at(pos[i].spec)
+                  .dG0_dX(ls.T0, atm.temperature, atm.pressure, key.ls_coeff));
     }
   }
 
@@ -1634,7 +1636,7 @@ void ComputeData::dD0_core_calc(const band_shape& shp,
     const Numeric& inv_gd = lshp.inv_gd;
     const Numeric& f0     = lshp.f0;
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       const Numeric d = ls.dD0_dX(atm, key.spec, key.ls_coeff);
 
       dz_fac[i] = -d / f0;
@@ -1643,8 +1645,9 @@ void ComputeData::dD0_core_calc(const band_shape& shp,
 
       dz[i] = -d * inv_gd;
     } else {
-      const Numeric d = ls.single_models[pos[i].spec].dD0_dX(
-          ls.T0, atm.temperature, atm.pressure, key.ls_coeff);
+      const Numeric d =
+          ls.single_models.at(pos[i].spec)
+              .dD0_dX(ls.T0, atm.temperature, atm.pressure, key.ls_coeff);
 
       dz_fac[i] = -d / f0;
 
@@ -1680,7 +1683,7 @@ void ComputeData::dY_core_calc(const SpeciesIsotope& spec,
     const auto& line = bnd.lines[pos[i].line];
     const auto& lshp = shp.lines[i];
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       ds[i] = line.z.Strength(line.qn, pol, pos[i].iz) *
               dline_strength_calc_dY(line.ls.dY_dX(atm, key.spec, key.ls_coeff),
                                      lshp.inv_gd,
@@ -1688,15 +1691,17 @@ void ComputeData::dY_core_calc(const SpeciesIsotope& spec,
                                      line,
                                      atm);
     } else {
-      ds[i] = line.z.Strength(line.qn, pol, pos[i].iz) *
-              dline_strength_calc_dY(
-                  line.ls.single_models[pos[i].spec].dY_dX(
+      ds[i] =
+          line.z.Strength(line.qn, pol, pos[i].iz) *
+          dline_strength_calc_dY(
+              line.ls.single_models.at(pos[i].spec)
+                  .dY_dX(
                       line.ls.T0, atm.temperature, atm.pressure, key.ls_coeff),
-                  lshp.inv_gd,
-                  spec,
-                  line,
-                  atm,
-                  pos[i].spec);
+              lshp.inv_gd,
+              spec,
+              line,
+              atm,
+              pos[i].spec);
     }
   }
 
@@ -1726,7 +1731,7 @@ void ComputeData::dG_core_calc(const SpeciesIsotope& spec,
     const auto& line = bnd.lines[pos[i].line];
     const auto& lshp = shp.lines[i];
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       ds[i] = line.z.Strength(line.qn, pol, pos[i].iz) *
               dline_strength_calc_dG(line.ls.dG_dX(atm, key.spec, key.ls_coeff),
                                      lshp.inv_gd,
@@ -1734,15 +1739,17 @@ void ComputeData::dG_core_calc(const SpeciesIsotope& spec,
                                      line,
                                      atm);
     } else {
-      ds[i] = line.z.Strength(line.qn, pol, pos[i].iz) *
-              dline_strength_calc_dG(
-                  line.ls.single_models[pos[i].spec].dG_dX(
+      ds[i] =
+          line.z.Strength(line.qn, pol, pos[i].iz) *
+          dline_strength_calc_dG(
+              line.ls.single_models.at(pos[i].spec)
+                  .dG_dX(
                       line.ls.T0, atm.temperature, atm.pressure, key.ls_coeff),
-                  lshp.inv_gd,
-                  spec,
-                  line,
-                  atm,
-                  pos[i].spec);
+              lshp.inv_gd,
+              spec,
+              line,
+              atm,
+              pos[i].spec);
     }
   }
 
@@ -1775,7 +1782,7 @@ void ComputeData::dDV_core_calc(const band_shape& shp,
     const Numeric& inv_gd = lshp.inv_gd;
     const Numeric& f0     = lshp.f0;
 
-    if (pos[i].spec == std::numeric_limits<Size>::max()) {
+    if (pos[i].spec == SpeciesEnum::unused) {
       const Numeric d = ls.dDV_dX(atm, key.spec, key.ls_coeff);
 
       dz_fac[i] = -d / f0;
@@ -1784,8 +1791,9 @@ void ComputeData::dDV_core_calc(const band_shape& shp,
 
       dz[i] = -d * inv_gd;
     } else {
-      const Numeric d = ls.single_models[pos[i].spec].dDV_dX(
-          ls.T0, atm.temperature, atm.pressure, key.ls_coeff);
+      const Numeric d =
+          ls.single_models.at(pos[i].spec)
+              .dDV_dX(ls.T0, atm.temperature, atm.pressure, key.ls_coeff);
 
       dz_fac[i] = -d / f0;
 

--- a/src/core/lbl/lbl_lineshape_voigt_lte_mirrored.h
+++ b/src/core/lbl/lbl_lineshape_voigt_lte_mirrored.h
@@ -43,7 +43,7 @@ struct single_shape {
                const AtmPoint&,
                const zeeman::pol,
                const Index,
-               const Size);
+               const SpeciesEnum);
 
   [[nodiscard]] constexpr Complex z(Numeric f) const {
     return Complex{inv_gd * (f - f0), z_imag};
@@ -376,8 +376,8 @@ struct ComputeData {
 
   Size filtered_line{std::numeric_limits<
       Size>::max()};  //! filter is for this and filtered_spec
-  Size filtered_spec{std::numeric_limits<
-      Size>::max()};  //! filter is for this and filtered_spec
+  SpeciesEnum filtered_spec{
+      SpeciesEnum::unused};  //! filter is for this and filtered_spec
   std::vector<Size>
       filter;  //! Filter for line parameters; resized all the time but reserves size of line shapes
 

--- a/src/core/lbl/lbl_lineshape_voigt_nlte.h
+++ b/src/core/lbl/lbl_lineshape_voigt_nlte.h
@@ -44,7 +44,7 @@ struct single_shape {
                const AtmPoint&,
                const zeeman::pol,
                const Index,
-               const Size);
+               const SpeciesEnum);
 
   [[nodiscard]] constexpr Complex z(Numeric f) const {
     return Complex{inv_gd * (f - f0), z_imag};

--- a/src/core/lbl/lbl_temperature_model.cpp
+++ b/src/core/lbl/lbl_temperature_model.cpp
@@ -383,6 +383,7 @@ std::string metric_unit_x1(const Numeric x,
             return std::format(
                 "{:.2f}{}{}Hz/Pa", v, c == ' ' ? ""sv : " "sv, c);
         }
+        break;
       case ETA: return std::format("{}", x);
       case DV:
         switch (t) {
@@ -400,6 +401,7 @@ std::string metric_unit_x1(const Numeric x,
             return std::format(
                 "{:.2f}{}{}Hz/Pa^2", v, c == ' ' ? ""sv : " "sv, c);
         }
+        break;
       case G:
         switch (t) {
           case T0:
@@ -416,6 +418,7 @@ std::string metric_unit_x1(const Numeric x,
             return std::format(
                 "{:.2f}{}{}/Pa^2", v, c == ' ' ? ""sv : " "sv, c);
         }
+        break;
       case Y:
         switch (t) {
           case T0:

--- a/src/core/lbl/lbl_temperature_model.cpp
+++ b/src/core/lbl/lbl_temperature_model.cpp
@@ -15,7 +15,7 @@ static_assert(LineShapeModelTypeSize == enumsize::LineShapeModelTypeSize,
 
 data::data(LineShapeModelType type, Vector X) : t(type), x(std::move(X)) {
   ARTS_USER_ERROR_IF(not good_enum(t), "Invalid model type")
-  ARTS_USER_ERROR_IF(auto n = model_size(t);
+  ARTS_USER_ERROR_IF(Size n = model_size(t);
                      n != std::numeric_limits<Size>::max() and
                          n != static_cast<Size>(x.size()),
                      "Invalid number of parameters for model {}"
@@ -443,37 +443,32 @@ std::string to_educational_string(const lbl::temperature::data& data,
   switch (data.Type()) {
     using enum LineShapeModelType;
     using enum LineShapeModelCoefficient;
-    case T0:
-      return std::format("LineShapeModelType::T0: {}",
-                         metric_unit_x0(data.X(X0), type));
+    case T0: return std::format("{}", metric_unit_x0(data.X(X0), type));
     case T1:
-      return std::format("LineShapeModelType::T1: {} * pow(T0 / T, {})",
+      return std::format("{} * pow(T0 / T, {})",
                          metric_unit_x0(data.X(X0), type),
                          metric_unit_x1(data.X(X1), data.Type(), type));
     case T2:
-      return std::format(
-          "LineShapeModelType::T2: {} * pow(T0 / T, {}) * (1 + {} * log(T / T0))",
-          metric_unit_x0(data.X(X0), type),
-          metric_unit_x1(data.X(X1), data.Type(), type),
-          data.X(X2));
+      return std::format("{} * pow(T0 / T, {}) * (1 + {} * log(T / T0))",
+                         metric_unit_x0(data.X(X0), type),
+                         metric_unit_x1(data.X(X1), data.Type(), type),
+                         data.X(X2));
     case T3:
-      return std::format("LineShapeModelType::T3: {} + {} * (T - T0)",
+      return std::format("{} + {} * (T - T0)",
                          metric_unit_x0(data.X(X0), type),
                          metric_unit_x1(data.X(X1), data.Type(), type));
     case T4:
-      return std::format(
-          "LineShapeModelType::T4: ({0} + {1} * (T0 / T - 1)) * pow(T0 / T, {2})",
-          metric_unit_x0(data.X(X0), type),
-          metric_unit_x1(data.X(X1), data.Type(), type),
-          data.X(X2));
+      return std::format("({0} + {1} * (T0 / T - 1)) * pow(T0 / T, {2})",
+                         metric_unit_x0(data.X(X0), type),
+                         metric_unit_x1(data.X(X1), data.Type(), type),
+                         data.X(X2));
     case T5:
-      return std::format(
-          "LineShapeModelType::T5: {} * pow(T0 / T, 0.25 + 1.5 * {})",
-          metric_unit_x0(data.X(X0), type),
-          metric_unit_x1(data.X(X1), data.Type(), type));
+      return std::format("{} * pow(T0 / T, 0.25 + 1.5 * {})",
+                         metric_unit_x0(data.X(X0), type),
+                         metric_unit_x1(data.X(X1), data.Type(), type));
     case AER:
       return std::format(
-          "LineShapeModelType::AER: (T < 250.0) ? "
+          "(T < 250.0) ? "
           "{0} + (T - 200.0) * ({1} - {0}) / (250.0 - 200.0) : "
           "(T > 296.0) ? "
           "{2} + (T - 296.0) * ({3} - {2}) / (340.0 - 296.0) : "
@@ -483,16 +478,15 @@ std::string to_educational_string(const lbl::temperature::data& data,
           metric_unit_x0(data.X(X2), type),
           metric_unit_x0(data.X(X3), type));
     case DPL:
-      return std::format(
-          "LineShapeModelType::DPL: {} * pow(T0 / T, {}) + {} * pow(T0 / T, {})",
-          metric_unit_x0(data.X(X0), type),
-          metric_unit_x1(data.X(X1), data.Type(), type),
-          metric_unit_x0(data.X(X2), type),
-          metric_unit_x1(data.X(X3), data.Type(), type));
+      return std::format("{} * pow(T0 / T, {}) + {} * pow(T0 / T, {})",
+                         metric_unit_x0(data.X(X0), type),
+                         metric_unit_x1(data.X(X1), data.Type(), type),
+                         metric_unit_x0(data.X(X2), type),
+                         metric_unit_x1(data.X(X3), data.Type(), type));
     case POLY: {
       std::string s{};
       Size i{};
-      std::string res{"LineShapeModelType::POLY: "};
+      std::string res{""};
       std::string_view x = ""sv;
       for (auto& v : data.X()) {
         res += std::format("{}{}{}{}",

--- a/src/core/options/arts_options.cc
+++ b/src/core/options/arts_options.cc
@@ -422,6 +422,7 @@ parameters that are mapped to the species identifier.
               Value{"rain", "rain", "rain tag"},
               Value{"free_electrons", "free_electrons", "free electrons tag"},
               Value{"particles", "particles", "particles tag"},
+              Value{"unused", "unused", "unused tag (used internally)"},
           },
       .preferred_print = 1,
   });
@@ -606,9 +607,8 @@ parameters that are mapped to the species identifier.
       .values_and_desc =
           {
               Value{"None", "No cutoff"},
-              Value{
-                  "ByLine",
-                  "Line's are cut 1-by-1 around f0 in *AbsorptionLine*"},
+              Value{"ByLine",
+                    "Line's are cut 1-by-1 around f0 in *AbsorptionLine*"},
           },
   });
 

--- a/src/core/quantum/quantum.cc
+++ b/src/core/quantum/quantum.cc
@@ -6,8 +6,6 @@
 #include <nonstd.h>
 #include <rational.h>
 
-#include <boost/container_hash/hash.hpp>
-#include <boost/functional/hash.hpp>
 #include <compare>
 #include <exception>
 #include <initializer_list>
@@ -705,92 +703,6 @@ bool vamdcCheck(const State& st, VAMDC type) {
   std::unreachable();
 }
 }  // namespace Quantum
-
-template <>
-struct std::hash<Quantum::Value> {
-  std::size_t operator()(const Quantum::Value& g) const {
-    if (auto* ptr = std::get_if<String>(&g.value))
-      return std::hash<String>{}(*ptr);
-    if (auto* ptr = std::get_if<Rational>(&g.value)) {
-      std::size_t seed{};
-
-      boost::hash_combine(seed, ptr->numer);
-      boost::hash_combine(seed, ptr->denom);
-
-      return seed;
-    }
-    return 0;
-  }
-};
-
-template <>
-struct std::hash<Quantum::UpperLower> {
-  std::size_t operator()(const Quantum::UpperLower& g) const {
-    std::size_t seed{};
-
-    boost::hash_combine(seed, std::hash<Quantum::Value>{}(g.upper));
-    boost::hash_combine(seed, std::hash<Quantum::Value>{}(g.lower));
-
-    return seed;
-  }
-};
-
-template <>
-struct std::hash<QuantumLevel> {
-  std::size_t operator()(const QuantumLevel& g) const {
-    std::size_t seed{};
-
-    // Has to be ordered or it will affect the hash
-    for (auto& qns : enumtyps::QuantumNumberTypeTypes) {
-      if (auto iter = g.find(qns); iter != g.end()) {
-        boost::hash_combine(seed, iter->first);
-        boost::hash_combine(seed, std::hash<Quantum::Value>{}(iter->second));
-      }
-    }
-
-    return seed;
-  }
-};
-
-template <>
-struct std::hash<QuantumState> {
-  std::size_t operator()(const QuantumState& g) const {
-    std::size_t seed{};
-
-    // Has to be ordered or it will affect the hash
-    for (auto& qns : enumtyps::QuantumNumberTypeTypes) {
-      if (auto iter = g.find(qns); iter != g.end()) {
-        boost::hash_combine(seed, iter->first);
-        boost::hash_combine(seed,
-                            std::hash<Quantum::UpperLower>{}(iter->second));
-      }
-    }
-
-    return seed;
-  }
-};
-
-std::size_t std::hash<QuantumLevelIdentifier>::operator()(
-    const QuantumLevelIdentifier& g) const {
-  std::size_t seed{};
-
-  boost::hash_combine(seed, g.isot.spec);
-  boost::hash_combine(seed, g.isot.isotname);
-  boost::hash_combine(seed, std::hash<QuantumLevel>{}(g.state));
-
-  return seed;
-}
-
-std::size_t std::hash<QuantumIdentifier>::operator()(
-    const QuantumIdentifier& g) const {
-  std::size_t seed{};
-
-  boost::hash_combine(seed, g.isot.spec);
-  boost::hash_combine(seed, g.isot.isotname);
-  boost::hash_combine(seed, std::hash<QuantumState>{}(g.state));
-
-  return seed;
-}
 
 void xml_io_stream<QuantumLevel>::parse(std::span<QuantumLevel> qns,
                                         std::istream& is_xml) {

--- a/src/core/quantum/quantum.cc
+++ b/src/core/quantum/quantum.cc
@@ -23,6 +23,8 @@ using enum QuantumNumberType;
 
 Value::Value(String x) : value(std::move(x)) {}
 
+Value::Value(Index x) : value(Rational(x, 1)) {}
+
 Value::Value(Rational x) : value(x) {}
 
 Value::Value() : Value(Rational{}) {}
@@ -914,7 +916,6 @@ void xml_io_stream<QuantumLevelIdentifier>::read(std::istream& is_xml,
 } catch (const std::exception& e) {
   ARTS_USER_ERROR("Error reading QuantumLevelIdentifier:\n{}", e.what())
 }
-
 
 std::string to_educational_string(const QuantumIdentifier& q) {
   return Quantum::Helpers::molecular_term_symbol(q);

--- a/src/core/quantum/quantum.h
+++ b/src/core/quantum/quantum.h
@@ -21,10 +21,10 @@ struct Value {
 
   Value();
 
-  explicit Value(String);    // Default initialize by string
-  explicit Value(Rational);  // Default initialize by rational
-  explicit Value(const std::integral auto& x) : value(Rational(x, 1)) {}
-  explicit Value(QuantumNumberType);  // Default initialize by type
+  Value(String);             // Default initialize by string
+  Value(Index);              // Default initialize by index
+  Value(Rational);           // Default initialize by rational
+  Value(QuantumNumberType);  // Default initialize by type
   Value(const Value&)                = default;
   Value(Value&&) noexcept            = default;
   Value& operator=(const Value&)     = default;
@@ -365,11 +365,15 @@ struct std::formatter<QuantumIdentifier> {
   FmtContext::iterator format(const QuantumIdentifier& q,
                               FmtContext& ctx) const {
     if (tags.help) {
-      return tags.format(ctx,
-                         "QuantumIdentifier: Species: "sv,
-                         q.isot,
-                         "; Symbol: ",
-                         to_educational_string(q));
+      tags.format(ctx, "Species: "sv, q.isot, " Quantum Numbers:"sv);
+      for (auto& [k, v] : q.state) {
+        tags.format(ctx, ' ', k, ": "sv, v, ',');
+      }
+      return ctx.out();
+    }
+
+    if (tags.depth > 0) {
+      return tags.format(ctx, to_educational_string(q));
     }
 
     tags.format(ctx, q.isot);

--- a/src/core/scattering/properties.h
+++ b/src/core/scattering/properties.h
@@ -6,6 +6,7 @@
 #include <xml.h>
 
 #include <algorithm>
+#include <boost/container_hash/hash.hpp>
 #include <string_view>
 
 #include "mystring.h"
@@ -31,8 +32,10 @@ namespace std {
 template <>
 struct hash<ScatteringSpeciesProperty> {
   std::size_t operator()(const ScatteringSpeciesProperty& ssp) const {
-    return std::hash<String>{}(ssp.species_name +
-                               std::string(toString(ssp.pproperty)));
+    std::size_t seed = 0;
+    boost::hash_combine(seed, ssp.species_name);
+    boost::hash_combine(seed, ssp.pproperty);
+    return seed;
   }
 };
 }  // namespace std

--- a/src/core/sensor/obsel.h
+++ b/src/core/sensor/obsel.h
@@ -6,6 +6,7 @@
 #include <rtepack.h>
 #include <xml.h>
 
+#include <boost/container_hash/hash.hpp>
 #include <memory>
 #include <unordered_map>
 #include <unordered_set>
@@ -175,9 +176,11 @@ struct SensorKey {
 template <>
 struct std::hash<SensorKey> {
   std::size_t operator()(const SensorKey& g) const {
-    return std::hash<SensorKeyType>{}(g.type) ^
-           (std::hash<Index>{}(g.measurement_elem)
-            << (8 * (sizeof(SensorKeyType) + sizeof(SensorJacobianModelType))));
+    std::size_t seed = 0;
+    boost::hash_combine(seed, std::hash<SensorKeyType>{}(g.type));
+    boost::hash_combine(seed, std::hash<Index>{}(g.sensor_elem));
+    boost::hash_combine(seed, std::hash<Index>{}(g.measurement_elem));
+    return seed;
   }
 };
 

--- a/src/core/spec/isotopologues.cc
+++ b/src/core/spec/isotopologues.cc
@@ -128,6 +128,7 @@ ArrayOfSpeciesIsotope isotopologues(SpeciesEnum spec) {
       deal_with_spec(rain);
       deal_with_spec(free_electrons);
       deal_with_spec(particles);
+      deal_with_spec(unused);
   }
 
 #undef deal_with_spec

--- a/src/core/spec/isotopologues.h
+++ b/src/core/spec/isotopologues.h
@@ -647,6 +647,8 @@ inline constexpr std::array Isotopologues{
     deal_with_spec(free_electrons),
     deal_with_spec(particles),
     /** Model species **/
+    // Special, leave last - control-flow species
+    deal_with_spec(unused),
 };
 
 #undef deal_with_spec

--- a/src/core/spec/species_tags.h
+++ b/src/core/spec/species_tags.h
@@ -5,6 +5,7 @@
 #include <isotopologues.h>
 #include <mystring.h>
 
+#include <boost/container_hash/hash.hpp>
 #include <set>
 
 namespace Species {
@@ -163,9 +164,13 @@ namespace std {
 template <>
 struct hash<SpeciesTag> {
   std::size_t operator()(const SpeciesTag& g) const {
-    return std::hash<Index>{}(g.spec_ind) ^
-           (std::hash<SpeciesTagType>{}(g.type) << 20) ^
-           (std::hash<SpeciesEnum>{}(g.cia_2nd_species) << 24);
+    std::size_t seed = 0;
+
+    boost::hash_combine(seed, std::hash<Index>{}(g.spec_ind));
+    boost::hash_combine(seed, std::hash<SpeciesTagType>{}(g.type));
+    boost::hash_combine(seed, std::hash<SpeciesEnum>{}(g.cia_2nd_species));
+
+    return seed;
   }
 };
 

--- a/src/m_atm.cc
+++ b/src/m_atm.cc
@@ -112,7 +112,7 @@ void keysSpecies(std::unordered_map<SpeciesEnum, Index> &keys,
 
     for (auto &line : value.lines) {
       for (auto &ls : line.ls.single_models) {
-        ++keys[ls.species];
+        ++keys[ls.first];
       }
     }
   }

--- a/src/partfun/partfun.cc
+++ b/src/partfun/partfun.cc
@@ -122,7 +122,8 @@ Numeric partfun_impl(Numeric T, const SpeciesIsotope& ir) {
       deal_with_spec(icecloud);
       deal_with_spec(rain);
       deal_with_spec(free_electrons);
-      deal_with_spec(particles)
+      deal_with_spec(particles);
+      deal_with_spec(unused);
   }
 
 #undef deal_with_spec
@@ -261,7 +262,8 @@ bool has_partfun(const SpeciesIsotope& ir) noexcept {
       deal_with_spec(icecloud);
       deal_with_spec(rain);
       deal_with_spec(free_electrons);
-      deal_with_spec(particles)
+      deal_with_spec(particles);
+      deal_with_spec(unused);
   }
 
 #undef deal_with_spec

--- a/src/python_interface/hpy_vector.h
+++ b/src/python_interface/hpy_vector.h
@@ -12,8 +12,6 @@
 
 #include "python_interface_value_type.h"
 
-NB_MAKE_OPAQUE(
-    std::vector<std::pair<LineShapeModelVariable, lbl::temperature::data>>);
 NB_MAKE_OPAQUE(std::vector<lbl::line_shape::species_model>);
 NB_MAKE_OPAQUE(Array<lagrange_interp::lag_t<-1, lagrange_interp::identity>>);
 NB_MAKE_OPAQUE(Array<lagrange_interp::lag_t<-1, lagrange_interp::loncross>>);

--- a/src/python_interface/py_lbl.cpp
+++ b/src/python_interface/py_lbl.cpp
@@ -78,43 +78,9 @@ void py_lbl(py::module_& m) try {
            })
       .doc() = "Temperature model";
 
-  using pair_vector_type =
-      std::vector<std::pair<LineShapeModelVariable, lbl::temperature::data>>;
-  auto lsvtml =
-      py::bind_vector<pair_vector_type, py::rv_policy::reference_internal>(
-          m, "LineShapeVariableTemperatureModelList")
-          .def("__getitem__",
-               [](pair_vector_type& self,
-                  LineShapeModelVariable x) -> lbl::temperature::data& {
-                 for (auto& [var, data] : self) {
-                   if (var == x) {
-                     return data;
-                   }
-                 }
-                 throw std::out_of_range(std::format("\"{}\"", x));
-               })
-          .def("__setitem__",
-               [](pair_vector_type& self,
-                  LineShapeModelVariable x,
-                  const lbl::temperature::data& y) {
-                 for (auto& [var, data] : self) {
-                   if (var == x) {
-                     data = y;
-                     return;
-                   }
-                 }
-                 self.emplace_back(x, y);
-               });
-  lsvtml.doc() = "A list of line shape models with temperature coefficients";
-  vector_interface(lsvtml);
-  generic_interface(lsvtml);
-
   py::class_<lbl::line_shape::species_model> lssm(m, "LineShapeSpeciesModel");
   generic_interface(lssm);
-  lssm.def_rw("species",
-              &lbl::line_shape::species_model::species,
-              "The species\n\n.. :class:`SpeciesEnum`")
-      .def_rw(
+  lssm.def_rw(
           "data",
           &lbl::line_shape::species_model::data,
           "The data\n\n.. :class:`list[tuple[LineShapeModelVariable, TemperatureModel]]`")
@@ -207,11 +173,9 @@ void py_lbl(py::module_& m) try {
       .def(
           "remove",
           [](lbl::line_shape::model& self, LineShapeModelVariable x) {
-            for (auto& specmod : self.single_models) {
-              auto ptr = std::find_if(specmod.data.begin(),
-                                      specmod.data.end(),
-                                      [x](auto& y) { return y.first == x; });
-              if (ptr != specmod.data.end()) specmod.data.erase(ptr);
+            for (auto& mod : self.single_models | stdv::values) {
+              auto ptr = mod.data.find(x);
+              if (ptr != mod.data.end()) mod.data.erase(ptr);
             }
           },
           "x"_a,
@@ -225,8 +189,8 @@ void py_lbl(py::module_& m) try {
   py::class_<lbl::zeeman::model> zlm(m, "ZeemanLineModel");
   generic_interface(zlm);
   zlm.def_rw("on",
-              &lbl::zeeman::model::on,
-              "If True, the Zeeman effect is included\n\n.. :class:`bool`")
+             &lbl::zeeman::model::on,
+             "If True, the Zeeman effect is included\n\n.. :class:`bool`")
       .def_prop_rw(
           "gl",
           [](lbl::zeeman::model& z) { return z.gl(); },
@@ -265,8 +229,8 @@ void py_lbl(py::module_& m) try {
   py::class_<lbl::line> al(m, "AbsorptionLine");
   generic_interface(al);
   al.def_rw("a",
-             &lbl::line::a,
-             "The Einstein coefficient [1 / s]\n\n.. :class:`Numeric`")
+            &lbl::line::a,
+            "The Einstein coefficient [1 / s]\n\n.. :class:`Numeric`")
       .def_rw("f0",
               &lbl::line::f0,
               "The line center frequency [Hz]\n\n.. :class:`Numeric`")
@@ -405,7 +369,7 @@ other : AbsorptionBands
         Size sum = 0;
         for (auto& [_, band] : self) {
           for (auto& line : band.lines) {
-            for (auto& lsm : line.ls.single_models) {
+            for (auto& lsm : line.ls.single_models | stdv::values) {
               sum += lsm.remove_variables<LineShapeModelVariable::Y,
                                           LineShapeModelVariable::G,
                                           LineShapeModelVariable::DV>();

--- a/src/python_interface/py_quantum.cpp
+++ b/src/python_interface/py_quantum.cpp
@@ -20,9 +20,10 @@
 namespace Python {
 void py_quantum(py::module_& m) try {
   py::class_<Quantum::Value> qval(m, "QuantumValue");
-  qval.def(py::init<String>())
-      .def(py::init<Rational>())
-      .def(py::init<QuantumNumberType>())
+  qval.def(py::init_implicit<String>())
+      .def(py::init_implicit<Index>())
+      .def(py::init_implicit<Rational>())
+      .def(py::init_implicit<QuantumNumberType>())
       .def_rw(
           "value",
           &Quantum::Value::value,

--- a/src/tests/test_vformat.cc
+++ b/src/tests/test_vformat.cc
@@ -27,7 +27,7 @@ lbl::line get_lbl_line() {
 
   l.ls.one_by_one = false;
   l.ls.T0         = 300.0;
-  auto& mod       = l.ls.single_models.emplace_back("H2O"_spec);
+  auto& mod       = l.ls.single_models["H2O"_spec];
 
   mod.data[LineShapeModelVariable::G0] =
       lbl::temperature::data{LineShapeModelType::T0, Vector{6.0}};

--- a/src/tests/test_vformat.cc
+++ b/src/tests/test_vformat.cc
@@ -6,43 +6,39 @@ QuantumIdentifier get_quantum_identifier() {
   QuantumIdentifier qid{};
   qid.isot = "H2O-161"_isot;
   qid.state.emplace(QuantumNumberType::J,
-                    Quantum::UpperLower{.upper = Quantum::Value{1},
-                                        .lower = Quantum::Value{1}});
+                    Quantum::UpperLower{.upper = 1, .lower = 1});
   qid.state.emplace(QuantumNumberType::K,
-                    Quantum::UpperLower{.upper = Quantum::Value{0},
-                                        .lower = Quantum::Value{0}});
+                    Quantum::UpperLower{.upper = 0, .lower = 0});
   return qid;
 }
 
-lbl::line get_lbl_line() {
-  lbl::line l{};
-  l.f0 = 1.0;
-  l.a  = 2.0;
-  l.e0 = 3.0;
-  l.gu = 4.0;
-  l.gl = 5.0;
-  l.qn.emplace(QuantumNumberType::J,
-               Quantum::UpperLower{.upper = Quantum::Value{1},
-                                   .lower = Quantum::Value{1}});
+AbsorptionLine get_lbl_line() {
+  using enum LineShapeModelVariable;
+  using enum LineShapeModelType;
+  using enum QuantumNumberType;
 
-  l.ls.one_by_one = false;
-  l.ls.T0         = 300.0;
-  auto& mod       = l.ls.single_models["H2O"_spec];
+  AbsorptionLine line{};
+  line.f0 = 1.0;
+  line.a  = 2.0;
+  line.e0 = 3.0;
+  line.gu = 4.0;
+  line.gl = 5.0;
+  line.qn.emplace(J, Quantum::UpperLower{.upper = 1, .lower = 1});
 
-  mod.data[LineShapeModelVariable::G0] =
-      lbl::temperature::data{LineShapeModelType::T0, Vector{6.0}};
-  mod.data[LineShapeModelVariable::D0] =
-      lbl::temperature::data{LineShapeModelType::T1, Vector{7.0, 8.0}};
+  line.ls.one_by_one = false;
+  line.ls.T0         = 300.0;
+  auto& mod          = line.ls.single_models["H2O"_spec];
+  mod.data[G0]       = {T0, Vector{6.0}};
+  mod.data[D0]       = {T1, Vector{7.0, 8.0}};
+  line.z.gu(6.0);
+  line.z.gl(7.0);
+  line.z.on = true;
 
-  l.z.gu(6.0);
-  l.z.gl(7.0);
-  l.z.on = true;
-
-  return l;
+  return line;
 }
 
-lbl::band_data get_lbl_band_data() {
-  lbl::band_data b{};
+AbsorptionBand get_lbl_band_data() {
+  AbsorptionBand b{};
 
   b.lines.emplace_back(get_lbl_line());
 

--- a/src/xml_io_old.cc
+++ b/src/xml_io_old.cc
@@ -13,7 +13,7 @@ ArtscatMeta ReadFromArtscat3Stream(std::istream& is) {
   // Default data and values for this type
   ArtscatMeta output{};
   output.data.ls.one_by_one = false;
-  output.data.ls.single_models.resize(2);
+  output.data.ls.single_models.reserve(2);
 
   // This always contains the rest of the line to parse. At the
   // beginning the entire line. Line gets shorter and shorter as we
@@ -133,15 +133,17 @@ ArtscatMeta ReadFromArtscat3Stream(std::istream& is) {
       }
 
       // Set line shape computer
-      output.data.ls.single_models[0].species = isotopologue.spec;
-      output.data.ls.single_models[0].data[LineShapeModelVariable::G0] =
+      output.data.ls.single_models[isotopologue.spec]
+          .data[LineShapeModelVariable::G0] =
           lbl::temperature::data{LineShapeModelType::T1, Vector{sgam, nair}};
-      output.data.ls.single_models[0].data[LineShapeModelVariable::D0] =
+      output.data.ls.single_models[isotopologue.spec]
+          .data[LineShapeModelVariable::D0] =
           lbl::temperature::data{LineShapeModelType::T5, Vector{psf, nair}};
-      output.data.ls.single_models[1].species = SpeciesEnum::Bath;
-      output.data.ls.single_models[1].data[LineShapeModelVariable::G0] =
+      output.data.ls.single_models[SpeciesEnum::Bath]
+          .data[LineShapeModelVariable::G0] =
           lbl::temperature::data{LineShapeModelType::T1, Vector{agam, nair}};
-      output.data.ls.single_models[1].data[LineShapeModelVariable::D0] =
+      output.data.ls.single_models[SpeciesEnum::Bath]
+          .data[LineShapeModelVariable::D0] =
           lbl::temperature::data{LineShapeModelType::T5, Vector{psf, nair}};
 
       if (not(output.data.gu > 0.0)) output.data.gu = 1.;
@@ -168,55 +170,46 @@ The error is:
 }
 
 lbl::line_shape::model from_artscat4(std::istream& is,
-                                     const Numeric T0,
+                                     const Numeric T0_,
                                      const QuantumIdentifier& qid) {
+  using enum LineShapeModelVariable;
+  using enum LineShapeModelType;
+  using enum LineShapeModelCoefficient;
+
   lbl::line_shape::model out;
   out.one_by_one = false;
-  out.T0         = T0;
-  out.single_models.resize(7);
+  out.T0         = T0_;
+  out.single_models.reserve(7);
 
-  out.single_models[0].species = qid.isot.spec;
-  out.single_models[1].species = to<SpeciesEnum>("N2");
-  out.single_models[2].species = to<SpeciesEnum>("O2");
-  out.single_models[3].species = to<SpeciesEnum>("H2O");
-  out.single_models[4].species = to<SpeciesEnum>("CO2");
-  out.single_models[5].species = to<SpeciesEnum>("H2");
-  out.single_models[6].species = to<SpeciesEnum>("He");
+  const std::array<SpeciesEnum, 7> species = {qid.isot.spec,
+                                              to<SpeciesEnum>("N2"),
+                                              to<SpeciesEnum>("O2"),
+                                              to<SpeciesEnum>("H2O"),
+                                              to<SpeciesEnum>("CO2"),
+                                              to<SpeciesEnum>("H2"),
+                                              to<SpeciesEnum>("He")};
 
-  for (auto& v : out.single_models) {
-    v.data[LineShapeModelVariable::G0] =
-        lbl::temperature::data{LineShapeModelType::T1, Vector{0, 0}};
-    v.data[LineShapeModelVariable::D0] =
-        lbl::temperature::data{LineShapeModelType::T5, Vector{0, 0}};
+  for (auto& spec : species) {
+    out.single_models[spec].data[G0] = lbl::temperature::data{T1, Vector{0, 0}};
+    out.single_models[spec].data[D0] = lbl::temperature::data{T5, Vector{0, 0}};
   }
 
   // G0 main coefficient
-  for (auto& v : out.single_models) {
-    is >> double_imanip() >>
-        v.data[LineShapeModelVariable::G0].X(LineShapeModelCoefficient::X0);
+  for (auto& spec : species) {
+    is >> double_imanip() >> out.single_models[spec].data[G0].X(X0);
   };
 
   // G0 exponent is same as D0 exponent
-  for (auto& v : out.single_models) {
-    is >> double_imanip() >>
-        v.data[LineShapeModelVariable::G0].X(LineShapeModelCoefficient::X1);
-    v.data[LineShapeModelVariable::D0].X(LineShapeModelCoefficient::X1) =
-        v.data[LineShapeModelVariable::G0].X(LineShapeModelCoefficient::X1);
+  for (auto& spec : species) {
+    is >> double_imanip() >> out.single_models[spec].data[G0].X(X1);
+    out.single_models[spec].data[D0].X(X1) =
+        out.single_models[spec].data[G0].X(X1);
   };
 
   // D0 coefficient
-  out.single_models.front().data[LineShapeModelVariable::D0].X(
-      LineShapeModelCoefficient::X0) = 0;
-  for (auto& v : out.single_models | stdv::drop(1)) {
-    is >> double_imanip() >>
-        v.data[LineShapeModelVariable::D0].X(LineShapeModelCoefficient::X0);
-  }
-
-  // Remove duplicate species
-  if (std::get<0>(stdr::unique(
-          out.single_models, {}, &lbl::line_shape::species_model::species)) !=
-      stdr::end(out.single_models)) {
-    out.single_models.pop_back();
+  out.single_models[species[0]].data[D0].X(X0) = 0;
+  for (auto& spec : species | stdv::drop(1)) {
+    is >> double_imanip() >> out.single_models[spec].data[D0].X(X0);
   }
 
   return out;

--- a/src/xml_io_old.cc
+++ b/src/xml_io_old.cc
@@ -10,6 +10,9 @@
 
 namespace {
 ArtscatMeta ReadFromArtscat3Stream(std::istream& is) {
+  using enum LineShapeModelVariable;
+  using enum LineShapeModelType;
+
   // Default data and values for this type
   ArtscatMeta output{};
   output.data.ls.one_by_one = false;
@@ -133,18 +136,12 @@ ArtscatMeta ReadFromArtscat3Stream(std::istream& is) {
       }
 
       // Set line shape computer
-      output.data.ls.single_models[isotopologue.spec]
-          .data[LineShapeModelVariable::G0] =
-          lbl::temperature::data{LineShapeModelType::T1, Vector{sgam, nair}};
-      output.data.ls.single_models[isotopologue.spec]
-          .data[LineShapeModelVariable::D0] =
-          lbl::temperature::data{LineShapeModelType::T5, Vector{psf, nair}};
-      output.data.ls.single_models[SpeciesEnum::Bath]
-          .data[LineShapeModelVariable::G0] =
-          lbl::temperature::data{LineShapeModelType::T1, Vector{agam, nair}};
-      output.data.ls.single_models[SpeciesEnum::Bath]
-          .data[LineShapeModelVariable::D0] =
-          lbl::temperature::data{LineShapeModelType::T5, Vector{psf, nair}};
+      auto& self    = output.data.ls.single_models[isotopologue.spec];
+      auto& air     = output.data.ls.single_models[SpeciesEnum::Bath];
+      self.data[G0] = {T1, Vector{sgam, nair}};
+      self.data[D0] = {T5, Vector{psf, nair}};
+      air.data[G0]  = {T1, Vector{agam, nair}};
+      air.data[D0]  = {T5, Vector{psf, nair}};
 
       if (not(output.data.gu > 0.0)) output.data.gu = 1.;
       if (not(output.data.gl > 0.0)) output.data.gl = 1.;


### PR DESCRIPTION
This switches to using a map instead of a vector to hold line shape data.  The interface is a lot cleaner and the performance is about the same (runs that take 7s takes +- 0.1s cf before, and file IO that takes 1s takes +- 0.2s - never in any sides favor.)

The gain is a much easier interface where ``.find`` or ``.at`` can be used instead of full algorithms looking at special member variables.