### PR TITLE
Remove mac-intel build from CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -51,16 +51,6 @@ jobs:
             jbuild: 4
             jcheck: 2
 
-          - name: macintel-default-clang
-            os: macos-15-intel
-            preset: default-clang-conda
-            pyarts: "yes"
-            check: "yes"
-            doc: "no"
-            devenv: "environment-dev-mac.yml"
-            jbuild: 4
-            jcheck: 2
-
           - name: mac-default-clang
             os: macos-15
             preset: default-clang-conda


### PR DESCRIPTION
Mac Intel CI runners have recently degraded significantly in performance which makes the builds taking way too much time.