### PR TITLE
Add sqrt(propmat) method and expm1() method

### DIFF
--- a/doc/arts/concept.radiative_transfer.rst
+++ b/doc/arts/concept.radiative_transfer.rst
@@ -241,3 +241,74 @@ The expression in the grid of :math:`\vec{x}` is then the following:
 where the last term is 0 for all but :math:`i=N` and :math:`i=N-1`
 and where the function :math:`f` is defined as
 the map from :math:`\vec{x}_i\rightarrow\vec{x}`.
+
+Potential improvements
+**********************
+
+Note that here, the indexing is not the same as above as
+it is experimental notation.  This section exists mostly
+as a reminder that we are using constant source and constant
+propagation matrix above.  If these are allowed to change
+within a layer, the equations below offers some approach to
+achieving it.
+
+.. note::
+
+  These are untested and not how ARTS compute things,
+  they are left as a future exercise so that we can
+  implement them later.  Just the concept, for instance,
+  of a Dawson function of a matrix is questionable.
+
+Potential 1
+^^^^^^^^^^^
+
+Linear in
+:math:`J = J_0 + (J_1 - J_0) \frac{r}{r_1}`:
+
+.. math::
+  I_1 = T_0 I_0 -
+  \left[\left(\log T_0\right)^{-1}\left(1 - T_0\right) + T_0\right]J_0 +
+  \left[1 + \left(\log T_0\right)^{-1}\left(1 - T_0\right)\right]J_1.
+
+or
+
+.. math::
+  I_1 = J_1 + T_0    \left(I_0 - J_0\right) -
+  \frac{1}{r} K^{-1} \left(1   - T_0\right) \left(J_1 - J_0\right).
+
+This is a classical solution to the radiative transfer equation to improve
+numerical stability when the propagation matrix :math:`K` is
+large.
+
+Potential 2
+^^^^^^^^^^^
+
+Linear in
+:math:`J = J_0 + (J_1 - J_0) \frac{r}{r_1}`
+and linear in
+:math:`K = K_0 + (K_1 - K_0) \frac{r}{r_1}`.
+Let
+:math:`\Delta J = J_1 - J_0` and
+:math:`\Delta K = K_1 - K_0`:
+
+.. math::
+  I_1 = J_1 + T_0 (I_0 - J_0) -
+  \sqrt{2r(\Delta K)^{-1}} \Bigl[ D_+(u_1) -
+  T_0 D_+(u_0) \Bigr] \Delta J
+
+where :math:`D_+(x)` is the Dawson function and:
+
+.. math::
+  u_0 = K_0 \sqrt{\frac{r}{2\Delta K}}, \quad
+  u_1 = u_0 + \sqrt{\frac{r \Delta K}{2}}
+
+This formulation has a problem: there is no clear solution
+to the Dawson function or to the square root at this time for
+propagation matrices.  Even if it were possible, the numerical
+stability would be questionable.  And the physical interpretation
+is also not straightforward, as an integral over a matrix is...
+questionable.
+
+Polarization is difficult to maintain here.  To my knowledge,
+the above formulation might not even tested for unpolarized radiative
+transfer.

