### PR TITLE
refactor: pass partfun XML list via file instead of command args

### DIFF
--- a/src/partfun/CMakeLists.txt
+++ b/src/partfun/CMakeLists.txt
@@ -18,6 +18,12 @@ endforeach()
 list(LENGTH partfun_xml_files partfun_xml_files_count)
 message(STATUS "Found ${partfun_xml_files_count} partition function XML files")
 
+set(partfun_xml_files_list ${CMAKE_CURRENT_BINARY_DIR}/partfun_xml_files.txt)
+file(WRITE ${partfun_xml_files_list} "")
+foreach(xml_file IN LISTS partfun_xml_files)
+    file(APPEND ${partfun_xml_files_list} "${xml_file}\n")
+endforeach()
+
 if (partfun_xml_files_count EQUAL 0)
   message(FATAL_ERROR "No partition function XML files found in ${ARTS_CAT_DATA_DIR}/partition-functions/
 You need to pass -DARTS_CAT_DATA_PATH=<path> to cmake to point to the directory containing your copy of arts-cat-data.")
@@ -26,8 +32,8 @@ endif()
 # Generate auto_partfun.h for the ARTS interface
 add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/auto_partfun.h ${partfun_cpp_files}
-        COMMAND partfun_generator ${partfun_xml_files}
-        DEPENDS partfun_generator ${partfun_xml_files}
+        COMMAND partfun_generator ${partfun_xml_files_list}
+        DEPENDS partfun_generator ${partfun_xml_files} ${partfun_xml_files_list}
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         COMMENT "Generating automatic partition function interface"
 )

--- a/src/partfun/make_auto_partfuns.cc
+++ b/src/partfun/make_auto_partfuns.cc
@@ -371,10 +371,19 @@ void make_files(const std::vector<std::string>& full_filenames) {
 }  // namespace
 
 int main(int argn, char** argv) try {
-  if (argn < 2)
+  if (argn != 2) throw std::runtime_error("USAGE: PROG <file-with-xml-list>");
+
+  std::vector<std::string> xmlfiles;
+  std::ifstream in{argv[1]};
+  if (!in)
     throw std::runtime_error(
-        "USAGE: PROG INPUT1.XML INPUT2.xml ... INPUTX.xml");
-  const std::vector<std::string> xmlfiles{argv + 1, argv + argn};
+        std::format("Failed to open list file: {}", argv[1]));
+
+  std::string line;
+  while (std::getline(in, line)) {
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    if (!line.empty()) xmlfiles.push_back(std::move(line));
+  }
 
   make_files(xmlfiles);
 


### PR DESCRIPTION
This PR changes the `partfun_generator` build-time tool to receive its list of partition function XML files via a text file on disk rather than as individual command-line arguments. This avoids running into platform command-line length limits when the catalog contains a large number of XML files.

### Changes
- `src/partfun/make_auto_partfuns.cc`: `main` now expects a single argument pointing to a file listing the XML paths (one per line), reads and parses that list, and validates that the file can be opened; also added a trailing newline.
- `src/partfun/CMakeLists.txt`: Writes the discovered `partfun_xml_files` into `partfun_xml_files.txt` in the build directory and invokes `partfun_generator` with that list file, adding it to the custom command's dependencies.

### Breaking Changes
None. This is an internal build-tool refactor with no user-facing API change.