### PR TITLE
Update boost dependency

### DIFF
--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -1,6 +1,5 @@
 dependencies:
         - binutils
-        - boost
         - ccache
         - clang
         - clangxx
@@ -17,6 +16,7 @@ dependencies:
         - gxx
         - ipykernel
         - lark-parser
+        - libboost-devel
         - libclang
         - libcxx
         - libcxx-devel

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -1,5 +1,4 @@
 dependencies:
-        - boost
         - ccache
         - clang
         - clangxx
@@ -14,6 +13,7 @@ dependencies:
         - ipykernel
         - lark-parser
         - ld64
+        - libboost-devel
         - libclang
         - libcxx
         - libcxx-devel

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -1,5 +1,4 @@
 dependencies:
-        - boost
         - make
         - cmake
         - docutils
@@ -8,6 +7,7 @@ dependencies:
         - fftw
         - ipykernel
         - lark-parser
+        - libboost-devel
         - libcxx
         - llvm-openmp < 21
         - matplotlib


### PR DESCRIPTION
The boost meta package is not available anymore in conda-forge, breaking creation of environments with Python 3.14. Depend on libboost-devel instead.