### PR TITLE
Use removesuffix instead of rstrip to remove fileextensions

### DIFF
--- a/python/doc/gen_examples.py
+++ b/python/doc/gen_examples.py
@@ -64,9 +64,9 @@ class rst:
 
 def pyrst(str):
     if str.endswith(".py"):
-        stem = str.rstrip(".py")
+        stem = str.removesuffix(".py")
     elif str.endswith(".rst"):
-        stem = str.rstrip(".rst")
+        stem = str.removesuffix(".rst")
     return stem + ".py", stem + ".rst"
 
 
@@ -144,7 +144,7 @@ def from_list(lst, path, save_path, with_plots):
 
         if len(files) > 1 and rstf != INTROFILE:
             heading = title_to_heading(
-                rstf.rstrip(".rst") if rstf else py.rstrip(".py")
+                rstf.removesuffix(".rst") if rstf else py.removesuffix(".py")
             )
             out += f"{heading}\n{'-' * len(heading)}\n\n"
 


### PR DESCRIPTION
`rstrip` has unintended side effects as it doesn't just match the whole string, but all characters in the string. Fixes missing `t` in `Clearsky flux from datase` title.