### PR TITLE
[ARTS-2.6] Avoid numpy 2.5 for now

### DIFF
--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -19,7 +19,7 @@ dependencies:
         - llvm-openmp
         - matplotlib
         - netcdf4
-        - numpy
+        - numpy<2.5
         - pkg-config
         - pytest
         - python-build

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -14,7 +14,7 @@ dependencies:
         - llvm-openmp
         - matplotlib
         - netcdf4
-        - numpy
+        - numpy<2.5
         - pkg-config
         - pytest
         - python-build


### PR DESCRIPTION
Leads to segfaults when accessing numpy members through ARTS types:

```python
x=pa.arts.Tensor3()
x.shape
```

Might be in our code or we may need to update pybind. Further investigation pending.