### PR TITLE
chore: depend on cpython to ensure GIL-enabled Python

### DIFF
--- a/environment-dev-linux-clang.yml
+++ b/environment-dev-linux-clang.yml
@@ -5,6 +5,7 @@ dependencies:
         - clangxx
         - cmake
         - compiler-rt
+        - cpython
         - doxygen
         - docutils
         - graphviz

--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -2,6 +2,7 @@ dependencies:
         - binutils
         - ccache
         - cmake
+        - cpython
         - doxygen
         - docutils
         - graphviz

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -4,6 +4,7 @@ dependencies:
         - clangxx<23
         - cmake
         - compiler-rt
+        - cpython
         - docutils
         - doxygen
         - eigen


### PR DESCRIPTION
Starting with Python 3.14, conda-forge ships the free-threaded (no-GIL) build as the default python package. CMake's `find_package(Python)` does not recognize this freethreading variant by default, so an ARTS configuration against it fails or selects an interpreter our nanobind-based bindings cannot use. We require the traditional GIL-enabled interpreter.
The clean fix would be to depend on the `python-gil` package, which explicitly pins the GIL build; however, that package does not exist for Python versions below 3.14, so adding it would break environment creation on 3.12 and 3.13. Depending on `cpython` instead achieves the same effect. It pulls in the GIL-enabled CPython interpreter while remaining installable across all currently supported Python versions, making it a workaround that works universally rather than only on 3.14+.