### PR TITLE
[ARTS-2.6] Update macOS Intel CI runner

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -57,7 +57,7 @@ jobs:
             jcheck: 2
 
           - name: mac-default-clang
-            os: macos-13
+            os: macos-15-intel
             preset: default-clang-conda
             check: "yes"
             doc: "no"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -56,7 +56,7 @@ jobs:
             jbuild: 4
             jcheck: 2
 
-          - name: mac-default-clang
+          - name: macintel-default-clang
             os: macos-15-intel
             preset: default-clang-conda
             check: "yes"
@@ -65,7 +65,7 @@ jobs:
             jbuild: 4
             jcheck: 2
 
-          - name: macm1-default-clang
+          - name: mac-default-clang
             os: macos-14
             preset: default-clang-conda
             check: "yes"
@@ -74,7 +74,7 @@ jobs:
             jbuild: 2
             jcheck: 2
 
-          - name: macm1-debug-clang
+          - name: mac-debug-clang
             os: macos-14
             preset: debug-clang-conda
             check: "yes"


### PR DESCRIPTION
macos-13 runner will be retired, see https://github.com/actions/runner-images/issues/13046