### PR TITLE
[ARTS-2.6] fix: ARM CI build failures from cpython detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,6 +350,7 @@ else (CMAKE_GENERATOR STREQUAL "Xcode")
   ARTS_ADD_COMPILER_FLAG (Wno-return-type-c-linkage)
   ARTS_ADD_COMPILER_FLAG (Wno-strict-overflow)
   ARTS_ADD_COMPILER_FLAG (Wno-psabi)
+  ARTS_ADD_COMPILER_FLAG (Wno-unused-template)
 endif (CMAKE_GENERATOR STREQUAL "Xcode")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Native")

--- a/environment-dev-linux.yml
+++ b/environment-dev-linux.yml
@@ -4,6 +4,7 @@ dependencies:
         - clang
         - clangxx
         - cmake
+        - cpython
         - docutils
         - gcc<15
         - gfortran<15

--- a/environment-dev-mac.yml
+++ b/environment-dev-mac.yml
@@ -3,6 +3,7 @@ dependencies:
         - clang
         - clangxx
         - cmake
+        - cpython
         - docutils
         - gfortran
         - glew


### PR DESCRIPTION
CMake requires cpython on arm platforms to properly detect the Python 3.14 interpreter. Add it to both linux and mac dev environments.

Suppress new unused-template warnings (in mdspan) from Clang 23.