### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/arts_ci.yml
+++ b/.github/workflows/arts_ci.yml
@@ -16,7 +16,7 @@ jobs:
           echo "Test testdata server access:"
           curl -o /dev/null --no-progress-meter https://arts.mi.uni-hamburg.de/svn/rt/arts-xml-data/trunk/planets/Earth/afgl/readme.txt && echo "OK" || echo "FAIL"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 10
 
@@ -29,7 +29,7 @@ jobs:
           python3 testdata/get_testdata.py testdata/cat_data_files.txt build/testdata
 
       - name: Upload testdata artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testdata
           path: build/

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -92,12 +92,12 @@ jobs:
             jcheck: 2
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 10
 
       - name: Download testdata artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: testdata
           path: ./build
@@ -116,7 +116,7 @@ jobs:
         if : runner.os == 'Windows'
         with:
           arch: x64
-      - uses: conda-incubator/setup-miniconda@v3
+      - uses: conda-incubator/setup-miniconda@v4
         with:
           miniforge-version: latest
           conda-remove-defaults: "true"
@@ -180,14 +180,14 @@ jobs:
           echo "Build size:"
           du -hs .
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: matrix.doc == 'yes'
         with:
           name: docs-doxygen
           path: |
             doxygen.tar.gz
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: matrix.doc == 'yes'
         with:
           name: docs-sphinx


### PR DESCRIPTION
Bumps the GitHub Actions used in CI workflows to their current major versions:

| Action | Old | New |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `conda-incubator/setup-miniconda` | v3 | v4 |

**Files changed:**
- `.github/workflows/arts_ci.yml`
- `.github/workflows/build-test.yml`

**Motivation:**
Stay current with upstream releases to pick up bug fixes, performance improvements, and to avoid future deprecation warnings.
