### PR TITLE
Flatten the absorption species

### DIFF
--- a/examples/2-clearsky-radiative-transfer/1-simple-outgoing-radiance/1-clearsky_upwelling_lw_radiance_at_toa.nolgpl.py
+++ b/examples/2-clearsky-radiative-transfer/1-simple-outgoing-radiance/1-clearsky_upwelling_lw_radiance_at_toa.nolgpl.py
@@ -25,10 +25,10 @@ ws.frequency_grid = pa.arts.convert.kaycm2freq(kayser_grid)  # in Hz
 # This example uses a reduced set of species to speed up the calculation.
 # Use the second line for a more realistic setup.
 ws.absorption_speciesSet(
-    species=["H2O-161, H2O-ForeignContCKDMT400, H2O-SelfContCKDMT400", "CO2-626"]
+    species=["H2O-161", "H2O-ForeignContCKDMT400", "H2O-SelfContCKDMT400", "CO2-626"]
 )
 # ws.absorption_speciesSet(
-#     species=["H2O, H2O-ForeignContCKDMT400, H2O-SelfContCKDMT400", "CO2", "O3"]
+#     species=["H2O", "H2O-ForeignContCKDMT400", "H2O-SelfContCKDMT400", "CO2", "O3"]
 # )
 
 # Read spectral line data from ARTS catalog

--- a/python/src/pyarts3/data.py
+++ b/python/src/pyarts3/data.py
@@ -315,7 +315,7 @@ def to_atmospheric_field(
 
 def to_absorption_species(
     atm_field: pyarts.arts.AtmField,
-) -> pyarts.arts.ArrayOfArrayOfSpeciesTag:
+) -> pyarts.arts.ArrayOfSpeciesTag:
     """Scans the ARTS data path for species relevant to the given atmospheric field.
 
     The scan is done over files in an arts-cat-data like directory structure.
@@ -324,7 +324,7 @@ def to_absorption_species(
         atm_field (pyarts3.arts.AtmField): A relevant atmospheric field.
 
     Returns:
-        pyarts3.arts.ArrayOfArrayOfSpeciesTag: All found species tags.
+        pyarts3.arts.ArrayOfSpeciesTag: All found species tags.
         The intent is that this is enough information to use pyarts3.Workspace.ReadCatalogData
     """
     species = atm_field.species_keys()
