### PR TITLE
fix: restore str->enum implicit conversion in supergeneric args under nanobind 2.13

### DIFF
--- a/environment-dev-linux-clang.yml
+++ b/environment-dev-linux-clang.yml
@@ -21,7 +21,7 @@ dependencies:
         - libcxx
         - libcxx-devel
         - llvm-openmp
-        - nanobind=2.9
+        - nanobind<=2.13
         - nbsphinx
         - matplotlib<3.12
         - netcdf4

--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -16,7 +16,7 @@ dependencies:
         - libboost-devel
         - make
         - matplotlib<3.12
-        - nanobind=2.9
+        - nanobind<=2.13
         - nbsphinx
         - netcdf4
         - ninja

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -20,7 +20,7 @@ dependencies:
         - libmicrohttpd
         - llvm-openmp
         - matplotlib<3.12
-        - nanobind=2.9
+        - nanobind<=2.13
         - nbsphinx
         - netcdf4
         - ninja

--- a/environment-dev-win.yml
+++ b/environment-dev-win.yml
@@ -11,7 +11,7 @@ dependencies:
         - libcxx
         - llvm-openmp < 21
         - matplotlib<3.12
-        - nanobind=2.9
+        - nanobind<=2.13
         - nbsphinx
         - netcdf4
         - ninja

--- a/src/python_interface/gen_auto_py_methods.cpp
+++ b/src/python_interface/gen_auto_py_methods.cpp
@@ -65,9 +65,9 @@ std::string method_arguments(const WorkspaceMethodInternalRecord& wsm) {
     } else {
       const auto& v          = wsm.gin.at(i);
       std::string_view comma = "";
-      os << ",\n    std::variant<";
+      os << ",\n    Python::Supergeneric<";
       for (auto& arg : generics[i]) {
-        os << std::exchange(comma, ", ") << "std::shared_ptr<py" << arg << ">";
+        os << std::exchange(comma, ", ") << "py" << arg;
       }
       os << "> * const _" << v;
     }
@@ -98,9 +98,9 @@ std::string method_arguments(const WorkspaceMethodInternalRecord& wsm) {
     } else {
       const auto& v          = wsm.gin.at(i);
       std::string_view comma = "";
-      os << ",\n    const std::variant<";
+      os << ",\n    const Python::Supergeneric<";
       for (auto& arg : generics[index]) {
-        os << std::exchange(comma, ", ") << "std::shared_ptr<py" << arg << ">";
+        os << std::exchange(comma, ", ") << "py" << arg;
       }
       os << "> * const _" << v;
     }

