### PR TITLE
Return values from workspace methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,6 @@ option (ENABLE_PYARTS_STUBS "Turn on python stub generation for pyarts library" 
 option (DISABLE_SHTNS "Turn off SHTns" OFF)
 option (IGNORE_CONDA_PATH "Turn on pathing guard for conda environment" OFF)
 option (NO_ASSERT "Turn off all asserts" OFF)
-option (NO_USER_ERRORS "Turn off all user error checking (reckless)" OFF)
 option (RELEASE_O2 "Use O2 instead of O3 in release mode" OFF)
 option (ARTS_SANITIZE "Turn on undefined behavior sanitizers" OFF)
 
@@ -178,11 +177,6 @@ add_definitions (-DEIGEN_DONT_PARALLELIZE)
 if (NO_ASSERT)
   add_definitions (-DNDEBUG)
 endif (NO_ASSERT)
-
-if (NO_USER_ERRORS)
-  message(STATUS "Experimental reckless build enabled (-DNO_USER_ERRORS=0 to disable)")
-  add_definitions (-DNO_ARTS_USER_ERRORS)
-endif (NO_USER_ERRORS)
 
 ########### ccache Support ##########
 
@@ -372,11 +366,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Native")
     ARTS_ADD_COMPILER_FLAG (fcx-fortran-rules)
     ARTS_ADD_COMPILER_FLAG (DNDEBUG)
 endif ()
-
-if (NO_USER_ERRORS)
-  ARTS_ADD_COMPILER_FLAG (Wno-unused-parameter)
-  ARTS_ADD_COMPILER_FLAG (Wno-unused-variable)
-endif (NO_USER_ERRORS)
 
 if (WERROR)
   ARTS_ADD_COMPILER_FLAG (Werror)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ add_custom_target(UtilityHeadersArts SOURCES ${HEADERFILES})
 add_library(workspace_core STATIC
   workspace_agendas.cpp
   workspace_groups.cpp
+  workspace_group_friends.cpp
   workspace_variables.cpp
 )
 target_link_libraries(workspace_core PRIVATE arts_options)
@@ -159,7 +160,6 @@ add_library(artsworkspace STATIC
   workspace_method_class.cpp
   workspace_method_extra_doc.cpp
   workspace_class.cpp
-  workspace_group_friends.cpp
   m_abs.cc
   m_atm.cc
   m_atm_profile.cc

--- a/src/core/atm/atm_field.h
+++ b/src/core/atm/atm_field.h
@@ -451,6 +451,8 @@ struct std::formatter<Atm::Data> {
 
   template <class FmtContext>
   FmtContext::iterator format(const Atm::Data &v, FmtContext &ctx) const {
+    if (tags.short_str) return tags.format(ctx, v.data);
+
     const std::string_view sep = tags.sep();
     tags.add_if_bracket(ctx, '[');
     tags.format(ctx, v.data, sep);

--- a/src/core/options/arts_options.cc
+++ b/src/core/options/arts_options.cc
@@ -990,6 +990,7 @@ radiation).
                  "InterceptParameter",
                  "PSD intercept parameter in arbitary units."}},
   });
+
   opts.emplace_back(EnumeratedOption{
       .name = "SizeParameter",
       .desc =
@@ -1000,6 +1001,17 @@ radiation).
                           Value{"DVeq",
                                 "d_veq",
                                 "Volume-equivalent diameter in m"}},
+  });
+
+  opts.emplace_back(EnumeratedOption{
+      .name = "WorkspaceInitialization",
+      .desc = "A flag for how initialize a new workspace.\n",
+      .values_and_desc =
+          {Value{
+               "FromGlobalDefaults",
+               "Initialize from the global default workspace - these are the variables that have defaults."},
+           Value{"Empty",
+                 "Initialize an empty workspace - no variables are set."}},
   });
 
   fix_static(opts);

