### PR TITLE
chore: bump matplotlib upper bound to <3.12 across dev environments

### DIFF
--- a/environment-dev-linux-clang.yml
+++ b/environment-dev-linux-clang.yml
@@ -23,7 +23,7 @@ dependencies:
         - llvm-openmp
         - nanobind=2.9
         - nbsphinx
-        - matplotlib<3.11
+        - matplotlib<3.12
         - netcdf4
         - ninja
         - numpy>=2

--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -15,7 +15,7 @@ dependencies:
         - lark-parser
         - libboost-devel
         - make
-        - matplotlib<3.11
+        - matplotlib<3.12
         - nanobind=2.9
         - nbsphinx
         - netcdf4

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -19,7 +19,7 @@ dependencies:
         - libcxx-devel
         - libmicrohttpd
         - llvm-openmp
-        - matplotlib<3.11
+        - matplotlib<3.12
         - nanobind=2.9
         - nbsphinx
         - netcdf4

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -10,7 +10,7 @@ dependencies:
         - libboost-devel
         - libcxx
         - llvm-openmp < 21
-        - matplotlib<3.11
+        - matplotlib<3.12
         - nanobind=2.9
         - nbsphinx
         - netcdf4


### PR DESCRIPTION
This PR raises the allowed matplotlib version across all platform development environments from `<3.11` to `<3.12`. The change keeps the conda dependency constraints current with the latest matplotlib 3.11 release.

### Changes
- `environment-dev-*.yml`: Updated the matplotlib pin from `matplotlib<3.11` to `matplotlib<3.12` so fresh dev environments can pick up the newest compatible release.