--- a/src/python_interface/python_interface.h
+++ b/src/python_interface/python_interface.h
@@ -18,9 +18,44 @@ namespace Python {
 namespace py = nanobind;
 using namespace py::literals;
 
+//! A ``std::variant<std::shared_ptr<T>...>`` used for supergeneric
+//! workspace-method arguments, with a custom nanobind type caster (defined
+//! below) that preserves the implicit-conversion (``convert``) flag when
+//! probing each alternative.
+//!
+//! This works around a nanobind 2.13 regression in
+//! ``type_caster<std::shared_ptr<T>>::from_python`` that strips the
+//! ``convert`` flag, which silently disabled implicit conversions such as
+//! ``"H2O"`` -> ``SpeciesEnum`` registered via
+//! ``py::implicitly_convertible<std::string, SpeciesEnum>``.  As a result,
+//! passing a ``str`` for a supergeneric ``key`` argument stopped matching any
+//! variant alternative.
+//!
+//! ``Supergeneric<...>`` is layout-compatible with the underlying variant and
+//! exposes it via ``operator const std::variant<...>&`` so the existing
+//! ``select_gin`` / ``select_gout`` / ``has_selected_value`` overloads (which
+//! take ``const std::variant<std::shared_ptr<T>...>&``) keep working without
+//! modification.
+template <typename... T>
+struct Supergeneric {
+  std::variant<std::shared_ptr<T>...> value;
+
+  operator const std::variant<std::shared_ptr<T>...>&() const { return value; }
+};
+
 template <typename... T>
 bool has_selected_value(const std::variant<std::shared_ptr<T>...>& x) {
   return std::visit([](const auto& ptr) { return static_cast<bool>(ptr); }, x);
+}
+
+template <typename... T>
+bool has_selected_value(const Supergeneric<T...>& x) {
+  return has_selected_value(x.value);
+}
+
+template <typename... T>
+std::string type(const Supergeneric<T...>* const x) {
+  return type(x ? &x->value : nullptr);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -59,6 +94,13 @@ std::variant<std::shared_ptr<T>...>& select_gout(
   }
 
   return *x;
+}
+
+template <typename... T>
+std::variant<std::shared_ptr<T>...>& select_gout(Supergeneric<T...>* const x,
+                                                 Workspace& ws,
+                                                 const char* const name) {
+  return select_gout(x ? &x->value : nullptr, ws, name);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -121,6 +163,12 @@ const std::variant<std::shared_ptr<T>...>& select_gin(
   return *x;
 }
 
+template <typename... T>
+const std::variant<std::shared_ptr<T>...>& select_gin(
+    const Supergeneric<T...>* const x, const char* const name) {
+  return select_gin(x ? &x->value : nullptr, name);
+}
+
 template <WorkspaceGroup T>
 const T& select_gin(const T* const x, const T& defval) {
   return x ? *x : defval;
@@ -141,5 +189,103 @@ struct std::hash<Python::ValueHolder<T>> {
     return std::hash<T>{}(x->val);
   }
 };
+
+NAMESPACE_BEGIN(NB_NAMESPACE)
+NAMESPACE_BEGIN(detail)
+
+//! Custom type caster for ``Python::Supergeneric<T...>``.
+//!
+//! It mirrors nanobind's stock ``std::variant<...>`` caster (see
+//! ``nanobind/stl/variant.h``) but, crucially, forwards the ``convert`` flag
+//! intact to each alternative's caster.  nanobind 2.13 added
+//! ``flags &= ~cast_flags::convert`` at the top of
+//! ``type_caster<std::shared_ptr<T>>::from_python`` (to fix a use-after-free
+//! with implicitly-converted temporaries), which as a side effect silently
+//! disabled implicit conversions such as ``str`` -> ``SpeciesEnum`` whenever
+//! the alternative is wrapped in ``std::shared_ptr<...>``.  ARTS exposes
+//! supergeneric workspace-method arguments as
+//! ``const std::variant<std::shared_ptr<pyT1>, ...> * const``, so passing
+//! ``key="H2O"`` stopped matching any alternative after the 2.13 upgrade.
+//!
+//! By taking ownership of the conversion here, the ``convert`` flag reaches
+//! the inner ``T`` caster (e.g. ``SpeciesEnum``), which then honors
+//! ``py::implicitly_convertible<std::string, SpeciesEnum>`` as before.  On
+//! success the produced ``T*`` (owned by the cleanup list for the duration of
+//! the call) is wrapped in a ``std::shared_ptr<T>`` whose deleter decrefs the
+//! Python source object, matching the lifetime semantics of the stock
+//! shared_ptr caster.
+template <typename... T>
+struct type_caster<Python::Supergeneric<T...>> {
+  using Value   = Python::Supergeneric<T...>;
+  using Variant = std::variant<std::shared_ptr<T>...>;
+
+  static constexpr auto Name =
+      union_name(make_caster<std::shared_ptr<T>>::Name...);
+
+  template <typename T_>
+  using Cast = movable_cast_t<T_>;
+  template <typename T_>
+  static constexpr bool can_cast() {
+    return true;
+  }
+
+  explicit operator Value*() { return &value; }
+  explicit operator Value&() { return (Value&)value; }
+  explicit operator Value&&() { return (Value&&)value; }
+
+  bool from_python(handle src, uint8_t flags, cleanup_list* cleanup) noexcept {
+    // Same two-pass strategy as nanobind's stock variant caster: first without
+    // convert, then with convert.  The difference is that the per-alternative
+    // probe below bypasses type_caster<std::shared_ptr<T>> (which strips the
+    // convert flag on nanobind 2.13+) and invokes the inner T caster
+    // directly, preserving convert so implicit conversions succeed.
+    if ((try_alt<T>(src, flags & ~(uint8_t)cast_flags::convert, cleanup) ||
+         ...) ||
+        (try_alt<T>(src, flags, cleanup) || ...))
+      return true;
+    return false;
+  }
+
+ private:
+  template <typename Alt>
+  bool try_alt(handle src, uint8_t flags, cleanup_list* cleanup) noexcept {
+    using CasterT = make_caster<Alt>;
+    CasterT caster;
+    if (!caster.from_python(src, flags, cleanup)) return false;
+    Alt* ptr = caster.operator Alt*();
+    if (!ptr) return false;
+    // Keep the Python source alive for the lifetime of the shared_ptr, the
+    // same way the stock shared_ptr caster does (see py_deleter in
+    // nanobind/stl/shared_ptr.h).
+    src.inc_ref();
+    value.value.template emplace<std::shared_ptr<Alt>>(
+        std::shared_ptr<Alt>(ptr, [src = src.ptr()](void*) noexcept {
+          if (is_alive()) {
+            gil_scoped_acquire guard;
+            Py_DECREF(src);
+          }
+        }));
+    return true;
+  }
+
+ public:
+  static handle from_cpp(const Value& v,
+                         rv_policy policy,
+                         cleanup_list* cleanup) noexcept {
+    return make_caster<Variant>::from_cpp(v.value, policy, cleanup);
+  }
+
+  static handle from_cpp(const Value* v,
+                         rv_policy policy,
+                         cleanup_list* cleanup) noexcept {
+    if (!v) return none().release();
+    return from_cpp(*v, policy, cleanup);
+  }
+
+  Value value;
+};
+
+NAMESPACE_END(detail)
+NAMESPACE_END(NB_NAMESPACE)
 
 #endif  // python_interface_h


### PR DESCRIPTION
This PR fixes a regression introduced by nanobind 2.13 that silently broke implicit Python-side conversions (such as `str` -> `SpeciesEnum`) for supergeneric workspace-method arguments leading to several tests failing, such as:

```
➜ ctest --test-dir build -R pyarts.arts.tests.core.vmr.log$
Test project /Users/u237002/Hacking/uhh/arts/build
    Start 95: pyarts.arts.tests.core.vmr.log
1/1 Test #95: pyarts.arts.tests.core.vmr.log ...***Failed    0.92 sec
Traceback (most recent call last):
  File "/Users/u237002/Hacking/uhh/arts/tests/core/vmr/log.py", line 64, in <module>
    ws.jac_targetsToggleLogarithmicAtmTarget(key="H2O")
TypeError: jac_targetsToggleLogarithmicAtmTarget(): incompatible function arguments. The following argument types are supported:
    1. jac_targetsToggleLogarithmicAtmTarget(self, jac_targets: pyarts3.arts.JacobianTargets | None = None, atm_field: pyarts3.arts.AtmField | None = None, key: pyarts3.arts.AtmKey | pyarts3.arts.SpeciesEnum | pyarts3.arts.SpeciesIsotope | pyarts3.arts.QuantumLevelIdentifier | pyarts3.arts.ScatteringSpeciesProperty | None = None) -> None

Invoked with types: pyarts3.workspace.workspace.Workspace, kwargs = { key: str }
```

It also relaxes the `nanobind` pin in the platform dev-environment files to `<=2.13` so the fix can be consumed.

### The underlying problem

ARTS exposes supergeneric workspace-method arguments to Python as `const std::variant<std::shared_ptr<pyT1>, std::shared_ptr<pyT2>, ...> * const`. The bindings register implicit conversions like `py::implicitly_convertible<std::string, SpeciesEnum>`, and the stock nanobind `std::variant` caster honors these by probing each alternative twice: first with the `convert` flag clear (exact matches only), then with `convert` set (allowing implicit conversions).

nanobind 2.13 added a single line at the top of `type_caster<std::shared_ptr<T>>::from_python` (in `nanobind/stl/shared_ptr.h`):

```cpp
flags &= ~((uint8_t) cast_flags::convert);
```

The intent of that change is to prevent dangling references to implicitly-converted temporaries owned by the cleanup list. But as a side effect, when the variant caster probes a `std::shared_ptr<T>` alternative during the second (`convert`-allowed) pass, the shared_ptr caster immediately clears `convert` before delegating to the inner `T` caster. The inner `T` caster (e.g. `SpeciesEnum`) therefore runs with `convert` unset and rejects the incoming `str` even though `implicitly_convertible<std::string, SpeciesEnum>` is registered. Since every alternative is a `std::shared_ptr<...>`, *all* alternatives fail, and `key="H2O"` raises a `TypeError` instead of constructing a `SpeciesEnum`.

This is purely a consequence of the `shared_ptr` wrapper interacting with the variant's two-pass strategy; the inner enum caster itself still honors implicit conversions when `convert` reaches it, which is why a non-supergeneric argument of type `SpeciesEnum` continues to work.

### The fix

`src/python_interface/python_interface.h`:

Add `Python::Supergeneric<...>`, a struct that is layout-compatible with `std::variant<std::shared_ptr<T>...>` (it exposes the variant via `operator const std::variant<...>&`) so the existing `select_gin` / `select_gout` / `has_selected_value` / `type` overloads keep working unchanged — forwarding overloads taking `Supergeneric` are added alongside them.

Add a custom nanobind `type_caster<Python::Supergeneric<...>>` that takes ownership of the conversion. It mirrors the stock variant caster's two-pass strategy (try without `convert`, then with `convert`), but instead of delegating each alternative probe to `type_caster<std::shared_ptr<T>>` — which is where the 2.13 regression strips the flag — it invokes the inner `T` caster directly (`make_caster<T>`) with the `convert` flag intact. On success the resulting `T*` (kept alive by the cleanup list for the duration of the call) is wrapped in a `std::shared_ptr<T>` whose deleter increfs/decrefs the Python source object, reproducing the lifetime semantics of nanobind's stock shared_ptr caster. `from_cpp` is delegated to the regular variant caster via the stored `value` member.

`src/python_interface/gen_auto_py_methods.cpp`:

Emit generated supergeneric arguments as `Python::Supergeneric<pyT...>` instead of `std::variant<std::shared_ptr<pyT>...>`, and drop the now-redundant `shared_ptr` wrapping in the alternative list, so the custom caster is selected for these parameters.

`environment-dev-*.yml`:

Relaxed the `nanobind=2.9` pin to `nanobind<=2.13` so the fixed build can use the newer nanobind on all platforms.

### Breaking Changes
None. `Supergeneric` is layout-compatible with the previous `std::variant<std::shared_ptr<T>...>` and the change is internal to the Python bindings; generated method signatures and runtime behavior match the pre-2.13 semantics.