### PR TITLE
make is required on a linux gcc build because of shtns being on by de…

### DIFF
--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -15,9 +15,10 @@ dependencies:
         - lark-parser
         - libboost-devel
         - libopenblas=*=*openmp*
+        - make
+        - matplotlib
         - nanobind=2.9
         - nbsphinx
-        - matplotlib
         - netcdf4
         - ninja
         - numpy>=2


### PR DESCRIPTION
…fault