### PR TITLE
ci: build Windows wheel without pip build isolation

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -155,7 +155,12 @@ jobs:
         if: matrix.check == 'yes'
         shell: bash -l {0}
         run: |
-          cmake --build build --target pyarts-package
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            cmake --build build --target pyarts_cpp
+            (cd build/python && python -m build --no-isolation)
+          else
+            cmake --build build --target pyarts-package
+          fi
 
       - name: Build SRC
         if: matrix.check == 'yes'


### PR DESCRIPTION
The Windows CI wheel build currently fails because the `pyarts-package` target's `python -m build` creates an isolated venv, and pip re-executed inside that venv cannot load conda's OpenSSL DLLs (`ImportError: DLL load failed while importing _ssl`). This PR switches Windows to a build path that avoids the isolation venv entirely, while leaving Linux and macOS unchanged.

### Changes
- `.github/workflows/build-test.yml`: On Windows, build `pyarts_cpp` and then run `python -m build --no-isolation` directly in `build/python`, bypassing the isolation venv that breaks DLL loading. Linux and macOS keep the original `pyarts-package` target.