@@ -352,7 +352,7 @@ def to_absorption_species(
         elif spec == pyarts.arts.SpeciesEnum.CarbonDioxide:
             out.append("CO2-CKDMT252")
 
-    return pyarts.arts.ArrayOfArrayOfSpeciesTag(np.unique(out))
+    return pyarts.arts.ArrayOfSpeciesTag(np.unique(out))
 
 
 def xarray_open_dataset(filename_or_obj, *args, **kwargs):

--- a/python/test/plots/test_plots.py
+++ b/python/test/plots/test_plots.py
@@ -3,31 +3,33 @@ from os.path import join, dirname
 import matplotlib.pyplot as plt
 import pyarts3.xml as axml
 from pyarts3.plots import plot_arts_lookup
-from pyarts3.arts import ArrayOfArrayOfSpeciesTag, SpeciesTag
+from pyarts3.arts import ArrayOfSpeciesTag, SpeciesTag
 
 
 class TestPlots:
     """Testing the ARTS plotting functions."""
+
     def test_plot_lookup(self):
         lookup_file = join(dirname(__file__), 'reference',
                            'abs_lookup_small.xml')
         fig, ax = plot_arts_lookup(axml.load(lookup_file))
-        
+
         fig.suptitle('Lookup table opacities')
         fig.subplots_adjust(top=0.88)
         plt.savefig("lookup_opacities.pdf")
-        
+
         lookup_file = join(dirname(__file__), 'reference',
                            'abs_lookup_small.xml')
         fig, ax = plot_arts_lookup(
             axml.load(lookup_file),
-            species=ArrayOfArrayOfSpeciesTag([[SpeciesTag("N2O")],
-                                              [SpeciesTag("O3")]]),
+            species=ArrayOfSpeciesTag([[SpeciesTag("N2O")],
+                                       [SpeciesTag("O3")]]),
             opacity=False)
-        
+
         fig.suptitle('Lookup table absorption cross sections [m$^2$]')
         fig.subplots_adjust(top=0.88)
         plt.savefig("lookup_crosssections.pdf")
+
 
 if __name__ == "__main__":
     x = TestPlots()

--- a/python/test/workspace/test_groups.py
+++ b/python/test/workspace/test_groups.py
@@ -101,13 +101,13 @@ class TestGroups:
     def testArrayOfAtmPoint(self):
         x = cxx.ArrayOfAtmPoint.from_dict({"t": [1, 2, 3], "O2": [0, 1, 2]})
         assert x[0]["t"] == 1
-        
+
         y = x.to_dict()
-        
+
         y["p"] = 5 + y[cxx.AtmKey.t]
         y[cxx.AtmKey.t] += 2
         x.update(y)
-        
+
         assert x[1]["t"] == 4
 
     def testArrayOfAbsorptionLines(self):
@@ -242,16 +242,6 @@ class TestGroups:
     def testArrayOfArrayOfSingleScatteringData(self):
         x = cxx.ArrayOfArrayOfSingleScatteringData()
         test.io(x, delete=True)
-
-    def testArrayOfArrayOfSpeciesTag(self):
-        x = cxx.ArrayOfArrayOfSpeciesTag(["H2O,H2O-PWR98"])
-
-        test.io(x, delete=True)
-        test.array(x)
-        test.array_of_array(x)
-
-        x = cxx.ArrayOfArrayOfSpeciesTag(["H2O", "H2O-PWR98"])
-        assert len(x) == 2
 
     def testArrayOfArrayOfString(self):
         x = cxx.ArrayOfArrayOfString([["OI"]])

--- a/python/test/workspace/test_methods.py
+++ b/python/test/workspace/test_methods.py
@@ -35,15 +35,15 @@ class TestMethods:
         """
         ws = self.ws
         species = [
-            "H2O-SelfContStandardType, H2O-ForeignContStandardType, " "H2O",
+            "H2O-SelfContStandardType", "H2O-ForeignContStandardType", "H2O",
             "N2-SelfContStandardType",
             "O3",
         ]
-        
+
         ws.absorption_speciesSet(ws.absorption_species, species)
-        ws.absorption_species_2 = pyarts.arts.ArrayOfArrayOfSpeciesTag()
+        ws.absorption_species_2 = pyarts.arts.ArrayOfSpeciesTag()
         ws.absorption_speciesSet(ws.absorption_species_2, species)
-        ws.absorption_species_3 = pyarts.arts.ArrayOfArrayOfSpeciesTag()
+        ws.absorption_species_3 = pyarts.arts.ArrayOfSpeciesTag()
         ws.absorption_speciesSet(
             absorption_species=ws.absorption_species_3, species=species
         )

--- a/src/core/spec/species_tags.h
+++ b/src/core/spec/species_tags.h
@@ -49,115 +49,15 @@ struct Tag {
 };
 }  // namespace Species
 
-using SpeciesTag = Species::Tag;
-
-class ArrayOfSpeciesTag final : public Array<SpeciesTag> {
- public:
-  ArrayOfSpeciesTag() noexcept : Array<SpeciesTag>() {}
-  explicit ArrayOfSpeciesTag(Index n) : Array<SpeciesTag>(n) {}
-  ArrayOfSpeciesTag(Index n, const SpeciesTag& fillvalue)
-      : Array<SpeciesTag>(n, fillvalue) {}
-  ArrayOfSpeciesTag(const ArrayOfSpeciesTag& A) = default;
-  ArrayOfSpeciesTag(ArrayOfSpeciesTag&& A) noexcept
-      : Array<SpeciesTag>(std::move(A)) {}
-  explicit ArrayOfSpeciesTag(std::vector<SpeciesTag> x)
-      : Array<SpeciesTag>(std::move(x)) {}
-
-  // Assignment operators:
-  ArrayOfSpeciesTag& operator=(SpeciesTag x);
-
-  ArrayOfSpeciesTag& operator=(const ArrayOfSpeciesTag& A);
-
-  ArrayOfSpeciesTag& operator=(ArrayOfSpeciesTag&& A) noexcept;
-
-  [[nodiscard]] bool operator==(const ArrayOfSpeciesTag& x) const;
-
-  ArrayOfSpeciesTag(std::string_view text);
-
-  /*! Returns the species of the first elements, it is not allowed to have an empty list calling this */
-  [[nodiscard]] SpeciesEnum Species() const;
-
-  //   /*! Returns the species of the first elements, it is not allowed to have an empty list calling this */
-  [[nodiscard]] SpeciesTagType Type() const;
-
-  [[nodiscard]] String Name() const;
-
-  [[nodiscard]] bool Plain() const noexcept;
-
-  [[nodiscard]] bool RequireLines() const noexcept;
-
-  [[nodiscard]] bool FreeElectrons() const noexcept;
-
-  [[nodiscard]] bool Particles() const noexcept;
-};
-
+using SpeciesTag               = Species::Tag;
+using ArrayOfSpeciesTag        = Array<SpeciesTag>;
 using ArrayOfArrayOfSpeciesTag = Array<ArrayOfSpeciesTag>;
 
 //! Struct to test of an ArrayOfArrayOfSpeciesTag contains a Speciestagtype
 struct SpeciesTagTypeStatus {
   bool Plain{false}, Predefined{false}, Cia{false}, XsecFit{false};
-  SpeciesTagTypeStatus(const ArrayOfArrayOfSpeciesTag& abs_species);
+  SpeciesTagTypeStatus(const ArrayOfSpeciesTag& abs_species);
 };
-
-/*! Find the next species of this type inclusively after the start index
- * 
- * @param[in] abs_species As WSV
- * @param[in] spec A Species
- * @param[in] i The starting index in the outermost 
- * @return An index larger or equal to i pointing to the next species, or -1 if there's no next species
- */
-Index find_next_species(const ArrayOfArrayOfSpeciesTag& abs_species,
-                        SpeciesEnum spec,
-                        Index i) noexcept;
-
-/*! Find the first species of this type
- * 
- * @param[in] abs_species As WSV
- * @param[in] spec A Species
- * @return An index larger or equal to 0 pointing to the first species, or -1 if there's no such species
- */
-Index find_first_species(const ArrayOfArrayOfSpeciesTag& abs_species,
-                         SpeciesEnum spec) noexcept;
-
-/*! Find the first species tag of this type
- * 
- * @param[in] abs_species As WSV
- * @param[in] tag A Species tag
- * @return [i, j] so that abs_species[i][j] is tag, or [-1, -1] if there's no such thing
- */
-std::pair<Index, Index> find_first_species_tag(
-    const ArrayOfArrayOfSpeciesTag& abs_species,
-    const SpeciesTag& tag) noexcept;
-
-/*! Find the first species tag of this type
- * 
- * @param[in] abs_species As WSV
- * @param[in] isot An isotopologue record
- * @return [i, j] so that abs_species[i][j] is the same isotopologue record as isot, or [-1, -1] if there's no such thing
- */
-std::pair<Index, Index> find_first_isotologue(
-    const ArrayOfArrayOfSpeciesTag& abs_species,
-    const SpeciesIsotope& isot) noexcept;
-
-/*! Find species that requires line-by-line calculations
- * 
- * @param abs_species  As WSV
- * @return The set of unique species that requires line-by-line calculations
- */
-std::set<SpeciesEnum> lbl_species(const ArrayOfArrayOfSpeciesTag&) noexcept;
-
-namespace Species {
-/** Parse a list of species tags into an Array<Tag>
- *
- * This is the function call that ArrayOfSpeciesTag uses
- * to create itself from a string_view, but it also performs
- * vital error checking necessary for ARTS internals
- *
- * @param text A textual representation of comma-separated species tags
- * @return Array<Tag> List of species tags with no constraints
- */
-Array<Tag> parse_tags(std::string_view text);
-}  // namespace Species
 
 namespace std {
 //! Allow SpeciesTag to be used in hashes
@@ -171,20 +71,6 @@ struct hash<SpeciesTag> {
     boost::hash_combine(seed, std::hash<SpeciesEnum>{}(g.cia_2nd_species));
 
     return seed;
-  }
-};
-
-//! Allow ArrayOfSpeciesTag to be used in hashes
-template <>
-struct hash<ArrayOfSpeciesTag> {
-  std::size_t operator()(const ArrayOfSpeciesTag& g) const {
-    std::size_t out = 0;
-    std::size_t i   = 1;
-    for (auto& a : g) {
-      out ^= (std::hash<SpeciesTag>{}(a) << i);
-      i++;
-    }
-    return out;
   }
 };
 }  // namespace std
@@ -225,10 +111,6 @@ struct std::formatter<SpeciesTag> {
 };
 
 template <>
-struct std::formatter<ArrayOfSpeciesTag>
-    : std::formatter<std::vector<SpeciesTag>> {};
-
-template <>
 struct xml_io_stream<SpeciesTag> {
   static constexpr std::string_view type_name = "SpeciesTag"sv;
 
@@ -238,18 +120,4 @@ struct xml_io_stream<SpeciesTag> {
                     std::string_view name = ""sv);
 
   static void read(std::istream& is, SpeciesTag& x, bifstream* pbifs = nullptr);
-};
-
-template <>
-struct xml_io_stream<ArrayOfSpeciesTag> {
-  static constexpr std::string_view type_name = "ArrayOfSpeciesTag"sv;
-
-  static void write(std::ostream& os,
-                    const ArrayOfSpeciesTag& x,
-                    bofstream* pbofs      = nullptr,
-                    std::string_view name = ""sv);
-
-  static void read(std::istream& is,
-                   ArrayOfSpeciesTag& x,
-                   bifstream* pbifs = nullptr);
 };

--- a/src/m_atm.cc
+++ b/src/m_atm.cc
@@ -138,11 +138,11 @@ void keysNLTE(std::unordered_map<QuantumLevelIdentifier, Index> &keys,
 }
 
 void keysSpecies(std::unordered_map<SpeciesEnum, Index> &keys,
-                 const ArrayOfArrayOfSpeciesTag &absorption_species) {
+                 const ArrayOfSpeciesTag &absorption_species) {
   if (absorption_species.empty()) return;
 
   for (auto &species_tags : absorption_species) {
-    if (species_tags.Species() != "AIR"_spec) ++keys[species_tags.Species()];
+    if (species_tags.Spec() != "AIR"_spec) ++keys[species_tags.Spec()];
   }
 }
 
@@ -357,7 +357,7 @@ void atmospheric_fieldAppendLineLevelData(
 
 void atmospheric_fieldAppendTagsSpeciesData(
     AtmField &atmospheric_field,
-    const ArrayOfArrayOfSpeciesTag &absorption_species,
+    const ArrayOfSpeciesTag &absorption_species,
     const String &basename,
     const String &extrapolation,
     const Index &missing_is_zero,
@@ -577,7 +577,7 @@ void atmospheric_fieldAppendAuto(const Workspace &ws,
 
   if (const String species_str = "absorption_species";
       ws.wsv_and_contains(species_str)) {
-    using aospec_t                 = ArrayOfArrayOfSpeciesTag;
+    using aospec_t                 = ArrayOfSpeciesTag;
     const auto &absorption_species = ws.get<aospec_t>(species_str);
     atmospheric_fieldAppendTagsSpeciesData(atmospheric_field,
                                            absorption_species,

--- a/src/m_cat.cc
+++ b/src/m_cat.cc
@@ -5,7 +5,7 @@ void ReadCatalogData(PredefinedModelData& absorption_predefined_model_data,
                      ArrayOfXsecRecord& absorption_xsec_fit_data,
                      ArrayOfCIARecord& absorption_cia_data,
                      AbsorptionBands& absorption_bands,
-                     const ArrayOfArrayOfSpeciesTag& absorption_species,
+                     const ArrayOfSpeciesTag& absorption_species,
                      const String& basename,
                      const Index& ignore_missing) try {
   ARTS_TIME_REPORT

--- a/src/m_lbl.cc
+++ b/src/m_lbl.cc
@@ -106,7 +106,7 @@ ARTS_METHOD_ERROR_CATCH
 
 void absorption_bandsReadSpeciesSplitCatalog(
     AbsorptionBands& absorption_bands,
-    const ArrayOfArrayOfSpeciesTag& absorbtion_species,
+    const ArrayOfSpeciesTag& absorbtion_species,
     const String& basename,
     const Index& ignore_missing_) try {
   ARTS_TIME_REPORT
@@ -118,18 +118,16 @@ void absorption_bandsReadSpeciesSplitCatalog(
   const String my_base = complete_basename(basename);
 
   std::set<SpeciesIsotope> isotopologues;
-  for (auto& specs : absorbtion_species) {
-    for (auto& spec : specs) {
-      if (spec.type == SpeciesTagType::Plain) {
-        if (spec.is_joker()) {
-          for (auto&& isot : Species::isotopologues(spec.Spec())) {
-            if (isot.is_predefined()) continue;
-            if (isot.is_joker()) continue;
-            isotopologues.insert(isot);
-          }
-        } else {
-          isotopologues.insert(spec.Isotopologue());
+  for (auto& spec : absorbtion_species) {
+    if (spec.type == SpeciesTagType::Plain) {
+      if (spec.is_joker()) {
+        for (auto&& isot : Species::isotopologues(spec.Spec())) {
+          if (isot.is_predefined()) continue;
+          if (isot.is_joker()) continue;
+          isotopologues.insert(isot);
         }
+      } else {
+        isotopologues.insert(spec.Isotopologue());
       }
     }
   }
@@ -507,7 +505,7 @@ ARTS_METHOD_ERROR_CATCH
 
 void absorption_bandsReadSpeciesSplitARTSCAT(
     AbsorptionBands& absorption_bands,
-    const ArrayOfArrayOfSpeciesTag& absorbtion_species,
+    const ArrayOfSpeciesTag& absorbtion_species,
     const String& basename,
     const Index& ignore_missing_,
     const Index& pure_species_) try {
@@ -526,11 +524,9 @@ void absorption_bandsReadSpeciesSplitARTSCAT(
 
   if (pure_species) {
     std::set<SpeciesEnum> specieses;
-    for (auto& specs : absorbtion_species) {
-      for (auto& spec : specs) {
-        if (spec.type == SpeciesTagType::Plain) {
-          specieses.insert(spec.Spec());
-        }
+    for (auto& spec : absorbtion_species) {
+      if (spec.type == SpeciesTagType::Plain) {
+        specieses.insert(spec.Spec());
       }
     }
 
@@ -546,18 +542,16 @@ void absorption_bandsReadSpeciesSplitARTSCAT(
     }
   } else {
     std::set<SpeciesIsotope> isotopologues;
-    for (auto& specs : absorbtion_species) {
-      for (auto& spec : specs) {
-        if (spec.type == SpeciesTagType::Plain) {
-          if (spec.is_joker()) {
-            for (auto&& isot : Species::isotopologues(spec.Spec())) {
-              if (isot.is_predefined()) continue;
-              if (isot.is_joker()) continue;
-              isotopologues.insert(isot);
-            }
-          } else {
-            isotopologues.insert(spec.Isotopologue());
+    for (auto& spec : absorbtion_species) {
+      if (spec.type == SpeciesTagType::Plain) {
+        if (spec.is_joker()) {
+          for (auto&& isot : Species::isotopologues(spec.Spec())) {
+            if (isot.is_predefined()) continue;
+            if (isot.is_joker()) continue;
+            isotopologues.insert(isot);
           }
+        } else {
+          isotopologues.insert(spec.Isotopologue());
         }
       }
     }

--- a/src/m_predefined_absorption_models.cc
+++ b/src/m_predefined_absorption_models.cc
@@ -22,7 +22,7 @@
 
 void absorption_predefined_model_dataReadSpeciesSplitCatalog(
     PredefinedModelData& absorption_predefined_model_data,
-    const ArrayOfArrayOfSpeciesTag& absorption_species,
+    const ArrayOfSpeciesTag& absorption_species,
     const String& basename,
     const Index& name_missing_,
     const Index& ignore_missing_) try {
@@ -40,23 +40,21 @@ void absorption_predefined_model_dataReadSpeciesSplitCatalog(
     tmpbasename += '.';
   }
 
-  for (auto& specs : absorption_species) {
-    for (auto& spec : specs) {
-      if (not spec.Isotopologue().is_predefined()) continue;
+  for (auto& spec : absorption_species) {
+    if (not spec.Isotopologue().is_predefined()) continue;
 
-      String filename = tmpbasename + spec.Isotopologue().FullName() + ".xml";
+    String filename = tmpbasename + spec.Isotopologue().FullName() + ".xml";
 
-      if (find_xml_file_existence(filename)) {
-        PredefinedModelData other;
-        xml_read_from_file(filename, other);
-        absorption_predefined_model_data.insert(other.begin(), other.end());
+    if (find_xml_file_existence(filename)) {
+      PredefinedModelData other;
+      xml_read_from_file(filename, other);
+      absorption_predefined_model_data.insert(other.begin(), other.end());
+    } else {
+      if (name_missing) {
+        absorption_predefined_model_data[spec.Isotopologue()].data =
+            Absorption::PredefinedModel::ModelName{};
       } else {
-        if (name_missing) {
-          absorption_predefined_model_data[spec.Isotopologue()].data =
-              Absorption::PredefinedModel::ModelName{};
-        } else {
-          ARTS_USER_ERROR_IF(not ignore_missing, "File {} not found", filename)
-        }
+        ARTS_USER_ERROR_IF(not ignore_missing, "File {} not found", filename)
       }
     }
   }

--- a/src/m_spectral_radiance.cc
+++ b/src/m_spectral_radiance.cc
@@ -395,16 +395,17 @@ void single_radiance_jacobianAddPathPropagation(
 
   const Size np  = ray_path.size();
   const Index nt = jacobian_targets.target_count();
+  const Index nx = jacobian_targets.x_size();
 
   ARTS_USER_ERROR_IF(
-      single_radiance_jacobian.ncols() != nt or
+      single_radiance_jacobian.ncols() != nx or
           ray_path_single_radiance_jacobian.nrows() != static_cast<Index>(np) or
           ray_path_single_radiance_jacobian.ncols() != nt,
       R"(Not same sizes:
 
 ray_path:                            (np)     = [{}]
 jacobian_targets:                    (nq)     = [{}]
-single_radiance_jacobian:            (nq)     = {:B,}
+single_radiance_jacobian:            (nx)     = {:B,}
 ray_path_single_radiance_jacobian:   (np, nq) = {:B,}
 )",
       np,

--- a/src/m_xsec_fit.cc
+++ b/src/m_xsec_fit.cc
@@ -17,7 +17,7 @@
 /* Workspace method: Doxygen documentation will be auto-generated */
 void absorption_xsec_fit_dataReadSpeciesSplitCatalog(
     ArrayOfXsecRecord& absorption_xsec_fit_data,
-    const ArrayOfArrayOfSpeciesTag& abs_species,
+    const ArrayOfSpeciesTag& abs_species,
     const String& basename,
     const Index& ignore_missing_) try {
   ARTS_TIME_REPORT
@@ -28,11 +28,9 @@ void absorption_xsec_fit_dataReadSpeciesSplitCatalog(
 
   // Build a set of species indices. Duplicates are ignored.
   std::set<SpeciesEnum> unique_species;
-  for (auto& asp : abs_species) {
-    for (auto& sp : asp) {
-      if (sp.Type() == SpeciesTagType::XsecFit) {
-        unique_species.insert(sp.Spec());
-      }
+  for (auto& sp : abs_species) {
+    if (sp.Type() == SpeciesTagType::XsecFit) {
+      unique_species.insert(sp.Spec());
     }
   }
 

--- a/src/python_interface/hpy_vector.h
+++ b/src/python_interface/hpy_vector.h
@@ -14,7 +14,6 @@
 
 NB_MAKE_OPAQUE(Array<lagrange_interp::lag_t<-1, lagrange_interp::identity>>);
 NB_MAKE_OPAQUE(Array<lagrange_interp::lag_t<-1, lagrange_interp::loncross>>);
-NB_MAKE_OPAQUE(Array<Array<SpeciesTag>>);
 NB_MAKE_OPAQUE(std::unordered_map<std::string, Wsv>);
 NB_MAKE_OPAQUE(QuantumLevel);
 NB_MAKE_OPAQUE(QuantumState);

--- a/src/python_interface/py_predefined.cpp
+++ b/src/python_interface/py_predefined.cpp
@@ -947,27 +947,24 @@ void py_predefined(py::module_& m) try {
   generic_interface(pdmd);
   pdmd.def_static(
           "fromcatalog",
-          [](const char* const basename,
-             const ArrayOfArrayOfSpeciesTag& specs) {
+          [](const char* const basename, const ArrayOfSpeciesTag& specs) {
             auto out = PredefinedModelData{};
-            for (auto& spec : specs) {
-              for (auto& mod : spec) {
-                if (mod.type == SpeciesTagType::Predefined) {
-                  String filename = (std::filesystem::path(basename) /
-                                     (mod.Isotopologue().FullName() + ".xml"))
-                                        .string();
-                  if (find_xml_file_existence(filename)) {
-                    PredefinedModelData data;
-                    xml_read_from_file(filename, data);
-                    std::visit(
-                        [&](auto& model) {
-                          out[mod.Isotopologue()].data = model;
-                        },
-                        data.at(mod.Isotopologue()).data);
-                  } else {
-                    out[mod.Isotopologue()].data =
-                        Absorption::PredefinedModel::ModelName{};
-                  }
+            for (auto& mod : specs) {
+              if (mod.type == SpeciesTagType::Predefined) {
+                String filename = (std::filesystem::path(basename) /
+                                   (mod.Isotopologue().FullName() + ".xml"))
+                                      .string();
+                if (find_xml_file_existence(filename)) {
+                  PredefinedModelData data;
+                  xml_read_from_file(filename, data);
+                  std::visit(
+                      [&](auto& model) {
+                        out[mod.Isotopologue()].data = model;
+                      },
+                      data.at(mod.Isotopologue()).data);
+                } else {
+                  out[mod.Isotopologue()].data =
+                      Absorption::PredefinedModel::ModelName{};
                 }
               }
             }

--- a/src/python_interface/py_species.cpp
+++ b/src/python_interface/py_species.cpp
@@ -237,121 +237,12 @@ Returns
   //////////////////////////////////////////////////////////////////////
 
   auto tmp1_ =
-      py::bind_vector<Array<SpeciesTag>, py::rv_policy::reference_internal>(
-          m, "_ArrayOfSpeciesTag");
+      py::bind_vector<ArrayOfSpeciesTag, py::rv_policy::reference_internal>(
+          m, "ArrayOfSpeciesTag");
   vector_interface(tmp1_);
   generic_interface(tmp1_);
 
   //////////////////////////////////////////////////////////////////////
-
-  py::class_<ArrayOfSpeciesTag> astag(m, "ArrayOfSpeciesTag");
-  generic_interface(astag);
-  astag.def(py::init_implicit<std::string>())
-      .def(py::init_implicit<Array<SpeciesTag>>())
-      .def(
-          "_inner",
-          [](ArrayOfSpeciesTag& s) -> Array<SpeciesTag>& { return s; },
-          py::rv_policy::reference_internal)
-      .def("__len__",
-           [](py::object& s) { return s.attr("_inner")().attr("__len__")(); })
-      .def("__getitem__",
-           [](py::object& s, py::object i) {
-             return s.attr("_inner")().attr("__getitem__")(i);
-           })
-      .def("__setitem__",
-           [](py::object& s, py::object i, py::object v) {
-             s.attr("_inner")().attr("__setitem__")(i, v);
-           })
-      .def(
-          "append",
-          [](py::object& s, py::object v) {
-            s.attr("_inner")().attr("append")(v);
-          },
-          "value"_a,
-          "Appends a value to the end of the list")
-      .def(
-          "pop",
-          [](py::object& s, py::object i) {
-            return s.attr("_inner")().attr("pop")(i);
-          },
-          "i"_a = -1,
-          "Pops an element from the list")
-      .def(py::self == py::self)
-      .def(py::self != py::self)
-      .def(
-          "__hash__",
-          [](const ArrayOfSpeciesTag& x) {
-            return std::hash<ArrayOfSpeciesTag>{}(x);
-          },
-          "Allows hashing")
-      .def(
-          "__getstate",
-          [](const ArrayOfSpeciesTag& x) {
-            return std::make_tuple(std::vector<SpeciesTag>(x.begin(), x.end()));
-          })
-      .def("__setstate__",
-           [](ArrayOfSpeciesTag* x,
-              const std::tuple<std::vector<SpeciesTag>>& v) {
-             new (x) ArrayOfSpeciesTag(std::get<0>(v));
-           })
-      .def("__init__", [](ArrayOfSpeciesTag* s, py::list l) {
-        auto x = py::cast<Array<SpeciesTag>>(l);
-        new (s) ArrayOfSpeciesTag();
-        for (auto& e : x) {
-          s->push_back(e);
-        }
-      });
-  py::implicitly_convertible<py::list, ArrayOfSpeciesTag>();
-
-  //////////////////////////////////////////////////////////////////////
-
-  auto tmp2_ = py::bind_vector<Array<Array<SpeciesTag>>,
-                               py::rv_policy::reference_internal>(
-      m, "_ArrayOfArrayOfSpeciesTag");
-  vector_interface(tmp2_);
-  generic_interface(tmp2_);
-
-  //////////////////////////////////////////////////////////////////////
-
-  auto b1 = py::bind_vector<ArrayOfArrayOfSpeciesTag,
-                            py::rv_policy::reference_internal>(
-      m, "ArrayOfArrayOfSpeciesTag");
-  generic_interface(b1);
-  vector_interface(b1);
-  b1.def("__init__",
-         [](ArrayOfArrayOfSpeciesTag* s, const Array<Array<SpeciesTag>>& x) {
-           new (s) ArrayOfArrayOfSpeciesTag(x.size());
-           for (auto& v : x) {
-             s->emplace_back();
-             for (auto& e : v) {
-               s->back().push_back(e);
-             }
-           }
-         });
-  b1.def_static(
-      "all_isotopologues",
-      []() {
-        ArrayOfArrayOfSpeciesTag out;
-        for (auto& x : Species::Isotopologues) {
-          if (not x.is_normal()) continue;
-          out.emplace_back(Array<SpeciesTag>{SpeciesTag(x)});
-        }
-        return out;
-      },
-      "Return a list of all species tags");
-  py::implicitly_convertible<Array<Array<SpeciesTag>>,
-                             ArrayOfArrayOfSpeciesTag>();
-  b1.def("__init__", [](ArrayOfArrayOfSpeciesTag* s, py::list l) {
-    auto x = py::cast<Array<Array<SpeciesTag>>>(l);
-    new (s) ArrayOfArrayOfSpeciesTag(x.size());
-    for (auto& v : x) {
-      s->emplace_back();
-      for (auto& e : v) {
-        s->back().push_back(e);
-      }
-    }
-  });
-  py::implicitly_convertible<py::list, ArrayOfArrayOfSpeciesTag>();
 
   auto sev = py::bind_map<SpeciesEnumVectors>(m, "SpeciesEnumVectors");
   generic_interface(sev);

--- a/src/tests/test_species_tags.cc
+++ b/src/tests/test_species_tags.cc
@@ -8,10 +8,8 @@
 int main(int argc, char** argv) try {
   ARTS_USER_ERROR_IF(argc not_eq 2, "Call as {} SPECIES_STRING", argv[0]);
 
-  const ArrayOfSpeciesTag tags(argv[1]);
-  for (auto& x : tags) {
-    std::println("{} {} {}", x, x.Isotopologue(), x.type);
-  }
+  const SpeciesTag x(argv[1]);
+  std::println("{} {} {}", x, x.Isotopologue(), x.type);
 
   return EXIT_SUCCESS;
 } catch (std::runtime_error& e) {

--- a/src/workspace_group_friends.cpp
+++ b/src/workspace_group_friends.cpp
@@ -10,7 +10,7 @@ namespace {
 std::unordered_map<std::string, WorkspaceGroupRecord> group_friends_internal() {
   std::unordered_map<std::string, WorkspaceGroupRecord> wsg_data;
 
-wsg_data["Block"] = {
+  wsg_data["Block"] = {
       .file = "covariance_matrix.h",
       .desc =
           R"(This holds a *BlockMatrix* and two *Range* objects and two indices to indicate the position in the *CovarianceMatrix*.
@@ -168,13 +168,11 @@ The python mapping allows treating this as a same rank :class:`~numpy.ndarray` i
 )",
   };
 
-  wsg_data["Tensor7"] = {
-      .file = "matpack.h",
-      .desc = R"(A 7 dimensional array of *Numeric*.
+  wsg_data["Tensor7"] = {.file = "matpack.h",
+                         .desc = R"(A 7 dimensional array of *Numeric*.
 
 The python mapping allows treating this as a same rank :class:`~numpy.ndarray` in python.
-)"
-  };
+)"};
 
   wsg_data["SurfacePoint"] = {
       .file = "surf.h",
@@ -253,7 +251,8 @@ so that reading routines can find the correct data files.
 
   wsg_data["Range"] = {
       .file = "matpack.h",
-      .desc = R"(A data type to index a contiguous range inside the multidimensional structures; e.g., *Vector*, *Matrix*, etc.
+      .desc =
+          R"(A data type to index a contiguous range inside the multidimensional structures; e.g., *Vector*, *Matrix*, etc.
 )",
   };
 
@@ -267,7 +266,6 @@ This includes:
 #. *InterpolationExtrapolation* flags indicating how to extrapolate the data field in its interpolation routine.
 )",
   };
-
 
   wsg_data["SubsurfaceData"] = {
       .file = "subsurface.h",
@@ -623,7 +621,6 @@ The types are *AscendingGrid* x *LatGrid* x *LonGrid*.  The grids are all sorted
                     "Tensor7",
                     "SubsurfacePoint",
                     "StokvecTensor3",
-                    "SpeciesTag",
                     "SpeciesIsotope",
                     "Sparse",
                     "NamedGriddedField2",

--- a/src/workspace_groups.cpp
+++ b/src/workspace_groups.cpp
@@ -249,7 +249,7 @@ Both the data and the grid may be named.  The grids are not sorted.
       .desc = R"(A 2 dimensional array of *Numeric*.
 
 The python mapping allows treating this as a same rank :class:`~numpy.ndarray` in python.
-)"
+)",
   };
 
   wsg_data["Numeric"] = {
@@ -403,7 +403,7 @@ The python mapping allows treating this 4-long :class:`~numpy.ndarray` in python
       .desc = R"(A vector of *Propmat*.
 
 The python mapping allows treating this as a 2-dimensional :class:`~numpy.ndarray` with size 7 as columns.
-)"
+)",
   };
 
   wsg_data["MuelmatVector"] = {
@@ -411,7 +411,7 @@ The python mapping allows treating this as a 2-dimensional :class:`~numpy.ndarra
       .desc = R"(A vector of *Muelmat*.
 
 The python mapping allows treating this as a 3-dimensional :class:`~numpy.ndarray` with size 4x4 as rows and columns.
-)"
+)",
   };
 
   wsg_data["MuelmatMatrix"] = {
@@ -419,7 +419,7 @@ The python mapping allows treating this as a 3-dimensional :class:`~numpy.ndarra
       .desc = R"(A matrix of *Muelmat*..
 
 The python mapping allows treating this as a 4-dimensional :class:`~numpy.ndarray` with size 4x4 as rows and columns.
-)"
+)",
   };
 
   wsg_data["StokvecVector"] = {
@@ -427,7 +427,7 @@ The python mapping allows treating this as a 4-dimensional :class:`~numpy.ndarra
       .desc = R"(A vector of *Stokvec*.
 
 The python mapping allows treating this as a 2-dimensional :class:`~numpy.ndarray` with size 4 as columns.
-)"
+)",
   };
 
   wsg_data["PropmatMatrix"] = {
@@ -435,7 +435,7 @@ The python mapping allows treating this as a 2-dimensional :class:`~numpy.ndarra
       .desc = R"(A matrix of *Propmat*.
 
 The python mapping allows treating this as a 3-dimensional :class:`~numpy.ndarray` with size 7 as columns.
-)"
+)",
   };
 
   wsg_data["SpecmatMatrix"] = {
@@ -862,7 +862,7 @@ of this term multiplied by a negative distance.
                 {
                     "AtmPoint",
                     "SensorObsel",
-                    "ArrayOfSpeciesTag",
+                    "SpeciesTag",
                     "CIARecord",
                     "SpeciesEnum",
                     "QuantumLevelIdentifier",

--- a/src/workspace_variables.cpp
+++ b/src/workspace_variables.cpp
@@ -77,7 +77,7 @@ to load the correct data.
 It is only used to let data-reading methods know which
 species they should read from the available input files.
 )--",
-      .type = "ArrayOfArrayOfSpeciesTag",
+      .type = "ArrayOfSpeciesTag",
   };
 
   wsv_data["altitude"] = {
@@ -1165,7 +1165,8 @@ Dimensions: [ ray_path.size() ]
   };
 
   wsv_data["ray_path_single_propagation_matrix_nonlte_jacobian"] = {
-      .desc = R"(The propagation matrix Jacobian along the path for nonlte source.
+      .desc =
+          R"(The propagation matrix Jacobian along the path for nonlte source.
 
 Dimensions: [ ray_path.size() x jacobian_targets.target_size() ]
 )",
@@ -1181,7 +1182,8 @@ See *propagation_matrix* for more information.
   };
 
   wsv_data["propagation_matrix_single_jacobian"] = {
-      .desc = R"--(A single propagation matrix Jacobian at a single *frequency* point.
+      .desc =
+          R"--(A single propagation matrix Jacobian at a single *frequency* point.
 
 See *propagation_matrix_jacobian* for more information.
 
@@ -1199,7 +1201,8 @@ See *propagation_matrix* for more information.
   };
 
   wsv_data["propagation_matrix_single_source_vector_nonlte_jacobian"] = {
-      .desc = R"--(A single non-LTE source vector Jacobian at a single *frequency* point.
+      .desc =
+          R"--(A single non-LTE source vector Jacobian at a single *frequency* point.
 
 See *propagation_matrix_jacobian* for more information.
 
@@ -1239,9 +1242,10 @@ Size is number of Jacobian targets.
   };
 
   wsv_data["max_stepsize"] = {
-      .desc = R"--(A control parameter for stepping through layers in ray tracing.
+      .desc =
+          R"--(A control parameter for stepping through layers in ray tracing.
 )--",
-      .type = "Numeric",
+      .type          = "Numeric",
       .default_value = "1000.0",
   };
 

--- a/tests/python/can-reference-into-array-into-method.py
+++ b/tests/python/can-reference-into-array-into-method.py
@@ -14,12 +14,11 @@ specs = pyarts.arts.ArrayOfArrayOfString([["O2"]])
 
 ws.absorption_speciesSet(species=specs[0])
 
-x = pyarts.arts.ArrayOfArrayOfSpeciesTag()
-
+x = pyarts.arts.ArrayOfSpeciesTag()
 ws.absorption_speciesSet(x, species=specs[0])
 
 assert x == ws.absorption_species
 
-x[0] = ["H2O"]
+x = pyarts.arts.ArrayOfSpeciesTag(["H2O"])
 
 assert x != ws.absorption_species


### PR DESCRIPTION
This makes absorption species a flat list.  It is an array of an array in ARTS2 because the shape matters.  There is no reason to keep this in ARTS3 and risks confusion.