### PR TITLE
[ARTS-2.6] fix: correct Wigner-3j m-index ordering in reduced_rovibrational_dipole

### DIFF
--- a/src/absorptionlines.cc
+++ b/src/absorptionlines.cc
@@ -1902,8 +1902,8 @@ Numeric Absorption::Lines::SelfVMR(
 Numeric Absorption::reduced_rovibrational_dipole(
     Rational Jf, Rational Ji, Rational lf, Rational li, Rational k) {
   if (not iseven(Jf + lf + 1))
-    return -sqrt(2 * Jf + 1) * wigner3j(Jf, k, Ji, li, lf - li, -lf);
-  return +sqrt(2 * Jf + 1) * wigner3j(Jf, k, Ji, li, lf - li, -lf);
+    return -sqrt(2 * Jf + 1) * wigner3j(Jf, k, Ji, lf, li - lf, -li);
+  return +sqrt(2 * Jf + 1) * wigner3j(Jf, k, Ji, lf, li - lf, -li);
 }
 
 Numeric Absorption::reduced_magnetic_quadrapole(Rational Jf,


### PR DESCRIPTION
This PR fixes a sign and magnitude error in the `reduced_rovibrational_dipole` function that produced wrong-sign and inflated first-order Rosenkranz Y coefficients for HITRAN CO2 line-mixing hot bands. The rigid-rotor dipole was computed with the incorrect Wigner-3j magnetic-index ordering (`li, lf-li, -lf` instead of `lf, li-lf, -li`), causing the relaxation-matrix sum-rule correction in `calcw` to be corrupted. The fundamental band (li=0) was largely unaffected because both orderings nearly agree, but hot bands (li=1,2,3) at low J saw magnitudes differ by factors of 2–6x.

### Changes
- `src/absorptionlines.cc`: Corrected the `wigner3j` arguments in `Absorption::reduced_rovibrational_dipole` to use the proper m-index ordering (`lf, li-lf, -li`), aligning the computed `Dipo0` with the values stored in HITRAN line-mixing band data files and the Lamouroux `LM_calc_CO2.for` reference to ~2e-8 across all P/Q/R lines.

Before/after comparison with script from #1130:
| ν (cm⁻¹) | Lamouroux Y/atm | ARTS Y/atm (fixed) | ARTS Y/atm (before) |
|----------|-----------------|--------------------|---------------------|
| 664.6265 | +0.00901 | +0.00888 | −0.00379 |
| 665.4140 | +0.02184 | +0.02160 | −0.08779 |
| 664.9896 | +0.00511 | +0.00503 | −0.11254 |
| 664.5586 | −0.00343 | −0.00376 | −0.12738 |

### Breaking Changes
⚠️ None for API consumers. However, line-mixing absorption results for CO2 hot bands (e.g., the 4.3 µm and 15 µm hot bands) will change numerically compared to prior versions — users comparing against old outputs should expect differences. These new values are the physically correct ones. Fixes #1130.