### PR TITLE
fix: remove unused kwargs from disort plot calls for matplotlib 3.11 compatibility

### DIFF
--- a/examples/2-clearsky-radiative-transfer/3-disort/2-clearsky-flux.py
+++ b/examples/2-clearsky-radiative-transfer/3-disort/2-clearsky-flux.py
@@ -68,9 +68,7 @@ assert np.allclose(
 ), "Mismatch from historical Disort spectral fluxes"
 
 fig = plt.figure(figsize=(16, 5))
-fig, ax = pyarts.plot(ws.disort_spectral_flux_field, fig=fig,
-                      alts=ws.disort_spectral_flux_field.alt_grid / 1e3,
-                      freqs=ws.freq_grid / 1e9, levels=50)
+fig, ax = pyarts.plot(ws.disort_spectral_flux_field, fig=fig, levels=50)
 fig.suptitle("Disort clearsky spectral fluxes")
 [a.set_ylabel("Altitude [km]") for a in ax]
 [a.set_xlabel("Frequency [GHz]") for a in ax]

--- a/examples/2-clearsky-radiative-transfer/3-disort/3-clearsky-flux-from-dataset.py
+++ b/examples/2-clearsky-radiative-transfer/3-disort/3-clearsky-flux-from-dataset.py
@@ -80,10 +80,7 @@ ws.disort_spectral_flux_fieldFromAgenda()
 
 f, s = pyarts.plot(
     ws.disort_spectral_flux_field,
-    freqs=pyarts.arts.convert.freq2kaycm(ws.freq_grid),
-    alts=ws.disort_spectral_flux_field.alt_grid/1e3,
     select='down_diffuse',
-    plotstyle='plot',
 )
 s.set_xlabel("Kaysers [cm$^{-1}$]")
 s.set_ylabel("Altitude [km]")


### PR DESCRIPTION
Drop the explicit alts/freqs/plotstyle arguments from the pyarts.plot calls in the clearsky-flux examples. pltstyle is unused. alts/freqs are unused since they're part of the DisortFlux class.

kwargs that are not consumed by the plot function are eventually passed to contourf. Since matplotlib 3.11, contourf does not accept unknown kwargs anymore causing a runtime error.