--- a/src/core/rtepack/rtepack_propagation_matrix.h
+++ b/src/core/rtepack/rtepack_propagation_matrix.h
@@ -35,7 +35,9 @@ struct propmat final : vec7 {
   [[nodiscard]] constexpr decltype(auto) W() { return data[6]; }
 
   //! Check if the matrix is purely rotational
-  [[nodiscard]] constexpr bool is_rotational() const { return A() == 0.0; }
+  [[nodiscard]] constexpr bool is_rotational() const {
+    return A() == 0.0 and B() == 0.0 and C() == 0.0 and D() == 0.0;
+  }
 
   //! Check if the matrix is polarized
   [[nodiscard]] constexpr bool is_polarized() const {

--- a/src/core/rtepack/rtepack_spectral_matrix.h
+++ b/src/core/rtepack/rtepack_spectral_matrix.h
@@ -160,49 +160,47 @@ constexpr specmat avg(specmat a, const specmat &b) {
   return a;
 }
 
+constexpr Complex det(const specmat &A) {
+  const auto [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p] = A;
+
+  return a * (f * (k * p - l * o) + g * (l * n - j * p) + h * (j * o - k * n)) +
+         b * (e * (l * o - k * p) + g * (i * p - l * m) + h * (k * m - i * o)) +
+         c * (e * (j * p - l * n) + f * (l * m - i * p) + h * (i * n - j * m)) +
+         d * (e * (k * n - j * o) + f * (i * o - k * m) + g * (j * m - i * n));
+}
+
+constexpr Complex tr(const specmat &A) {
+  return A[0, 0] + A[1, 1] + A[2, 2] + A[3, 3];
+}
+
+constexpr Complex midtr(const specmat &A) {
+  return {std::midpoint(std::midpoint(A[0, 0].real(), A[1, 1].real()),
+                        std::midpoint(A[2, 2].real(), A[3, 3].real())),
+          std::midpoint(std::midpoint(A[0, 0].imag(), A[1, 1].imag()),
+                        std::midpoint(A[2, 2].imag(), A[3, 3].imag()))};
+}
+
 constexpr specmat inv(const specmat &A) {
   const auto [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p] = A;
 
-  const Complex div =
-      1.0 / (a * f * k * p - a * f * l * o - a * g * j * p + a * g * l * n +
-             a * h * j * o - a * h * k * n - b * e * k * p + b * e * l * o +
-             b * g * i * p - b * g * l * m - b * h * i * o + b * h * k * m +
-             c * e * j * p - c * e * l * n - c * f * i * p + c * f * l * m +
-             c * h * i * n - c * h * j * m - d * e * j * o + d * e * k * n +
-             d * f * i * o - d * f * k * m - d * g * i * n + d * g * j * m);
-
-  return div * specmat{(f * k * p - f * l * o - g * j * p + g * l * n +
-                        h * j * o - h * k * n),
-                       (-b * k * p + b * l * o + c * j * p - c * l * n -
-                        d * j * o + d * k * n),
-                       (b * g * p - b * h * o - c * f * p + c * h * n +
-                        d * f * o - d * g * n),
-                       (-b * g * l + b * h * k + c * f * l - c * h * j -
-                        d * f * k + d * g * j),
-                       (-e * k * p + e * l * o + g * i * p - g * l * m -
-                        h * i * o + h * k * m),
-                       (a * k * p - a * l * o - c * i * p + c * l * m +
-                        d * i * o - d * k * m),
-                       (-a * g * p + a * h * o + c * e * p - c * h * m -
-                        d * e * o + d * g * m),
-                       (a * g * l - a * h * k - c * e * l + c * h * i +
-                        d * e * k - d * g * i),
-                       (e * j * p - e * l * n - f * i * p + f * l * m +
-                        h * i * n - h * j * m),
-                       (-a * j * p + a * l * n + b * i * p - b * l * m -
-                        d * i * n + d * j * m),
-                       (a * f * p - a * h * n - b * e * p + b * h * m +
-                        d * e * n - d * f * m),
-                       (-a * f * l + a * h * j + b * e * l - b * h * i -
-                        d * e * j + d * f * i),
-                       (-e * j * o + e * k * n + f * i * o - f * k * m -
-                        g * i * n + g * j * m),
-                       (a * j * o - a * k * n - b * i * o + b * k * m +
-                        c * i * n - c * j * m),
-                       (-a * f * o + a * g * n + b * e * o - b * g * m -
-                        c * e * n + c * f * m),
-                       (a * f * k - a * g * j - b * e * k + b * g * i +
-                        c * e * j - c * f * i)};
+  return specmat{
+             f * (k * p - l * o) + g * (l * n - j * p) + h * (j * o - k * n),
+             b * (l * o - k * p) + c * (j * p - l * n) + d * (k * n - j * o),
+             b * (g * p - h * o) + c * (h * n - f * p) + d * (f * o - g * n),
+             b * (h * k - g * l) + c * (f * l - h * j) + d * (g * j - f * k),
+             e * (l * o - k * p) + g * (i * p - l * m) + h * (k * m - i * o),
+             a * (k * p - l * o) + c * (l * m - i * p) + d * (i * o - k * m),
+             a * (h * o - g * p) + c * (e * p - h * m) + d * (g * m - e * o),
+             a * (g * l - h * k) + c * (h * i - e * l) + d * (e * k - g * i),
+             e * (j * p - l * n) + f * (l * m - i * p) + h * (i * n - j * m),
+             a * (l * n - j * p) + b * (i * p - l * m) + d * (j * m - i * n),
+             a * (f * p - h * n) + b * (h * m - e * p) + d * (e * n - f * m),
+             a * (h * j - f * l) + b * (e * l - h * i) + d * (f * i - e * j),
+             e * (k * n - j * o) + f * (i * o - k * m) + g * (j * m - i * n),
+             a * (j * o - k * n) + b * (k * m - i * o) + c * (i * n - j * m),
+             a * (g * n - f * o) + b * (e * o - g * m) + c * (f * m - e * n),
+             a * (f * k - g * j) + b * (g * i - e * k) + c * (e * j - f * i)} /
+         det(A);
 }
 
 using specmat_vector            = matpack::data_t<specmat, 1>;

--- a/src/core/rtepack/rtepack_transmission.h
+++ b/src/core/rtepack/rtepack_transmission.h
@@ -2,6 +2,7 @@
 
 #include "rtepack_mueller_matrix.h"
 #include "rtepack_propagation_matrix.h"
+#include "rtepack_spectral_matrix.h"
 
 namespace rtepack {
 struct tran {
@@ -18,7 +19,8 @@ struct tran {
 
   tran(const propmat &k1, const propmat &k2, const Numeric r);
 
-  muelmat operator()() const noexcept;
+  [[nodiscard]] muelmat operator()() const noexcept;
+  [[nodiscard]] muelmat expm1() const noexcept;
 
   [[nodiscard]] muelmat deriv(const muelmat &t,
                               const propmat &k1,
@@ -42,6 +44,8 @@ void two_level_exp(muelmat &t,
 muelmat exp(propmat k, Numeric r = 1.0);
 
 propmat logK(const muelmat& m);
+
+specmat sqrt(const propmat& pm);
 
 void two_level_exp(muelmat_vector_view t,
                    const propmat_vector_const_view &k1,

--- a/src/python_interface/py_rtepack.cpp
+++ b/src/python_interface/py_rtepack.cpp
@@ -505,7 +505,8 @@ void py_rtepack(py::module_ &m) try {
   auto rp = m.def_submodule("rtepack");
   auto tr = py::class_<rtepack::tran>(rp, "tran");
   generic_interface(tr);
-  tr.doc() = "Class for computing the transmission Mueller matrix and its derivative";
+  tr.doc() =
+      "Class for computing the transmission Mueller matrix and its derivative";
   tr.def(py::init<Propmat, Propmat, Numeric>(), "k1"_a, "k2"_a, "r"_a)
       .def("__call__", &rtepack::tran::operator(), "Returns the Mueller matrix")
       .def("deriv",
@@ -516,11 +517,36 @@ void py_rtepack(py::module_ &m) try {
            "dk"_a,
            "r"_a,
            "dr"_a,
-           "Returns the derivative of the Mueller matrix");
-  rp.def("logK",
-         &rtepack::logK,
-         "m"_a,
-         R"(Returns the logarithm of the Mueller matrix as a Propagation matrix
+           "Returns the derivative of the Mueller matrix")
+      .def("expm1",
+           &rtepack::tran::expm1,
+           "Returns the Mueller matrix minus the identity matrix");
+  rp.def(
+        "sqrt",
+        &rtepack::sqrt,
+        "K"_a,
+        R"(Returns the square root of the Propagation matrix as a spectral matrix
+
+.. math::
+    \mathrm{K} = \mathrm{S} \mathrm{S},
+
+The return value of this method is the spectral matrix :math:`\mathrm{S}`.
+
+Parameters
+----------
+K : Specmat
+    The propagation matrix
+
+Returns
+-------
+Specmat
+    The square root of the Propagation matrix as a spectral matrix.
+)")
+      .def(
+          "logK",
+          &rtepack::logK,
+          "m"_a,
+          R"(Returns the logarithm of the Mueller matrix as a Propagation matrix
 
 This only works for a Mueller matrix that has been generated from a Propagation matrix using
 

--- a/tests/python/math/logK.py
+++ b/tests/python/math/logK.py
@@ -79,3 +79,13 @@ for i in range(10):
         pass
 
 assert made_it, "logK tests failed after 10 attempts"
+
+
+print("UNTESTED BECAUSE BAD RESULTS, JUST NOT NAN")
+for i in range(7):
+    K = pyarts.arts.Propmat([0, 0, 0, 0, 0, 0, 0])
+    K[i] = 2
+    expK = tra(K, K, 1.0)()
+
+    logK = ln(expK)
+    assert not np.isnan(logK.sum())

--- a/tests/python/math/sqrtK.py
+++ b/tests/python/math/sqrtK.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pyarts3 as pyarts
+import scipy as sp
+
+
+for i in range(1000):
+    K = pyarts.arts.Propmat(np.random.normal(0.0, 10.0, size=7))
+
+    rK = sp.linalg.sqrtm(K.as_matrix())
+    rKp = pyarts.arts.rtepack.sqrt(K)
+
+    assert np.allclose(rKp, rK)
+    assert np.allclose(rKp @ rKp, K.as_matrix())
+
+for i in range(7):
+    K = pyarts.arts.Propmat([0, 0, 0, 0, 0, 0, 0])
+    K[i] = 2
+
+    rK = sp.linalg.sqrtm(K.as_matrix())
+    rKp = pyarts.arts.rtepack.sqrt(K)
+
+    assert np.allclose(rKp, rK)
+    assert np.allclose(rKp @ rKp, K.as_matrix())


### PR DESCRIPTION
This adds expm1() to the tran class to compute (exp(-Kr) - 1) more accurately, and sqrt(K) to rtepack.

The main reasons are for being able to do some updates in the future the the step-by-step RT equation.

The code helps things like

linear in tau:

$$
  I_1 = J_1 + T_0    \left(I_0 - J_0\right) -
  \frac{1}{r} K^{-1} \left(1   - T_0\right) \left(J_1 - J_0\right).
$$

and linear in tau and k:

$$
  I_1 = J_1 + T_0 (I_0 - J_0) -
  \sqrt{2r(\Delta K)^{-1}} \Bigl[ D_+(u_1) -
  T_0 D_+(u_0) \Bigr] \Delta J,
$$

where the deltas are the change between levels.  I am not sure yet how well these apply to polarized RT but need the basic maths in place to test it.  Especially the latter is difficult as there are no Dawson functions for matrices, so it seems difficult to use.