### PR TITLE
Silent warnings

### DIFF
--- a/src/core/util/arts_omp.cc
+++ b/src/core/util/arts_omp.cc
@@ -69,36 +69,6 @@ void arts_omp_set_num_threads(int i [[maybe_unused]]) {
 #endif
 }
 
-//! Wrapper for omp_get_nested
-/*! 
-  This wrapper works with and without OMP support.
-
-  \return 1 or 0, depending on if nested parallel execution is enabled or not. 
-*/
-int arts_omp_get_nested() {
-#ifdef _OPENMP
-  int nested = omp_get_nested();
-#else
-  int nested = 0;
-#endif
-
-  return nested;
-}
-
-//! Wrapper for omp_set_nested
-/*! 
-  This wrapper works with and without OMP support.
-
-  \param i Turn on nested parallelism with 1, turn off with 0.
-*/
-void arts_omp_set_nested(int i [[maybe_unused]]) {
-#ifdef _OPENMP
-  omp_set_nested(i);
-#else
-  // Nothing to do here.
-#endif
-}
-
 //! Wrapper for omp_set_dynamic
 /*! 
   This wrapper works with and without OMP support.

--- a/src/core/util/arts_omp.h
+++ b/src/core/util/arts_omp.h
@@ -27,11 +27,7 @@ bool arts_omp_in_parallel();
 
 int arts_omp_get_thread_num();
 
-int arts_omp_get_nested();
-
 void arts_omp_set_num_threads(int i);
-
-void arts_omp_set_nested(int i);
 
 void arts_omp_set_dynamic(int i);
 

--- a/src/tests/scattering/test_utils.h.in
+++ b/src/tests/scattering/test_utils.h.in
@@ -184,6 +184,14 @@ template <typename A, typename B> Numeric max_rel_error(const A& a, const B& b) 
   return max;
 }
 
+#if defined(__GNUC__) 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#elif defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-int-float-conversion"
+#endif
+
 /** Functional filling of tensor.
  *
  * Applies a given function mapping element coordinates to tensor
@@ -225,6 +233,10 @@ template <Index axis, matpack::any_md Tensor> void fill_along_axis(Tensor& t) {
   auto get_coord = [](auto... params) { return std::get<axis>(std::make_tuple(params...)); };
   generate(t, get_coord);
 }
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 /** Fill tensor with increasing values along axis.
  *


### PR DESCRIPTION
2 changes:

GCC and Clang have pragmas to dismiss warnings in the test-suite.

GCC has deprecated some OMP functionality and were generating warnings.  I simply removed these methods as they were unused.