### PR TITLE
fix: correct Wigner 3j argument order in reduced_dipole

### DIFF
--- a/environment-dev-linux-clang.yml
+++ b/environment-dev-linux-clang.yml
@@ -23,7 +23,7 @@ dependencies:
         - llvm-openmp
         - nanobind=2.9
         - nbsphinx
-        - matplotlib
+        - matplotlib<3.11
         - netcdf4
         - ninja
         - numpy>=2

--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -15,7 +15,7 @@ dependencies:
         - lark-parser
         - libboost-devel
         - make
-        - matplotlib
+        - matplotlib<3.11
         - nanobind=2.9
         - nbsphinx
         - netcdf4

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -19,7 +19,7 @@ dependencies:
         - libcxx-devel
         - libmicrohttpd
         - llvm-openmp
-        - matplotlib
+        - matplotlib<3.11
         - nanobind=2.9
         - nbsphinx
         - netcdf4

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -10,7 +10,7 @@ dependencies:
         - libboost-devel
         - libcxx
         - llvm-openmp < 21
-        - matplotlib
+        - matplotlib<3.11
         - nanobind=2.9
         - nbsphinx
         - netcdf4

--- a/src/core/lbl/lbl_lineshape_voigt_ecs_hartmann.cpp
+++ b/src/core/lbl/lbl_lineshape_voigt_ecs_hartmann.cpp
@@ -54,8 +54,8 @@ Numeric reduced_dipole(const Rational Jf,
                        const Rational li,
                        const Rational k) {
   if (not iseven(Jf + lf + 1))
-    return -sqrtr(2 * Jf + 1) * wigner3j(Jf, k, Ji, li, lf - li, -lf);
-  return +sqrtr(2 * Jf + 1) * wigner3j(Jf, k, Ji, li, lf - li, -lf);
+    return -sqrtr(2 * Jf + 1) * wigner3j(Jf, k, Ji, lf, li - lf, -li);
+  return +sqrtr(2 * Jf + 1) * wigner3j(Jf, k, Ji, lf, li - lf, -li);
 }
 
 void relaxation_matrix_offdiagonal(MatrixView& W,


### PR DESCRIPTION
Fixes an incorrect argument ordering in the Wigner 3j symbol computed inside `reduced_dipole` within the Hartmann ECS line-shape model. The previous call swapped the `(li, lf - li, -lf)` triplet with `(lf, li - lf, -li)`, producing wrong reduced dipole values and thus erroneous scaling of relaxation-matrix off-diagonal elements. The corrected arguments restore the physically intended coupling for the rotational quantum numbers.

Same fix as in ARTS 2.6 PR #1133.

### Changes
- `src/core/lbl/lbl_lineshape_voigt_ecs_hartmann.cpp`: Updated both branches of the `iseven(Jf + lf + 1)` conditional in `reduced_dipole` to call `wigner3j(Jf, k, Ji, lf, li - lf, -li)` instead of `wigner3j(Jf, k, Ji, li, lf - li, -lf)`, ensuring the bra-side and ket-side angular momentum couplings are passed in the correct order.

### Breaking Changes
None — this is a bug fix. Results previously computed with the Hartmann ECS line-shape model for affected transitions will change numerically to the correct values.