--- a/src/core/util/format_tags.h
+++ b/src/core/util/format_tags.h
@@ -81,7 +81,7 @@ struct format_tags {
 
   template <class FmtContext>
   void add_if_bracket(FmtContext& ctx, char x) const {
-    if (bracket) std::format_to(ctx.out(), "{}", x);
+    if (bracket) ctx.out() += x;
   }
 
   template <class FmtContext>

--- a/src/m_obsel.cc
+++ b/src/m_obsel.cc
@@ -57,7 +57,7 @@ void measurement_sensorAddVectorGaussian(ArrayOfSensorObsel& measurement_sensor,
   ARTS_USER_ERROR_IF(n != stds.size(),
                      "Must have a standard deviation for each frequency point")
   ARTS_USER_ERROR_IF(stdr::any_of(stds, Cmp::le(0)),
-                     "No negative standard deviation not allowed.\nstds := {:B,}", stds)
+                     "Standard deviation must be positive.\nstds := {:B,}", stds)
   ARTS_USER_ERROR_IF(nonzero == 0, "pol is 0")
 
   measurement_sensor.resize(sz + n);

--- a/src/m_obsel.cc
+++ b/src/m_obsel.cc
@@ -56,6 +56,8 @@ void measurement_sensorAddVectorGaussian(ArrayOfSensorObsel& measurement_sensor,
   ARTS_USER_ERROR_IF(n < 2, "Must have a frequency grid")
   ARTS_USER_ERROR_IF(n != stds.size(),
                      "Must have a standard deviation for each frequency point")
+  ARTS_USER_ERROR_IF(stdr::any_of(stds, Cmp::le(0)),
+                     "No negative standard deviation not allowed.\nstds := {:B,}", stds)
   ARTS_USER_ERROR_IF(nonzero == 0, "pol is 0")
 
   measurement_sensor.resize(sz + n);

--- a/src/make_auto_wsg.cpp
+++ b/src/make_auto_wsg.cpp
@@ -178,7 +178,7 @@ template <> {0}& Workspace::get_or<{0}>(const std::string& name) {{
 template <> {0}& Workspace::get<{0}>(const std::string& name) const try {{
   return wsv.at(name).get<{0}>();
 }} catch (std::out_of_range&) {{
-  throw std::runtime_error(std::format("Undefined workspace variable \"{{0}}\"", name));
+  throw std::runtime_error(std::format("Cannot get workspace variable \"{{0}}\" - it is not yet set on the workspace", name));
 }} catch (std::exception& e) {{
   throw std::runtime_error(std::format("Error getting workspace variable \"{{0}}\":\n{{1}}", name, std::string_view(e.what())));
 }}

--- a/src/make_auto_wsm.cpp
+++ b/src/make_auto_wsm.cpp
@@ -712,8 +712,8 @@ void various_checks_or_throw() {
       if (not is_workspace and not is_wsg and not is_wsg_friend) {
         errors.push_back(std::format(
             "Method {} has a return type.  Its return type \"{}\" is not void or Workspace, and it is not a workspace group (or friend of one).",
-            wsmr.return_type,
-            name));
+            name,
+            wsmr.return_type));
       }
 
       if (wsmr.return_desc.empty()) {

--- a/src/python_interface/gen_auto_py_helpers.cpp
+++ b/src/python_interface/gen_auto_py_helpers.cpp
@@ -373,6 +373,19 @@ String method_docs(const String& name) try {
                        optval);
   }
 
+  if (method.return_type != "void") {
+    out += std::format(
+        R"(
+Returns
+-------
+opt : {0}
+    {1})",
+        std::format("~pyarts3.arts.{}{}",
+                    method.return_type == "Workspace" ? "Cxx"sv : ""sv,
+                    method.return_type),
+        unwrap_stars(until_first_newline(method.return_desc)));
+  }
+
   fix();
 
   if (auto ptr = wsadoc.find(name); ptr != wsadoc.end()) {

--- a/src/python_interface/gen_auto_py_methods.cpp
+++ b/src/python_interface/gen_auto_py_methods.cpp
@@ -474,7 +474,7 @@ std::string method_resolution_simple(const std::string& name,
                                      const WorkspaceMethodInternalRecord& wsm) {
   std::ostringstream os;
 
-  os << "        " << name << "(";
+  os << "        return " << name << "(";
 
   bool any = false;
   if (wsm.pass_workspace) {
@@ -655,7 +655,7 @@ std::string method_argument_documentation(
 std::string method(const std::string& name,
                    const WorkspaceMethodInternalRecord& wsm) {
   return std::format(
-      R"-x-(  ws.def("{0}",[]({1}) -> void {{
+      R"-x-(  ws.def("{0}",[]({1}) -> {7} {{
     try {{
 {2}{3}
     }} catch (std::exception& e) {{
@@ -672,7 +672,8 @@ std::string method(const std::string& name,
       method_resolution(name, wsm),
       method_error(name, wsm),
       method_argument_documentation(wsm),
-      method_docs(name));
+      method_docs(name),
+    wsm.return_type);
 }
 
 void methods(int nfiles) {

--- a/src/workspace_agenda_class.h
+++ b/src/workspace_agenda_class.h
@@ -31,12 +31,9 @@ class Agenda {
   void finalize(bool fix = false);
 
   //! Copies the required workspace variables from the agenda
+  template<bool share_only>
   void copy_workspace(Workspace& out,
-                      const Workspace& in,
-                      bool share_only = false) const;
-
-  //! Copies the required workspace variables from the agenda
-  [[nodiscard]] Workspace copy_workspace(const Workspace& in) const;
+                      const Workspace& in) const;
 
   //! Executes the agenda without checks on the current workspace
   void execute(Workspace& ws) const;

--- a/src/workspace_agenda_class.h
+++ b/src/workspace_agenda_class.h
@@ -30,10 +30,14 @@ class Agenda {
   //! Must be called before named agendas, will deal with input and output variables for copy_workspace
   void finalize(bool fix = false);
 
-  //! Copies the required workspace variables from the agenda
-  template<bool share_only>
-  void copy_workspace(Workspace& out,
-                      const Workspace& in) const;
+  //! Copies the required workspace variables from the agenda (shares workspace variables not required to be copied)
+  void copy_workspace(Workspace& out, const Workspace& in) const;
+
+  //! Share the required workspace variables from the agenda
+  void share_workspace(Workspace& out, const Workspace& in) const;
+
+  //! Only copy the required workspace variables (ignores shared workspace variables)
+  void copy_only_workspace(Workspace& out, const Workspace& in) const;
 
   //! Executes the agenda without checks on the current workspace
   void execute(Workspace& ws) const;

--- a/src/workspace_class.cpp
+++ b/src/workspace_class.cpp
@@ -72,10 +72,6 @@ void Workspace::overwrite(const std::string& name, const Wsv& data) try {
       data.type_name()));
 }
 
-std::ostream& operator<<(std::ostream& os, const Workspace& ws) {
-  return os << std::format("{:s,}", ws);
-}
-
 bool Workspace::contains(const std::string& name) const {
   return wsv.contains(name);
 }
@@ -88,6 +84,8 @@ bool Workspace::wsv_and_contains(const std::string& name) const {
       name)
   return contains(name);
 }
+
+Size Workspace::erase(const std::string& name) { return wsv.erase(name); }
 
 void Workspace::init(const std::string& name) try {
   set(name, Wsv::from_named_type(workspace_variables().at(name).type));

--- a/src/workspace_class.cpp
+++ b/src/workspace_class.cpp
@@ -16,14 +16,11 @@ Workspace::Workspace(WorkspaceInitialization how_to_initialize) : wsv{} {
   }
 }
 
-Workspace::Workspace(std::unordered_map<std::string, Wsv> wsv)
-    : wsv(std::move(wsv)) {};
-
 const Wsv& Workspace::share(const std::string& name) const try {
   return wsv.at(name);
 } catch (std::out_of_range&) {
   throw std::runtime_error(
-      std::format("Undefined workspace variable \"{}\"", name));
+      std::format("Cannot share workspace variable \"{}\" - is not set", name));
 }
 
 Wsv Workspace::copy(const std::string& name) const {
@@ -90,8 +87,9 @@ Size Workspace::erase(const std::string& name) { return wsv.erase(name); }
 void Workspace::init(const std::string& name) try {
   set(name, Wsv::from_named_type(workspace_variables().at(name).type));
 } catch (std::out_of_range&) {
-  throw std::runtime_error(
-      std::format("Undefined workspace variable \"{}\"", name));
+  throw std::runtime_error(std::format(
+      "Cannot initialize workspace variable \"{}\" - it is not a workspace variable",
+      name));
 } catch (std::exception& e) {
   throw std::runtime_error(
       std::format("Error setting '{}'\n{}", name, e.what()));

--- a/src/workspace_class.h
+++ b/src/workspace_class.h
@@ -82,7 +82,8 @@ struct Workspace {
   //! As contains, but also checks if the variable is a workspace variable
   [[nodiscard]] bool wsv_and_contains(const std::string& name) const;
 
-  friend std::ostream& operator<<(std::ostream& os, const Workspace& ws);
+  //! Removes the workspace variable with the given name.
+  Size erase(const std::string& name);
 
   [[nodiscard]] auto begin() { return wsv.begin(); }
 

--- a/src/workspace_class.h
+++ b/src/workspace_class.h
@@ -1,20 +1,17 @@
 #pragma once
 
+#include <enumsWorkspaceInitialization.h>
 #include <format_tags.h>
 #include <wsv_value_wrapper.h>
 
 #include <memory>
 #include <unordered_map>
 
-enum class WorkspaceInitialization : bool { FromGlobalDefaults, Empty };
-
 struct Workspace {
   std::unordered_map<std::string, Wsv> wsv;
 
   Workspace(WorkspaceInitialization how_to_initialize =
                 WorkspaceInitialization::FromGlobalDefaults);
-
-  Workspace(std::unordered_map<std::string, Wsv>);
 
   //! Returns a shared pointer to the workspace variable with the given name.
   [[nodiscard]] const Wsv& share(const std::string& name) const;

--- a/src/workspace_methods.cpp
+++ b/src/workspace_methods.cpp
@@ -105,7 +105,7 @@ std::string WorkspaceMethodInternalRecord::header(const std::string& name,
   const auto& wsv = internal_workspace_variables();
   const auto& wsa = internal_workspace_agendas();
 
-  const std::string spaces(name.size() + 6, ' ');
+  const std::string spaces(name.size() + return_type.size() + 2, ' ');
 
   const auto overloads = generic_overloads();
   int GVAR             = 0;
@@ -116,7 +116,7 @@ std::string WorkspaceMethodInternalRecord::header(const std::string& name,
     doc += "template <WorkspaceGroup T>\n";
   }
 
-  doc += std::format("void {}(", name);
+  doc += std::format("{} {}(", return_type, name);
 
   bool first = true;
   if (pass_workspace) {
@@ -214,7 +214,7 @@ int WorkspaceMethodInternalRecord::count_overloads() const try {
 
 std::string WorkspaceMethodInternalRecord::call(const std::string& name) const
     try {
-  const std::string spaces(6, ' ');
+  const std::string spaces(return_type.size() + 2, ' ');
 
   std::string doc = std::format("  {}(\n      ", name);
 
@@ -281,10 +281,11 @@ Remove the manual definition of these methods from workspace_methods.cpp.
     input_op.push_back(agname + "_operator");
 
     wsm_data[agname + "Execute"] = {
-        .desc   = "Executes *" + agname + "*, see it for more details\n",
-        .author = {"``Automatically Generated``"},
-        .out    = ag.output,
-        .in     = input,
+        .desc        = "Executes *" + agname + "*, see it for more details\n",
+        .author      = {"``Automatically Generated``"},
+        .return_type = "Workspace",
+        .out         = ag.output,
+        .in          = input,
         .pass_workspace = true,
     };
 
@@ -874,7 +875,7 @@ returned as well.
       .gin = {"key"},
       .gin_type  = {"AtmKey"},
       .gin_value = {AtmKey::t},
-      .gin_desc  = {"Key to find the *GeodeticField3* in the atmospheric field"},
+      .gin_desc = {"Key to find the *GeodeticField3* in the atmospheric field"},
   };
 
   wsm_data["atmospheric_profileFitNonLTE"] = {
@@ -1928,7 +1929,7 @@ ice and supercooled water for atmospheric applications. Quarterly
 Journal of the Royal Meteorological Society, 131(608), 1539-1565.
 )--",
       .author    = {"Patrick Eriksson", "Richard Larsson"},
-      .out      = {"water_equivalent_pressure_operator"},
+      .out       = {"water_equivalent_pressure_operator"},
       .gin       = {"only_liquid"},
       .gin_type  = {"Index"},
       .gin_value = {Index{0}},
@@ -3226,7 +3227,8 @@ minor changes, like removing absorption lines outside of some frequency span.
   };
 
   wsm_data["absorption_bandsReadSplit"] = {
-      .desc      = R"--(Reads all xml-files in a given directory and puts them into *absorption_bands*.
+      .desc =
+          R"--(Reads all xml-files in a given directory and puts them into *absorption_bands*.
 
 .. note::
     The ``dir`` path has to be absolute or relative to the working path, the environment

--- a/src/workspace_methods.cpp
+++ b/src/workspace_methods.cpp
@@ -284,6 +284,7 @@ Remove the manual definition of these methods from workspace_methods.cpp.
         .desc        = "Executes *" + agname + "*, see it for more details\n",
         .author      = {"``Automatically Generated``"},
         .return_type = "Workspace",
+        .return_desc = "The internal workspace, cleaned from all input/output.",
         .out         = ag.output,
         .in          = input,
         .pass_workspace = true,

--- a/src/workspace_methods.cpp
+++ b/src/workspace_methods.cpp
@@ -112,6 +112,11 @@ std::string WorkspaceMethodInternalRecord::header(const std::string& name,
 
   std::string doc{};
 
+  if (name.size() > 7 and wsa.contains(name.substr(0, name.size() - 7)) and
+      name.substr(name.size() - 7) == "Execute") {
+    return doc;
+  }
+
   if (has_any()) {
     doc += "template <WorkspaceGroup T>\n";
   }
@@ -160,12 +165,6 @@ std::string WorkspaceMethodInternalRecord::header(const std::string& name,
     if (wsv_ptr != wsv.end()) {
       doc += std::format(
           "{}const {}& {}", comma(first, spaces), wsv_ptr->second.type, str);
-      continue;
-    }
-
-    auto wsa_ptr = wsa.find(str);
-    if (wsa_ptr != wsa.end()) {
-      doc += std::format("{}const Agenda& {}", comma(first, spaces), str);
       continue;
     }
 

--- a/src/workspace_methods.h
+++ b/src/workspace_methods.h
@@ -11,6 +11,7 @@ struct WorkspaceMethodInternalRecord {
   std::string desc;
   std::vector<std::string> author;
   std::string return_type{"void"};
+  std::string return_desc{};
   std::vector<std::string> out{};
   std::vector<std::string> gout{};
   std::vector<std::string> gout_type{};

--- a/src/workspace_methods.h
+++ b/src/workspace_methods.h
@@ -10,6 +10,7 @@
 struct WorkspaceMethodInternalRecord {
   std::string desc;
   std::vector<std::string> author;
+  std::string return_type{"void"};
   std::vector<std::string> out{};
   std::vector<std::string> gout{};
   std::vector<std::string> gout_type{};

--- a/tests/python/retval/test_returns.py
+++ b/tests/python/retval/test_returns.py
@@ -1,0 +1,18 @@
+import pyarts3 as pyarts
+import numpy as np
+
+
+ws = pyarts.Workspace()
+
+ws.atmospheric_fieldInit(toa=100e3)
+ws.surface_fieldEarth()
+ws.ray_path_observer_agendaSetGeometric()
+
+ws2 = ws.ray_path_observer_agendaExecute(
+  spectral_radiance_observer_position = [300e3, 0, 0],
+  spectral_radiance_observer_line_of_sight = [180.0, 0.0]
+)
+
+ws2.atmospheric_field["t"] = 123.4
+
+assert ws.atmospheric_field["t"].data == 123.4, "Shared data not working"


### PR DESCRIPTION
This is a small change that allows returning values from a workspace method.  I wanted to introspect the workspace created by an agenda.

The only supported methods so far are the agenda execute methods, which now returns the workspace that it creates locally to execute the agenda.  This workspace is first cleaned from proper temporaries to not cause segfaults.  The returned workspace contains all locally created variables as well as all shared and copied values from the original workspace.  Note that this is proper sharing, so changing a value on the new workspace will affect the original - use with care.

The way to use this is to add .return_type and .return_desc to the workspace method.  This should be practically free for types such as Vector and Workspace since they can be moved out of the function (so their destruction is just delayed in case you are not using the return value, which is not a problem).  Please ensure your type follows NRVO when using this so that there is no overhead.

You can also optionally pass a workspace to the agenda execute method now that is used instead of the locally created workspace.  Using this is very complicated and only available in C++, but my tests show the overhead of the agenda methods dropped from 4microns to about 2.5 microns (though this is so small I suspect it might be noise).

Some bugs got seen in the process of adding this so they are now removed.