### PR TITLE
Fix arts_omp_parallel condition

### DIFF
--- a/src/core/util/arts_omp.cc
+++ b/src/core/util/arts_omp.cc
@@ -14,6 +14,7 @@
 */
 
 #include "arts_omp.h"
+#include <limits>
 
 //! Wrapper for omp_get_max_threads.
 /*! 
@@ -126,7 +127,8 @@ bool arts_omp_parallel(unsigned long long n [[maybe_unused]],
 #ifdef _OPENMP
   return additional_condition and not arts_omp_in_parallel() and
          arts_omp_get_max_threads() > 1 and
-         arts_omp_get_max_threads() < static_cast<int>(n);
+         (n == std::numeric_limits<unsigned long long>::max() or
+          arts_omp_get_max_threads() < static_cast<int>(n));
 #else
   return false;
 #endif

--- a/src/m_rad.cc
+++ b/src/m_rad.cc
@@ -403,7 +403,7 @@ void high_performance(
   std::string error{};
 
   //! Dynamic scheduling as some simulations may take much longer time than others
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for schedule(dynamic) if (arts_omp_parallel(-1, N > 1))
   for (Size i = 0; i < N; i++) {
     try {
       const Size ip          = simulations[i].iposlos;
@@ -441,7 +441,7 @@ void high_performance(
 
   ARTS_USER_ERROR_IF(not error.empty(), "Errors occurred:\n{:}", error);
 
-#pragma omp parallel for schedule(dynamic)
+#pragma omp parallel for schedule(dynamic) if (arts_omp_parallel(-1, M > 1))
   for (Size iv = 0; iv < M; ++iv) {
     const SensorObsel &obsel = measurement_sensor[iv];
 


### PR DESCRIPTION
When n = -1 (passed as unsigned long long) to `arts_omp_parallel`, it becomes ULLONG_MAX. The comparison `arts_omp_get_max_threads() < static_cast<int>(n)` evaluates `static_cast<int>(ULLONG_MAX)`, which truncates to -1 on most platforms. Since max_threads < -1 is always false, parallelisation is always disabled if n = -1 is passed and lnot the indented behavior.

[Example on godbolt](https://godbolt.org/z/9Peo4Ydo3)
