### PR TITLE
Generate sitemap for better SEO

### DIFF
--- a/environment-dev-linux-clang.yml
+++ b/environment-dev-linux-clang.yml
@@ -37,6 +37,7 @@ dependencies:
         - sphinx-copybutton
         - sphinx-favicon
         - sphinx-rtd-theme=3
+        - sphinx-sitemap
         - sphinxcontrib-jquery
         - sphinxcontrib-bibtex
         - tqdm

--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -31,6 +31,7 @@ dependencies:
         - sphinx-copybutton
         - sphinx-favicon
         - sphinx-rtd-theme=3
+        - sphinx-sitemap
         - sphinxcontrib-jquery
         - sphinxcontrib-bibtex
         - tqdm

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -34,6 +34,7 @@ dependencies:
         - sphinx-copybutton
         - sphinx-favicon
         - sphinx-rtd-theme=3
+        - sphinx-sitemap
         - sphinxcontrib-jquery
         - sphinxcontrib-bibtex
         - tqdm

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -26,6 +26,7 @@ dependencies:
         - sphinx-copybutton
         - sphinx-favicon
         - sphinx-rtd-theme=3
+        - sphinx-sitemap
         - sphinxcontrib-jquery
         - sphinxcontrib-bibtex
         - tqdm

--- a/python/doc/source/conf.py
+++ b/python/doc/source/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx_copybutton',
     'sphinx_favicon',
+    'sphinx_sitemap',
     'matplotlib.sphinxext.plot_directive',
     'nbsphinx',
     'sphinx.ext.graphviz',
@@ -358,3 +359,6 @@ graphviz_output_format = 'svg'
 bibtex_bibfiles = ['j_full.bib', 'references.bib']
 bibtex_default_style = 'plain'
 
+# Sitemap configuration
+html_baseurl = 'https://atmtools.github.io/arts-docs-master/'
+sitemap_url_scheme = "{link}"


### PR DESCRIPTION
Hopefully pursues search engines to index all docs, not just the front page. `sitemap.xml` is also linked in the top-level `robots.txt` on https://atmtools.github.io/

If you're building locally, you need to `mamba install sphinx-sitemap`.