### PR TITLE
ci: update GitHub Actions runners to macOS 26 and Windows 2025-VS2026

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -82,7 +82,7 @@ jobs:
             jcheck: 2
 
           - name: windows-default-msvc
-            os: windows-2025
+            os: windows-2025-vs2026
             preset: default-msvc-conda
             pyarts: "yes"
             check: "yes"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -62,7 +62,7 @@ jobs:
             jcheck: 2
 
           - name: mac-default-clang
-            os: macos-15
+            os: macos-26
             preset: default-clang-conda
             pyarts: "yes"
             check: "yes"
@@ -72,7 +72,7 @@ jobs:
             jcheck: 2
 
           - name: mac-reldeb-clang
-            os: macos-15
+            os: macos-26
             preset: reldeb-clang-conda
             pyarts: "yes"
             check: "yes"


### PR DESCRIPTION
This PR updates the CI configuration to use the latest GitHub-hosted runner images. The macOS runners are upgraded to `macos-26`, and the Windows runner is updated to use the new `windows-2025-vs2026` image with MSVC 19.50 (upgraded from 19.44). [GitHub will start migration](https://github.blog/changelog/2026-02-05-github-actions-early-february-2026-updates/#windows-server-2025-with-visual-studio-2026-image-now-available-for-github-hosted-runners) of the `windows-2025` runner to this image in June.